### PR TITLE
[1단계 - DB 복제와 캐시] 페드로(류형욱) 미션 제출합니다.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mysql_writer:
     user: root
@@ -6,7 +5,7 @@ services:
       context: ./writer
       dockerfile: Dockerfile
     ports:
-      - 33306:3306
+      - "33306:3306"
     networks:
       coupon_dock_net:
         ipv4_address: 172.20.0.10
@@ -24,7 +23,7 @@ services:
       context: ./reader
       dockerfile: Dockerfile
     ports:
-      - 33307:3306
+      - "33307:3306"
     networks:
       coupon_dock_net:
         ipv4_address: 172.20.0.11

--- a/src/main/java/coupon/CouponApplication.java
+++ b/src/main/java/coupon/CouponApplication.java
@@ -2,7 +2,9 @@ package coupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CouponApplication {
 

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -1,0 +1,53 @@
+package coupon.config;
+
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class DataSourceConfig {
+
+    protected static final String WRITER = "writer";
+    protected static final String READER = "reader";
+
+    @Bean(name = WRITER)
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = READER)
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    public DataSource dynamicDataSource(
+            @Qualifier(WRITER) DataSource writerDataSource,
+            @Qualifier(READER) DataSource readerDataSource
+    ) {
+        DynamicDataSource dynamicDataSource = new DynamicDataSource();
+        Map<Object, Object> dataSourceMap = Map.of(
+                WRITER, writerDataSource,
+                READER, readerDataSource
+        );
+
+        dynamicDataSource.setTargetDataSources(dataSourceMap);
+        dynamicDataSource.setDefaultTargetDataSource(writerDataSource);
+        return dynamicDataSource;
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource() {
+        DataSource dataSource = dynamicDataSource(writerDataSource(), readerDataSource());
+        return new LazyConnectionDataSourceProxy(dataSource);
+    }
+}

--- a/src/main/java/coupon/config/DynamicDataSource.java
+++ b/src/main/java/coupon/config/DynamicDataSource.java
@@ -1,0 +1,14 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class DynamicDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager.isCurrentTransactionReadOnly()
+                ? DataSourceConfig.READER
+                : DataSourceConfig.WRITER;
+    }
+}

--- a/src/main/java/coupon/domain/BaseEntity.java
+++ b/src/main/java/coupon/domain/BaseEntity.java
@@ -1,0 +1,24 @@
+package coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "start_date", nullable = false)
+    protected LocalDateTime startDate;
+
+    @LastModifiedDate
+    @Column(name = "end_date", nullable = false)
+    protected LocalDateTime endDate;
+}

