### PR TITLE
 [1단계 - DB 복제와 캐시] 로키(정해성) 미션 제출합니다.

### DIFF
--- a/src/main/java/coupon/aspect/ImmediateRead.java
+++ b/src/main/java/coupon/aspect/ImmediateRead.java
@@ -1,0 +1,11 @@
+package coupon.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ImmediateRead {
+}

--- a/src/main/java/coupon/aspect/ImmediateReadAspect.java
+++ b/src/main/java/coupon/aspect/ImmediateReadAspect.java
@@ -1,6 +1,7 @@
 package coupon.aspect;
 
 import coupon.config.DataSourceRouter;
+import org.aspectj.lang.annotation.After;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
@@ -17,5 +18,10 @@ public class ImmediateReadAspect {
     @Before("immediateRead()")
     public void beforeImmediateReadMode() {
         DataSourceRouter.setImmediateReadMode(true);
+    }
+
+    @After("immediateRead()")
+    public void afterImmediateReadMode() {
+        DataSourceRouter.setImmediateReadMode(false);
     }
 }

--- a/src/main/java/coupon/aspect/ImmediateReadAspect.java
+++ b/src/main/java/coupon/aspect/ImmediateReadAspect.java
@@ -1,0 +1,21 @@
+package coupon.aspect;
+
+import coupon.config.DataSourceRouter;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class ImmediateReadAspect {
+
+    @Pointcut("@annotation(coupon.aspect.ImmediateRead)")
+    public void immediateRead() {
+    }
+
+    @Before("immediateRead()")
+    public void beforeImmediateReadMode() {
+        DataSourceRouter.setImmediateReadMode(true);
+    }
+}

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -1,0 +1,59 @@
+package coupon.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class DataSourceConfig {
+
+    private static final String READ_DATASOURCE = "readDataSource";
+    private static final String WRITE_DATASOURCE = "writeDataSource";
+    private static final String ROUTE_DATASOURCE = "routeDataSource";
+
+    @Bean(name = READ_DATASOURCE)
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(name = WRITE_DATASOURCE)
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(name = ROUTE_DATASOURCE)
+    @DependsOn({READ_DATASOURCE, WRITE_DATASOURCE})
+    public DataSource routingDataSource() {
+        DataSourceRouter dataSourceRouter = new DataSourceRouter();
+
+        Map<Object, Object> dataSources = new HashMap<>(Map.of(
+                DataSourceRouter.READ_DATASOURCE_KEY, readerDataSource(),
+                DataSourceRouter.WRITE_DATASOURCE_KEY, writerDataSource()
+        ));
+        dataSourceRouter.setTargetDataSources(dataSources);
+        dataSourceRouter.setDefaultTargetDataSource(writerDataSource());
+
+        return dataSourceRouter;
+    }
+
+    @Bean
+    @Primary
+    @DependsOn(ROUTE_DATASOURCE)
+    public DataSource defaultDataSource() {
+        return new LazyConnectionDataSourceProxy(routingDataSource());
+    }
+}

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -19,7 +19,7 @@ public class DataSourceConfig {
     private static final String WRITE_DATASOURCE = "writeDataSource";
     private static final String ROUTE_DATASOURCE = "routeDataSource";
 
-    @Bean(name = READ_DATASOURCE)
+    @Bean(name = WRITE_DATASOURCE)
     @ConfigurationProperties(prefix = "coupon.datasource.writer")
     public DataSource writerDataSource() {
         return DataSourceBuilder.create()
@@ -27,7 +27,7 @@ public class DataSourceConfig {
                 .build();
     }
 
-    @Bean(name = WRITE_DATASOURCE)
+    @Bean(name = READ_DATASOURCE)
     @ConfigurationProperties(prefix = "coupon.datasource.reader")
     public DataSource readerDataSource() {
         return DataSourceBuilder.create()

--- a/src/main/java/coupon/config/DataSourceRouter.java
+++ b/src/main/java/coupon/config/DataSourceRouter.java
@@ -1,0 +1,18 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class DataSourceRouter extends AbstractRoutingDataSource {
+
+    public static final String READ_DATASOURCE_KEY = "read";
+    public static final String WRITE_DATASOURCE_KEY = "write";
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return READ_DATASOURCE_KEY;
+        }
+        return WRITE_DATASOURCE_KEY;
+    }
+}

--- a/src/main/java/coupon/config/DataSourceRouter.java
+++ b/src/main/java/coupon/config/DataSourceRouter.java
@@ -8,8 +8,17 @@ public class DataSourceRouter extends AbstractRoutingDataSource {
     public static final String READ_DATASOURCE_KEY = "read";
     public static final String WRITE_DATASOURCE_KEY = "write";
 
+    private static final ThreadLocal<Boolean> isImmediateReadMode = ThreadLocal.withInitial(() -> false);
+
+    public static void setImmediateReadMode(boolean isimmediateReadMode) {
+        isImmediateReadMode.set(isimmediateReadMode);
+    }
+
     @Override
     protected Object determineCurrentLookupKey() {
+        if (isImmediateReadMode.get()) {
+            return WRITE_DATASOURCE_KEY;
+        }
         if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
             return READ_DATASOURCE_KEY;
         }

--- a/src/main/java/coupon/controller/CouponController.java
+++ b/src/main/java/coupon/controller/CouponController.java
@@ -1,0 +1,31 @@
+package coupon.controller;
+
+import coupon.domain.Coupon;
+import coupon.service.CouponService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/coupons")
+public class CouponController {
+
+    private final CouponService couponService;
+
+    public CouponController(CouponService couponService) {
+        this.couponService = couponService;
+    }
+
+    @GetMapping("/{couponId}")
+    public Coupon getCoupon(@PathVariable Long couponId) {
+        return couponService.getCoupon(couponId);
+    }
+
+    @PostMapping
+    public Coupon createCoupon(@RequestBody Coupon coupon) {
+        return couponService.createCoupon(coupon);
+    }
+}

--- a/src/main/java/coupon/controller/CouponController.java
+++ b/src/main/java/coupon/controller/CouponController.java
@@ -24,6 +24,11 @@ public class CouponController {
         return couponService.getCoupon(couponId);
     }
 
+    @GetMapping("/{couponId}/immediate")
+    public Coupon getCouponImmediately(@PathVariable Long couponId) {
+        return couponService.getCouponImmediately(couponId);
+    }
+
     @PostMapping
     public Coupon createCoupon(@RequestBody Coupon coupon) {
         return couponService.createCoupon(coupon);

--- a/src/main/java/coupon/domain/Category.java
+++ b/src/main/java/coupon/domain/Category.java
@@ -1,0 +1,5 @@
+package coupon.domain;
+
+public enum Category {
+    CLOTHES, ELECTRONICS, FURNITURE, FOOD
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -2,6 +2,8 @@ package coupon.domain;
 
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,7 +25,10 @@ public class Coupon {
 
     @Embedded
     private MinimumAmount minimumAmount;
-    private String category;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
     private LocalDate startDate;
     private LocalDate endDate;
 
@@ -34,7 +39,7 @@ public class Coupon {
             String name,
             BigDecimal discountAmount,
             BigDecimal minimumAmount,
-            String category,
+            Category category,
             LocalDate startDate,
             LocalDate endDate
     ) {
@@ -54,7 +59,7 @@ public class Coupon {
             CouponName name,
             DiscountAmount discountAmount,
             MinimumAmount minimumAmount,
-            String category,
+            Category category,
             LocalDate startDate,
             LocalDate endDate
     ) {
@@ -83,7 +88,7 @@ public class Coupon {
         return minimumAmount.getMinimumAmount();
     }
 
-    public String getCategory() {
+    public Category getCategory() {
         return category;
     }
 

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -14,6 +14,9 @@ import java.time.LocalDate;
 @Entity
 public class Coupon {
 
+    private static final BigDecimal LOWEST_ALLOWED_DISCOUNT_RATE = BigDecimal.valueOf(3);
+    private static final BigDecimal HIGHEST_ALLOWED_DISCOUNT_RATE = BigDecimal.valueOf(20);
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -78,13 +81,22 @@ public class Coupon {
     private void validateDiscountRate(BigDecimal discountAmount, BigDecimal minimumAmount) {
         BigDecimal discountRate = discountAmount.multiply(BigDecimal.valueOf(100))
                 .divide(minimumAmount, RoundingMode.DOWN);
-        if (discountRate.compareTo(BigDecimal.valueOf(3)) < 0) {
+        if (isLowerThanLowestAllowedDiscountRate(discountRate)) {
             throw new IllegalArgumentException("할인율은 3% 이상이어야 합니다.");
         }
-        if (discountRate.compareTo(BigDecimal.valueOf(20)) > 0) {
+        if (isUpperThanHighestAllowedDiscountRate(discountRate)) {
             throw new IllegalArgumentException("할인율은 20% 이하여야 합니다.");
         }
     }
+
+    private boolean isLowerThanLowestAllowedDiscountRate(BigDecimal discountRate) {
+        return discountRate.compareTo(LOWEST_ALLOWED_DISCOUNT_RATE) < 0;
+    }
+
+    private boolean isUpperThanHighestAllowedDiscountRate(BigDecimal discountRate) {
+        return discountRate.compareTo(HIGHEST_ALLOWED_DISCOUNT_RATE) > 0;
+    }
+
 
     public Long getId() {
         return id;

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -19,7 +19,6 @@ public class Coupon {
     private CouponName name;
 
     private BigDecimal discountAmount;
-    private BigDecimal discountRate;
     private BigDecimal minimumAmount;
     private String category;
     private LocalDate startDate;
@@ -31,7 +30,6 @@ public class Coupon {
     public Coupon(
             String name,
             BigDecimal discountAmount,
-            BigDecimal discountRate,
             BigDecimal minimumAmount,
             String category,
             LocalDate startDate,
@@ -41,7 +39,6 @@ public class Coupon {
                 null,
                 new CouponName(name),
                 discountAmount,
-                discountRate,
                 minimumAmount,
                 category,
                 startDate,
@@ -53,7 +50,6 @@ public class Coupon {
             Long id,
             CouponName name,
             BigDecimal discountAmount,
-            BigDecimal discountRate,
             BigDecimal minimumAmount,
             String category,
             LocalDate startDate,
@@ -62,7 +58,6 @@ public class Coupon {
         this.id = id;
         this.name = name;
         this.discountAmount = discountAmount;
-        this.discountRate = discountRate;
         this.minimumAmount = minimumAmount;
         this.category = category;
         this.startDate = startDate;
@@ -79,10 +74,6 @@ public class Coupon {
 
     public BigDecimal getDiscountAmount() {
         return discountAmount;
-    }
-
-    public BigDecimal getDiscountRate() {
-        return discountRate;
     }
 
     public BigDecimal getMinimumAmount() {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -18,7 +18,8 @@ public class Coupon {
     @Embedded
     private CouponName name;
 
-    private BigDecimal discountAmount;
+    @Embedded
+    private DiscountAmount discountAmount;
 
     @Embedded
     private MinimumAmount minimumAmount;
@@ -40,7 +41,7 @@ public class Coupon {
         this(
                 null,
                 new CouponName(name),
-                discountAmount,
+                new DiscountAmount(discountAmount),
                 new MinimumAmount(minimumAmount),
                 category,
                 startDate,
@@ -51,7 +52,7 @@ public class Coupon {
     private Coupon(
             Long id,
             CouponName name,
-            BigDecimal discountAmount,
+            DiscountAmount discountAmount,
             MinimumAmount minimumAmount,
             String category,
             LocalDate startDate,
@@ -75,7 +76,7 @@ public class Coupon {
     }
 
     public BigDecimal getDiscountAmount() {
-        return discountAmount;
+        return discountAmount.getDiscountAmount();
     }
 
     public BigDecimal getMinimumAmount() {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,0 +1,90 @@
+package coupon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private BigDecimal discountAmount;
+    private BigDecimal discountRate;
+    private BigDecimal minimumAmount;
+    private String category;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    protected Coupon() {
+    }
+
+    public Coupon(
+            String name,
+            BigDecimal discountAmount,
+            BigDecimal discountRate,
+            BigDecimal minimumAmount,
+            String category,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        this(null, name, discountAmount, discountRate, minimumAmount, category, startDate, endDate);
+    }
+
+    private Coupon(
+            Long id,
+            String name,
+            BigDecimal discountAmount,
+            BigDecimal discountRate,
+            BigDecimal minimumAmount,
+            String category,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        this.id = id;
+        this.name = name;
+        this.discountAmount = discountAmount;
+        this.discountRate = discountRate;
+        this.minimumAmount = minimumAmount;
+        this.category = category;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public BigDecimal getDiscountAmount() {
+        return discountAmount;
+    }
+
+    public BigDecimal getDiscountRate() {
+        return discountRate;
+    }
+
+    public BigDecimal getMinimumAmount() {
+        return minimumAmount;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 
 @Entity
@@ -63,6 +64,8 @@ public class Coupon {
             LocalDate startDate,
             LocalDate endDate
     ) {
+        validateDiscountRate(discountAmount.getDiscountAmount(), minimumAmount.getMinimumAmount());
+
         this.id = id;
         this.name = name;
         this.discountAmount = discountAmount;
@@ -70,6 +73,17 @@ public class Coupon {
         this.category = category;
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    private void validateDiscountRate(BigDecimal discountAmount, BigDecimal minimumAmount) {
+        BigDecimal discountRate = discountAmount.multiply(BigDecimal.valueOf(100))
+                .divide(minimumAmount, RoundingMode.DOWN);
+        if (discountRate.compareTo(BigDecimal.valueOf(3)) < 0) {
+            throw new IllegalArgumentException("할인율은 3% 이상이어야 합니다.");
+        }
+        if (discountRate.compareTo(BigDecimal.valueOf(20)) > 0) {
+            throw new IllegalArgumentException("할인율은 20% 이하여야 합니다.");
+        }
     }
 
     public Long getId() {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,7 +14,10 @@ public class Coupon {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String name;
+
+    @Embedded
+    private CouponName name;
+
     private BigDecimal discountAmount;
     private BigDecimal discountRate;
     private BigDecimal minimumAmount;
@@ -33,12 +37,21 @@ public class Coupon {
             LocalDate startDate,
             LocalDate endDate
     ) {
-        this(null, name, discountAmount, discountRate, minimumAmount, category, startDate, endDate);
+        this(
+                null,
+                new CouponName(name),
+                discountAmount,
+                discountRate,
+                minimumAmount,
+                category,
+                startDate,
+                endDate
+        );
     }
 
     private Coupon(
             Long id,
-            String name,
+            CouponName name,
             BigDecimal discountAmount,
             BigDecimal discountRate,
             BigDecimal minimumAmount,
@@ -61,7 +74,7 @@ public class Coupon {
     }
 
     public String getName() {
-        return name;
+        return name.getName();
     }
 
     public BigDecimal getDiscountAmount() {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -19,7 +19,9 @@ public class Coupon {
     private CouponName name;
 
     private BigDecimal discountAmount;
-    private BigDecimal minimumAmount;
+
+    @Embedded
+    private MinimumAmount minimumAmount;
     private String category;
     private LocalDate startDate;
     private LocalDate endDate;
@@ -39,7 +41,7 @@ public class Coupon {
                 null,
                 new CouponName(name),
                 discountAmount,
-                minimumAmount,
+                new MinimumAmount(minimumAmount),
                 category,
                 startDate,
                 endDate
@@ -50,7 +52,7 @@ public class Coupon {
             Long id,
             CouponName name,
             BigDecimal discountAmount,
-            BigDecimal minimumAmount,
+            MinimumAmount minimumAmount,
             String category,
             LocalDate startDate,
             LocalDate endDate
@@ -77,7 +79,7 @@ public class Coupon {
     }
 
     public BigDecimal getMinimumAmount() {
-        return minimumAmount;
+        return minimumAmount.getMinimumAmount();
     }
 
     public String getCategory() {

--- a/src/main/java/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/domain/CouponName.java
@@ -1,0 +1,49 @@
+package coupon.domain;
+
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+public class CouponName {
+
+    private String name;
+
+    protected CouponName() {
+    }
+
+    public CouponName(String name) {
+        validate(name);
+        this.name = name;
+    }
+
+    private void validate(String name) {
+        if (StringUtils.isBlank(name)) {
+            throw new IllegalArgumentException("쿠폰 이름은 필수입니다.");
+        }
+        if (name.length() > 30) {
+            throw new IllegalArgumentException("쿠폰 이름은 30자 이하여야 합니다.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CouponName that = (CouponName) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/domain/CouponName.java
@@ -7,6 +7,8 @@ import java.util.Objects;
 @Embeddable
 public class CouponName {
 
+    private static final int MAXIMUM_VALID_LENGTH = 30;
+
     private String name;
 
     protected CouponName() {
@@ -21,7 +23,7 @@ public class CouponName {
         if (StringUtils.isBlank(name)) {
             throw new IllegalArgumentException("쿠폰 이름은 필수입니다.");
         }
-        if (name.length() > 30) {
+        if (name.length() > MAXIMUM_VALID_LENGTH) {
             throw new IllegalArgumentException("쿠폰 이름은 30자 이하여야 합니다.");
         }
     }

--- a/src/main/java/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/domain/DiscountAmount.java
@@ -1,0 +1,55 @@
+package coupon.domain;
+
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@Embeddable
+public class DiscountAmount {
+
+    private BigDecimal discountAmount;
+
+    protected DiscountAmount() {
+    }
+
+    public DiscountAmount(BigDecimal discountAmount) {
+        validate(discountAmount);
+        this.discountAmount = discountAmount;
+    }
+
+    private void validate(BigDecimal discountAmount) {
+        if (discountAmount == null) {
+            throw new IllegalArgumentException("할인 금액은 필수입니다.");
+        }
+        if (discountAmount.remainder(BigDecimal.valueOf(500)).compareTo(BigDecimal.ZERO) != 0) {
+            throw new IllegalArgumentException("할인 금액은 500원 단위여야 합니다.");
+        }
+        if (discountAmount.compareTo(BigDecimal.valueOf(1_000)) < 0) {
+            throw new IllegalArgumentException("할인 금액은 1,000원 이상이어야 합니다.");
+        }
+        if (discountAmount.compareTo(BigDecimal.valueOf(10_000)) > 0) {
+            throw new IllegalArgumentException("할인 금액은 10,000원 이하여야 합니다.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DiscountAmount that = (DiscountAmount) o;
+        return Objects.equals(discountAmount, that.discountAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(discountAmount);
+    }
+
+    public BigDecimal getDiscountAmount() {
+        return discountAmount;
+    }
+}

--- a/src/main/java/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/domain/DiscountAmount.java
@@ -7,6 +7,10 @@ import java.util.Objects;
 @Embeddable
 public class DiscountAmount {
 
+    private static final BigDecimal AMOUNT_UNIT = BigDecimal.valueOf(500);
+    private static final BigDecimal LOWEST_ALLOWED_AMOUNT = BigDecimal.valueOf(1_000);
+    private static final BigDecimal HIGHEST_ALLOWED_AMOUNT = BigDecimal.valueOf(10_000);
+
     private BigDecimal discountAmount;
 
     protected DiscountAmount() {
@@ -21,15 +25,27 @@ public class DiscountAmount {
         if (discountAmount == null) {
             throw new IllegalArgumentException("할인 금액은 필수입니다.");
         }
-        if (discountAmount.remainder(BigDecimal.valueOf(500)).compareTo(BigDecimal.ZERO) != 0) {
+        if (isMultipleOfAmountUnit(discountAmount)) {
             throw new IllegalArgumentException("할인 금액은 500원 단위여야 합니다.");
         }
-        if (discountAmount.compareTo(BigDecimal.valueOf(1_000)) < 0) {
+        if (isLowerThanLowestAllowedAmount(discountAmount)) {
             throw new IllegalArgumentException("할인 금액은 1,000원 이상이어야 합니다.");
         }
-        if (discountAmount.compareTo(BigDecimal.valueOf(10_000)) > 0) {
+        if (isUpperThanHighestAllowedAmount(discountAmount)) {
             throw new IllegalArgumentException("할인 금액은 10,000원 이하여야 합니다.");
         }
+    }
+
+    private boolean isMultipleOfAmountUnit(BigDecimal discountAmount) {
+        return discountAmount.remainder(AMOUNT_UNIT).compareTo(BigDecimal.ZERO) != 0;
+    }
+
+    private boolean isLowerThanLowestAllowedAmount(BigDecimal discountAmount) {
+        return discountAmount.compareTo(LOWEST_ALLOWED_AMOUNT) < 0;
+    }
+
+    private boolean isUpperThanHighestAllowedAmount(BigDecimal discountAmount) {
+        return discountAmount.compareTo(HIGHEST_ALLOWED_AMOUNT) > 0;
     }
 
     @Override

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -1,0 +1,37 @@
+package coupon.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberCoupon> memberCoupons = new ArrayList<>();
+
+    public Member() {
+    }
+
+    public void addCoupon(Coupon coupon) {
+        MemberCoupon memberCoupon = new MemberCoupon(coupon, this);
+        memberCoupons.add(memberCoupon);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public List<MemberCoupon> getMemberCoupons() {
+        return memberCoupons;
+    }
+}

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,0 +1,71 @@
+package coupon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+
+@Entity
+public class MemberCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Coupon coupon;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private boolean used;
+
+    private LocalDate usedDate;
+
+    private LocalDate expiredDate;
+
+    protected MemberCoupon() {
+    }
+
+    public MemberCoupon(Coupon coupon, Member member) {
+        this(null, coupon, member);
+    }
+
+    private MemberCoupon(Long id, Coupon coupon, Member member) {
+        this.id = id;
+        this.coupon = coupon;
+        this.member = member;
+        this.used = false;
+        this.usedDate = null;
+        this.expiredDate = LocalDate.now().plusDays(7);
+    }
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public Coupon getCoupon() {
+        return coupon;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public boolean isUsed() {
+        return used;
+    }
+
+    public LocalDate getUsedDate() {
+        return usedDate;
+    }
+
+    public LocalDate getExpiredDate() {
+        return expiredDate;
+    }
+}

--- a/src/main/java/coupon/domain/MinimumAmount.java
+++ b/src/main/java/coupon/domain/MinimumAmount.java
@@ -1,0 +1,52 @@
+package coupon.domain;
+
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@Embeddable
+public class MinimumAmount {
+
+    private BigDecimal minimumAmount;
+
+    protected MinimumAmount() {
+    }
+
+    public MinimumAmount(BigDecimal minimumAmount) {
+        validate(minimumAmount);
+        this.minimumAmount = minimumAmount;
+    }
+
+    private void validate(BigDecimal minimumAmount) {
+        if (minimumAmount == null) {
+            throw new IllegalArgumentException("최소 주문 금액은 필수입니다.");
+        }
+        if (minimumAmount.compareTo(BigDecimal.valueOf(5_000)) < 0) {
+            throw new IllegalArgumentException("최소 주문 금액은 5,000원 이상이어야 합니다.");
+        }
+        if (minimumAmount.compareTo(BigDecimal.valueOf(100_000)) > 0) {
+            throw new IllegalArgumentException("최소 주문 금액은 100,000원 이하여야 합니다.");
+        }
+    }
+
+    public BigDecimal getMinimumAmount() {
+        return minimumAmount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MinimumAmount that = (MinimumAmount) o;
+        return Objects.equals(minimumAmount, that.minimumAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minimumAmount);
+    }
+}

--- a/src/main/java/coupon/domain/MinimumAmount.java
+++ b/src/main/java/coupon/domain/MinimumAmount.java
@@ -7,6 +7,9 @@ import java.util.Objects;
 @Embeddable
 public class MinimumAmount {
 
+    private static final BigDecimal LOWEST_ALLOWED_AMOUNT = BigDecimal.valueOf(5_000);
+    private static final BigDecimal HIGHEST_ALLOWED_AMOUNT = BigDecimal.valueOf(100_000);
+
     private BigDecimal minimumAmount;
 
     protected MinimumAmount() {
@@ -21,16 +24,20 @@ public class MinimumAmount {
         if (minimumAmount == null) {
             throw new IllegalArgumentException("최소 주문 금액은 필수입니다.");
         }
-        if (minimumAmount.compareTo(BigDecimal.valueOf(5_000)) < 0) {
+        if (isLowerThanLowestAllowedAmount(minimumAmount)) {
             throw new IllegalArgumentException("최소 주문 금액은 5,000원 이상이어야 합니다.");
         }
-        if (minimumAmount.compareTo(BigDecimal.valueOf(100_000)) > 0) {
+        if (isUpperThanHighestAllowedAmount(minimumAmount)) {
             throw new IllegalArgumentException("최소 주문 금액은 100,000원 이하여야 합니다.");
         }
     }
 
-    public BigDecimal getMinimumAmount() {
-        return minimumAmount;
+    private boolean isLowerThanLowestAllowedAmount(BigDecimal minimumAmount) {
+        return minimumAmount.compareTo(LOWEST_ALLOWED_AMOUNT) < 0;
+    }
+
+    private boolean isUpperThanHighestAllowedAmount(BigDecimal minimumAmount) {
+        return minimumAmount.compareTo(HIGHEST_ALLOWED_AMOUNT) > 0;
     }
 
     @Override
@@ -48,5 +55,9 @@ public class MinimumAmount {
     @Override
     public int hashCode() {
         return Objects.hash(minimumAmount);
+    }
+
+    public BigDecimal getMinimumAmount() {
+        return minimumAmount;
     }
 }

--- a/src/main/java/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+import coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,28 @@
+package coupon.service;
+
+import coupon.domain.Coupon;
+import coupon.repository.CouponRepository;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public CouponService(CouponRepository couponRepository) {
+        this.couponRepository = couponRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(Long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(() -> new NoSuchElementException("쿠폰이 존재하지 않습니다."));
+    }
+
+    @Transactional
+    public Coupon createCoupon(Coupon coupon) {
+        return couponRepository.save(coupon);
+    }
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,5 +1,6 @@
 package coupon.service;
 
+import coupon.aspect.ImmediateRead;
 import coupon.domain.Coupon;
 import coupon.repository.CouponRepository;
 import java.util.NoSuchElementException;
@@ -19,6 +20,12 @@ public class CouponService {
     public Coupon getCoupon(Long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new NoSuchElementException("쿠폰이 존재하지 않습니다."));
+    }
+
+    @ImmediateRead
+    @Transactional(readOnly = true)
+    public Coupon getCouponImmediately(Long couponId) {
+        return getCoupon(couponId);
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
         use_sql_comments: true
         hbm2ddl.auto: update
         check_nullability: true
-        query.in_clause_prameter_padding: true
+        query.in_clause_parameter_padding: true
     open-in-view: false
 
 coupon.datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,9 +12,9 @@ spring:
         format_sql: true
         show_sql: false
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
-        query.in_clause_parameter_padding: true
+        query.in_clause_prameter_padding: true
     open-in-view: false
 
 coupon.datasource:

--- a/src/test/java/coupon/domain/CouponNameTest.java
+++ b/src/test/java/coupon/domain/CouponNameTest.java
@@ -1,0 +1,51 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CouponNameTest {
+
+    @Test
+    @DisplayName("쿠폰 이름을 생성한다.")
+    void createCouponName() {
+        String name = "coupon";
+
+        CouponName couponName = new CouponName(name);
+
+        assertThat(couponName).isEqualTo(new CouponName("coupon"));
+    }
+
+    @Test
+    @DisplayName("쿠폰 이름이 null인 경우 예외가 발생한다.")
+    void createCouponNameWhenNull() {
+        String nullName = null;
+
+        assertThatThrownBy(() -> new CouponName(nullName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 이름은 필수입니다.");
+    }
+
+    @ParameterizedTest
+    @DisplayName("쿠폰 이름이 없는 경우 예외가 발생한다.")
+    @CsvSource(value = {"''", "' '", "'    '"})
+    void createCouponNameWhenNoName(String blankName) {
+        assertThatThrownBy(() -> new CouponName(blankName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 이름은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("쿠폰 이름이 30자를 초과하면 예외가 발생한다.")
+    void createCouponNameWhenNameLengthExceeds30() {
+        String tooLongName = "0123456789012345678901234567890";
+
+        assertThatThrownBy(() -> new CouponName(tooLongName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 이름은 30자 이하여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/domain/CouponTest.java
@@ -1,0 +1,63 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CouponTest {
+
+    @Test
+    @DisplayName("쿠폰을 생성한다.")
+    void createCoupon() {
+        Coupon coupon = new Coupon(
+                "coupon",
+                BigDecimal.valueOf(1_000),
+                BigDecimal.valueOf(10_000),
+                Category.FOOD,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7)
+        );
+
+        assertThat("coupon").isEqualTo(coupon.getName());
+    }
+
+    @Test
+    @DisplayName("쿠폰의 할인율이 3% 미만인 경우 예외가 발생한다.")
+    void createCouponWhenDiscountRateLessThan3Percent() {
+        // 1000 / 33334 * 100 = 2.99...
+        BigDecimal discountAmount = BigDecimal.valueOf(1_000);
+        BigDecimal minimumAmount = BigDecimal.valueOf(33_334);
+
+        assertThatThrownBy(() -> new Coupon(
+                "coupon",
+                discountAmount,
+                minimumAmount,
+                Category.FOOD,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인율은 3% 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("쿠폰의 할인율이 20% 초과인 경우 예외가 발생한다.")
+    void createCouponWhenDiscountRateExceeds20Percent() {
+        // 2500 / 11900 * 100 = 21.00...
+        BigDecimal discountAmount = BigDecimal.valueOf(2_500);
+        BigDecimal minimumAmount = BigDecimal.valueOf(11_900);
+
+        assertThatThrownBy(() -> new Coupon(
+                "coupon",
+                discountAmount,
+                minimumAmount,
+                Category.FOOD,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7)
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인율은 20% 이하여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/domain/DiscountAmountTest.java
@@ -1,0 +1,64 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class DiscountAmountTest {
+
+    @ParameterizedTest
+    @DisplayName("할인 금액을 생성한다.")
+    @CsvSource(value = {"1_000", "5_000", "10_000"})
+    void createDiscountAmount(int value) {
+        BigDecimal amount = BigDecimal.valueOf(value);
+
+        DiscountAmount discountAmount = new DiscountAmount(amount);
+
+        assertThat(discountAmount).isEqualTo(new DiscountAmount(BigDecimal.valueOf(value)));
+    }
+
+    @Test
+    @DisplayName("할인 금액이 null인 경우 예외가 발생한다.")
+    void createDiscountAmountWhenNull() {
+        BigDecimal nullAmount = null;
+
+        assertThatThrownBy(() -> new DiscountAmount(nullAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("최소 금액이 1,000원 미만인 경우 예외가 발생한다.")
+    void createDiscountAmountWhenAmountLessThan5_000() {
+        BigDecimal tooSmallAmount = BigDecimal.valueOf(500);
+
+        assertThatThrownBy(() -> new DiscountAmount(tooSmallAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 1,000원 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("최소 금액이 10,000원 초과인 경우 예외가 발생한다.")
+    void createDiscountAmountWhenAmountExceeds100_000() {
+        BigDecimal tooLargeAmount = BigDecimal.valueOf(10_500);
+
+        assertThatThrownBy(() -> new DiscountAmount(tooLargeAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 10,000원 이하여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("할인 금액이 500원 단위가 아닌 경우 예외가 발생한다.")
+    void createDiscountAmountWhenAmountIsNot500() {
+        BigDecimal not500Amount = BigDecimal.valueOf(1_100);
+
+        assertThatThrownBy(() -> new DiscountAmount(not500Amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 500원 단위여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/MinimumAmountTest.java
+++ b/src/test/java/coupon/domain/MinimumAmountTest.java
@@ -1,0 +1,54 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class MinimumAmountTest {
+
+    @ParameterizedTest
+    @DisplayName("최소 금액을 생성한다.")
+    @CsvSource(value = {"5_000", "10_000", "100_000"})
+    void createMinimumAmount(int value) {
+        BigDecimal amount = BigDecimal.valueOf(value);
+
+        MinimumAmount minimumAmount = new MinimumAmount(amount);
+
+        assertThat(minimumAmount).isEqualTo(new MinimumAmount(BigDecimal.valueOf(value)));
+    }
+
+    @Test
+    @DisplayName("최소 금액이 null인 경우 예외가 발생한다.")
+    void createMinimumAmountWhenNull() {
+        BigDecimal nullAmount = null;
+
+        assertThatThrownBy(() -> new MinimumAmount(nullAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 주문 금액은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("최소 금액이 5,000원 미만인 경우 예외가 발생한다.")
+    void createMinimumAmountWhenAmountLessThan5_000() {
+        BigDecimal tooSmallAmount = BigDecimal.valueOf(4_999);
+
+        assertThatThrownBy(() -> new MinimumAmount(tooSmallAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 주문 금액은 5,000원 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("최소 금액이 100,000원 초과인 경우 예외가 발생한다.")
+    void createMinimumAmountWhenAmountExceeds100_000() {
+        BigDecimal tooLargeAmount = BigDecimal.valueOf(100_001);
+
+        assertThatThrownBy(() -> new MinimumAmount(tooLargeAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 주문 금액은 100,000원 이하여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -36,7 +36,7 @@ class CouponServiceTest {
         );
         Coupon save = couponRepository.save(coupon);
 
-        Coupon findCoupon = couponService.getCoupon(save.getId());
+        Coupon findCoupon = couponService.getCouponImmediately(save.getId());
 
         assertAll(
                 () -> assertThat(findCoupon.getId()).isNotNull(),

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import coupon.domain.Category;
 import coupon.domain.Coupon;
 import coupon.repository.CouponRepository;
 import java.math.BigDecimal;
@@ -29,7 +30,7 @@ class CouponServiceTest {
                 "coupon",
                 BigDecimal.valueOf(5000),
                 BigDecimal.valueOf(5000),
-                "Food",
+                Category.FOOD,
                 LocalDate.now(),
                 LocalDate.now()
         );
@@ -60,7 +61,7 @@ class CouponServiceTest {
                 "coupon",
                 BigDecimal.valueOf(5000),
                 BigDecimal.valueOf(5000),
-                "Food",
+                Category.FOOD,
                 LocalDate.now(),
                 LocalDate.now()
         );

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -28,8 +28,8 @@ class CouponServiceTest {
     void getCoupon() {
         Coupon coupon = new Coupon(
                 "coupon",
-                BigDecimal.valueOf(5000),
-                BigDecimal.valueOf(5000),
+                BigDecimal.valueOf(1_000),
+                BigDecimal.valueOf(10_000),
                 Category.FOOD,
                 LocalDate.now(),
                 LocalDate.now()
@@ -59,8 +59,8 @@ class CouponServiceTest {
     void createCoupon() {
         Coupon coupon = new Coupon(
                 "coupon",
-                BigDecimal.valueOf(5000),
-                BigDecimal.valueOf(5000),
+                BigDecimal.valueOf(1_000),
+                BigDecimal.valueOf(10_000),
                 Category.FOOD,
                 LocalDate.now(),
                 LocalDate.now()

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -27,8 +27,8 @@ class CouponServiceTest {
     void getCoupon() {
         Coupon coupon = new Coupon(
                 "coupon",
-                BigDecimal.valueOf(1000),
-                BigDecimal.valueOf(1000),
+                BigDecimal.valueOf(5000),
+                BigDecimal.valueOf(5000),
                 "Food",
                 LocalDate.now(),
                 LocalDate.now()
@@ -58,8 +58,8 @@ class CouponServiceTest {
     void createCoupon() {
         Coupon coupon = new Coupon(
                 "coupon",
-                BigDecimal.valueOf(1000),
-                BigDecimal.valueOf(1000),
+                BigDecimal.valueOf(5000),
+                BigDecimal.valueOf(5000),
                 "Food",
                 LocalDate.now(),
                 LocalDate.now()

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -28,7 +28,6 @@ class CouponServiceTest {
         Coupon coupon = new Coupon(
                 "coupon",
                 BigDecimal.valueOf(1000),
-                BigDecimal.valueOf(0.1),
                 BigDecimal.valueOf(1000),
                 "Food",
                 LocalDate.now(),
@@ -60,7 +59,6 @@ class CouponServiceTest {
         Coupon coupon = new Coupon(
                 "coupon",
                 BigDecimal.valueOf(1000),
-                BigDecimal.valueOf(0.1),
                 BigDecimal.valueOf(1000),
                 "Food",
                 LocalDate.now(),

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,74 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import coupon.domain.Coupon;
+import coupon.repository.CouponRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Test
+    @DisplayName("쿠폰을 조회한다.")
+    void getCoupon() {
+        Coupon coupon = new Coupon(
+                "coupon",
+                BigDecimal.valueOf(1000),
+                BigDecimal.valueOf(0.1),
+                BigDecimal.valueOf(1000),
+                "Food",
+                LocalDate.now(),
+                LocalDate.now()
+        );
+        Coupon save = couponRepository.save(coupon);
+
+        Coupon findCoupon = couponService.getCoupon(save.getId());
+
+        assertAll(
+                () -> assertThat(findCoupon.getId()).isNotNull(),
+                () -> assertThat(findCoupon.getName()).isEqualTo("coupon")
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 쿠폰을 조회하면 예외가 발생한다.")
+    void getCouponWhenNonExistentCoupon() {
+        Long notExistCouponId = 9999999L;
+
+        assertThatThrownBy(() -> couponService.getCoupon(notExistCouponId))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("쿠폰이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("쿠폰을 생성한다.")
+    void createCoupon() {
+        Coupon coupon = new Coupon(
+                "coupon",
+                BigDecimal.valueOf(1000),
+                BigDecimal.valueOf(0.1),
+                BigDecimal.valueOf(1000),
+                "Food",
+                LocalDate.now(),
+                LocalDate.now()
+        );
+
+        Coupon save = couponService.createCoupon(coupon);
+
+        assertThat(save.getName()).isEqualTo("coupon");
+    }
+}


### PR DESCRIPTION
땡이 안녕하세요!
레벨2 마지막 페어에서 리뷰어-리뷰이로 만나네요!
리뷰 잘 부탁드립니다!

복제 지연을 어떻게 해결할까 라는 고민에 **`지연없이 빠르게 읽기 전용 메서드를 추가`** 하는것으로 해결했습니다.
제가 생각하는 근거는 다음과 같습니다.

### 쿠폰 생성후 빠르게 읽어야 하는 상황이 별로 없다.
- 쿠폰을 발급(여기서 발급이란 사용자에게 발급하는 것이 아닌 쿠폰 그 자체를 의미, 사용자가 사용하는 쿠폰은 MemberCoupon)하는 주체는 쇼핑몰 사용자가 아닌 쇼핑몰 관리자 입니다.
- 쿠폰에는 발급 시작일이 있으므로 쿠폰을 발급하자 마자 (1분 이내에) 사용자에게 부여하는게 아닌 이벤트가 있기 충분한 시간전에 발급을 해둬야 합니다.
- 따라서 쿠폰 생성후 바로 읽는 상황은 관리자가 쿠폰을 만들고 잘 만들어졌는지 확인하는 상황밖에 없다 생각했습니다.

### 읽기전용 DB에 먼저 조회 후 쓰기 DB에 조회하면 안되는것인가?
- 모든 쿠폰 조회 로직이 이 절차를 거치게 되면 사용자가 실제로 없는 쿠폰을 조회할때마다 reader db -> writer db를 조회하게 됩니다.
- 이 경우 불필요하게 writer db를 조회하게 되어서 writer db에 성능저하가 생길 수 있다 생각합니다.

그래서 `@ImmediateRead` 어노테이션을 만들어 해당 어노테이션이 붙어있다면 `@Transactional(readOnly = true)` 옵션이 있더라도 writer db에서 쿠폰을 조회하도록 했습니다.
이 api는 쿠폰 생성 후 관리자의 확인용으로만 사용됩니다. 