--- a/src/main/java/coupon/domain/coupon/Category.java
+++ b/src/main/java/coupon/domain/coupon/Category.java
@@ -1,0 +1,5 @@
+package coupon.domain.coupon;
+
+public enum Category {
+    FASHION, ELECTRONICS, FURNITURE, FOOD
+}

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -1,0 +1,117 @@
+package coupon.domain.coupon;
+
+import coupon.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "coupon")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseEntity {
+
+    private static final int MAX_NAME_LENGTH = 30;
+    private static final int MIN_DISCOUNT_AMOUNT = 1000;
+    private static final int MAX_DISCOUNT_AMOUNT = 100000;
+    private static final int DISCOUNT_UNIT = 500;
+    private static final int MIN_DISCOUNT_RATE = 3;
+    private static final int MAX_DISCOUNT_RATE = 20;
+    private static final int MIN_MIN_ORDER_AMOUNT = 5000;
+    private static final int MAX_MIN_ORDER_AMOUNT = 100000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private int discountAmount;
+
+    private int discountRate;
+
+    private int minimumOrderAmount;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    public Coupon(
+            Long id, String name,
+            int discountAmount, int minimumOrderAmount, Category category,
+            LocalDateTime startDate, LocalDateTime endDate
+    ) {
+        validate(name, discountAmount, minimumOrderAmount, startDate, endDate);
+        int rate = calcDiscountRate(discountAmount, minimumOrderAmount);
+        this.id = id;
+        this.name = name;
+        this.discountAmount = discountAmount;
+        this.discountRate = rate;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.category = category;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    private void validate(String name, int discountAmount, int minimumOrderAmount, LocalDateTime startDate,
+                          LocalDateTime endDate) {
+        validateCouponName(name);
+        validateDiscountAmount(discountAmount);
+        validateMinimumOrderAmount(minimumOrderAmount);
+        validateDate(startDate, endDate);
+    }
+
+    public void validateCouponName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("쿠폰 이름이 비어 있습니다.");
+        }
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new IllegalArgumentException("쿠폰 이름은 " + MAX_NAME_LENGTH + "자 이하여야 합니다.");
+        }
+    }
+
+    private void validateDiscountAmount(int discountAmount) {
+        if (discountAmount < MIN_DISCOUNT_AMOUNT) {
+            throw new IllegalArgumentException("할인 금액은 " + MIN_DISCOUNT_AMOUNT + "원 이상이어야 합니다.");
+        }
+        if (discountAmount > MAX_DISCOUNT_AMOUNT) {
+            throw new IllegalArgumentException("할인 금액은 " + MAX_DISCOUNT_AMOUNT + "원 이하여야 합니다.");
+        }
+        if (discountAmount % DISCOUNT_UNIT != 0) {
+            throw new IllegalArgumentException("할인 금액은 " + DISCOUNT_UNIT + "원 단위로 입력해야 합니다.");
+        }
+    }
+
+    private int calcDiscountRate(int discountAmount, int minimumOrderAmount) {
+        int rate = (int) ((double) discountAmount / minimumOrderAmount * 100);
+        if (rate < MIN_DISCOUNT_RATE) {
+            throw new IllegalArgumentException("할인율은 " + MIN_DISCOUNT_RATE + "% 이상이어야 합니다.");
+        }
+        if (rate > MAX_DISCOUNT_RATE) {
+            throw new IllegalArgumentException("할인율은 " + MAX_DISCOUNT_RATE + "% 이하여야 합니다.");
+        }
+        return rate;
+    }
+
+    private void validateMinimumOrderAmount(int minimumOrderAmount) {
+        if (minimumOrderAmount < MIN_MIN_ORDER_AMOUNT) {
+            throw new IllegalArgumentException("최소 주문 금액은 " + MIN_MIN_ORDER_AMOUNT + "원 이상이어야 합니다.");
+        }
+        if (minimumOrderAmount > MAX_MIN_ORDER_AMOUNT) {
+            throw new IllegalArgumentException("최소 주문 금액은 " + MAX_MIN_ORDER_AMOUNT + "원 이하여야 합니다.");
+        }
+    }
+
+    private void validateDate(LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작일은 종료일 이전이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/CouponRepository.java
+++ b/src/main/java/coupon/domain/coupon/CouponRepository.java
@@ -1,0 +1,6 @@
+package coupon.domain.coupon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/coupon/domain/coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/coupon/MemberCoupon.java
@@ -1,0 +1,55 @@
+package coupon.domain.coupon;
+
+import coupon.domain.BaseEntity;
+import coupon.domain.member.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "member_coupon")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCoupon extends BaseEntity {
+
+    private static final int COUPON_USABLE_DAYS = 7;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Member member;
+
+    @ManyToOne(optional = false)
+    private Coupon coupon;
+
+    private boolean isUsed = false;
+
+    private LocalDateTime issuedAt;
+
+    private LocalDateTime expireAt;
+
+    public MemberCoupon(Member member, Coupon coupon) {
+        this.member = member;
+        this.coupon = coupon;
+        this.isUsed = false;
+        this.issuedAt = LocalDateTime.now();
+        this.expireAt = calcExpireAt(issuedAt);
+    }
+
+    private LocalDateTime calcExpireAt(LocalDateTime issuedAt) {
+        return issuedAt.plusDays(COUPON_USABLE_DAYS)
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(59)
+                .withNano(999999);
+    }
+}

--- a/src/main/java/coupon/domain/coupon/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/coupon/MemberCouponRepository.java
@@ -1,0 +1,6 @@
+package coupon.domain.coupon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+}

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -1,0 +1,33 @@
+package coupon.domain.member;
+
+import coupon.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public Member(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Member(String name) {
+        this(null, name);
+    }
+}

--- a/src/main/java/coupon/domain/member/MemberRepository.java
+++ b/src/main/java/coupon/domain/member/MemberRepository.java
@@ -1,0 +1,6 @@
+package coupon.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,35 @@
+package coupon.service;
+
+import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.CouponRepository;
+import coupon.support.TransactionSupport;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final TransactionSupport transactionSupport;
+
+    @Transactional
+    public long create(Coupon coupon) {
+        Coupon saved = couponRepository.save(coupon);
+        return saved.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseGet(() -> findFromWriterDB(couponId));
+    }
+
+    private Coupon findFromWriterDB(long couponId) {
+        return transactionSupport.withNewTransaction(
+                () -> couponRepository.findById(couponId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: " + couponId))
+        );
+    }
+}

--- a/src/main/java/coupon/support/TransactionSupport.java
+++ b/src/main/java/coupon/support/TransactionSupport.java
@@ -1,0 +1,15 @@
+package coupon.support;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionSupport {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public <T> T withNewTransaction(Supplier<T> method) {
+        return method.get();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,12 +10,16 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
 
 coupon.datasource:
   writer:

--- a/src/test/java/coupon/domain/coupon/CouponTest.java
+++ b/src/test/java/coupon/domain/coupon/CouponTest.java
@@ -1,0 +1,118 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CouponTest {
+
+    @DisplayName("쿠폰 이름이 유효하면 예외가 발생하지 않는다.")
+    @ValueSource(strings = {"coupon", "Coupon"})
+    @ParameterizedTest
+    void couponWithValidName(String couponName) {
+        // when & then
+        assertThatCode(
+                () -> new Coupon(
+                        null, couponName,
+                        1000, 10000, Category.FOOD,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(30)
+                )
+        ).doesNotThrowAnyException();
+
+    }
+
+    @DisplayName("쿠폰 이름이 비어 있으면 예외가 발생한다.")
+    @NullAndEmptySource
+    @ParameterizedTest
+    void validateNameNotBlank(String couponName) {
+        // when & then
+        assertThatThrownBy(
+                () -> new Coupon(
+                        null, couponName,
+                        1000, 10000, Category.FOOD,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(30)
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("쿠폰 이름이 30자를 초과하면 예외가 발생한다.")
+    @Test
+    void validateNameLength() {
+        // given
+        String testName = "name".repeat(10);
+
+        // when & then
+        assertThatThrownBy(
+                () -> new Coupon(
+                        null, testName,
+                        1000, 10000, Category.FOOD,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(30)
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("할인 금액은 1000원 이상, 10000원 이하여야 한다.")
+    @ValueSource(ints = {999, 1001, 9999, 10001})
+    @ParameterizedTest
+    void validateDiscountAmount(int discountAmount) {
+        // when & then
+        assertThatThrownBy(
+                () -> new Coupon(
+                        null, "couponName",
+                        discountAmount, 10000, Category.FOOD,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(30)
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("할인율은 3% 이상, 20% 이하여야 한다.")
+    @ValueSource(ints = {2, 21})
+    @ParameterizedTest
+    void validateDiscountRate(int discountRate) {
+        // givien
+        int discountAmount = 1000;
+        int minimumOrderAmount = (int) ((double) discountAmount / discountRate * 100);
+
+        // when & then
+        assertThatThrownBy(
+                () -> new Coupon(
+                        null, "couponName",
+                        1000, minimumOrderAmount, Category.FOOD,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(30)
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("최소 주문 금액은 5000원 이상, 100000원 이하여야 한다.")
+    @ValueSource(ints = {4999, 100001})
+    @ParameterizedTest
+    void validateMinimumOrderAmount(int minimumOrderAmount) {
+        // when & then
+        assertThatThrownBy(
+                () -> new Coupon(
+                        null, "couponName",
+                        1000, minimumOrderAmount, Category.FOOD,
+                        LocalDateTime.now(), LocalDateTime.now().plusDays(30)
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("쿠폰의 시작일이 종료일보다 늦으면 예외가 발생한다.")
+    @Test
+    void validateDate() {
+        // when & then
+        assertThatThrownBy(
+                () -> new Coupon(
+                        null, "couponName",
+                        1000, 10000, Category.FOOD,
+                        LocalDateTime.now().plusSeconds(1L), LocalDateTime.now()
+                )
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/coupon/domain/coupon/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/coupon/MemberCouponTest.java
@@ -1,0 +1,34 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import coupon.domain.member.Member;
+import coupon.fixture.CouponFixture;
+import coupon.fixture.MemberFixture;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberCouponTest {
+
+    @DisplayName("멤버의 쿠폰은 발급일을 포함하여 7일 동안 사용할 수 있다.")
+    @Test
+    void issueEndDate() {
+        // given
+        Coupon coupon = CouponFixture.TEST_COUPON;
+        Member member = MemberFixture.TEST_MEMBER;
+        LocalDateTime now = LocalDateTime.now();
+
+        // when
+        MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
+        LocalDateTime actual = memberCoupon.getExpireAt();
+
+        // then
+        LocalDateTime expected = now.plusDays(7)
+                .withHour(23)
+                .withMinute(59)
+                .withSecond(59)
+                .withNano(999999);
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/src/test/java/coupon/fixture/CouponFixture.java
+++ b/src/test/java/coupon/fixture/CouponFixture.java
@@ -1,0 +1,14 @@
+package coupon.fixture;
+
+import coupon.domain.coupon.Category;
+import coupon.domain.coupon.Coupon;
+import java.time.LocalDateTime;
+
+public class CouponFixture {
+
+    public static final Coupon TEST_COUPON = new Coupon(
+            null, "테스트 쿠폰",
+            1000, 10000, Category.ELECTRONICS,
+            LocalDateTime.now(), LocalDateTime.now().plusDays(7)
+    );
+}

--- a/src/test/java/coupon/fixture/MemberFixture.java
+++ b/src/test/java/coupon/fixture/MemberFixture.java
@@ -1,0 +1,8 @@
+package coupon.fixture;
+
+import coupon.domain.member.Member;
+
+public class MemberFixture {
+
+        public static final Member TEST_MEMBER = new Member(null, "test");
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,37 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.CouponRepository;
+import coupon.fixture.CouponFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @AfterEach
+    void tearDown() {
+        couponRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("복제 지연 테스트")
+    @Test
+    void replicaDelay() {
+        Coupon coupon = CouponFixture.TEST_COUPON;
+        long id = couponService.create(coupon);
+        Coupon savedCoupon = couponService.getCoupon(id);
+        assertThat(savedCoupon).isNotNull();
+    }
+}


### PR DESCRIPTION
망쵸 안녕하세요👋

레벨2 첫 페어였는데 마지막 미션(이번엔 맞겠죠?)에서 또 만나니 반갑네요!
아직도 ObjectMapper로 같이 삽질하던게 기억납니다ㅋㅋㅋ

1단계 미션은 어떠한 수를 써서라도 복제 지연 상황에서 데이터를 정상적으로 가져올 수 있도록 구현하는 것이 목적이라고 생각했어요.

별도의 캐시를 둘 수도 있겠지만, 2단계 미션 제목이 캐시이기도 하고 현재 구현에서는 과한 도입인 것 같아 우선 레플리카에서 미스 발생 시 소스에서 다시 한 번 읽어오도록 구현해 두었습니다.

명시적인 설정으로 인해 대략 1초 정도의 복제 지연이 발생하는데, 쿠폰 생성 후 유저가 1초 이내에 바로 다시 조회할 일이 많지는 않을 것이므로 지금 정도의 규모에서는 부하 분산을 위해 R/W 인스턴스를 분리한 의미 역시 상실되지 않는다고 판단했습니다. (고의로 DB에 존재하지 않는 쿠폰을 반복적으로 조회한다면 어느 정도의 오버헤드는 발생하겠네요)

리뷰 잘 부탁드려요!