### PR TITLE
[1단계 - DB 복제와 캐시] 재즈(함석명) 미션 제출합니다.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,12 +6,13 @@ services:
       context: ./writer
       dockerfile: Dockerfile
     ports:
-      - 33306:3306
+      - "33306:3306"
     networks:
       coupon_dock_net:
         ipv4_address: 172.20.0.10
     volumes:
       - ./data/writer:/var/lib/mysql
+      - ./init/schema.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_writer
     restart: always
     environment:
@@ -24,12 +25,13 @@ services:
       context: ./reader
       dockerfile: Dockerfile
     ports:
-      - 33307:3306
+      - "33307:3306"
     networks:
       coupon_dock_net:
         ipv4_address: 172.20.0.11
     volumes:
       - ./data/reader:/var/lib/mysql
+      - ./init/schema.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_reader
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -8,8 +8,8 @@ CREATE TABLE IF NOT EXISTS coupon
     discount_amount         INT,
     minimum_order_amount    INT,
     category                ENUM('FASHION', 'ELECTRONICS', 'FURNITURE', 'FOOD') NOT NULL,
-    issue_started_at        DATETIME        NOT NULL,
-    issue_ended_at          DATETIME        NOT NULL,
+    issue_started_at        DATETIME(6)     NOT NULL,
+    issue_ended_at          DATETIME(6)     NOT NULL,
     issue_limit             BIGINT          NOT NULL,
     issue_count             BIGINT          NOT NULL,
     PRIMARY KEY (coupon_id)

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -1,0 +1,36 @@
+CREATE DATABASE IF NOT EXISTS coupon;
+USE coupon;
+
+CREATE TABLE IF NOT EXISTS coupon
+(
+    coupon_id               BIGINT          NOT NULL AUTO_INCREMENT,
+    name                    VARCHAR(30)     NOT NULL,
+    discount_amount         INT,
+    minimum_order_amount    INT,
+    category                ENUM('FASHION', 'ELECTRONICS', 'FURNITURE', 'FOOD') NOT NULL,
+    issue_started_at        DATETIME        NOT NULL,
+    issue_ended_at          DATETIME        NOT NULL,
+    issue_limit             BIGINT          NOT NULL,
+    issue_count             BIGINT          NOT NULL,
+    PRIMARY KEY (coupon_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS member
+(
+    member_id   BIGINT          NOT NULL AUTO_INCREMENT,
+    name        VARCHAR(20)     NOT NULL,
+    PRIMARY KEY (member_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS member_coupon
+(
+    member_coupon_id    BIGINT  NOT NULL AUTO_INCREMENT,
+    coupon_id           BIGINT,
+    member_id           BIGINT,
+    used                BOOLEAN,
+    issued_at           DATETIME,
+    use_ended_at        DATETIME,
+    PRIMARY KEY (member_coupon_id),
+    CONSTRAINT fk_coupon FOREIGN KEY (coupon_id) REFERENCES coupon(coupon_id),
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member(member_id)
+) ENGINE=InnoDB;

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -28,8 +28,8 @@ CREATE TABLE IF NOT EXISTS member_coupon
     coupon_id           BIGINT,
     member_id           BIGINT,
     used                BOOLEAN,
-    issued_at           DATETIME,
-    use_ended_at        DATETIME,
+    issued_at           DATETIME(6),
+    use_ended_at        DATETIME(6),
     PRIMARY KEY (member_coupon_id),
     CONSTRAINT fk_coupon FOREIGN KEY (coupon_id) REFERENCES coupon(coupon_id),
     CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member(member_id)

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS coupon
     name                    VARCHAR(30)     NOT NULL,
     discount_amount         INT,
     minimum_order_amount    INT,
-    category                ENUM('FASHION', 'ELECTRONICS', 'FURNITURE', 'FOOD') NOT NULL,
+    category                VARCHAR(255) NOT NULL,
     issue_started_at        DATETIME(6)     NOT NULL,
     issue_ended_at          DATETIME(6)     NOT NULL,
     issue_limit             BIGINT          NOT NULL,

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -1,0 +1,52 @@
+package coupon.config;
+
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class DataSourceConfig {
+
+    public static final String READER = "reader";
+    public static final String WRITER = "writer";
+
+    @Bean(READER)
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(WRITER)
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier(READER) DataSource reader,
+            @Qualifier(WRITER) DataSource writer
+    ) {
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+        Map<Object, Object> dataSources = Map.of(
+                READER, reader,
+                WRITER, writer
+        );
+        routingDataSource.setTargetDataSources(dataSources);
+        routingDataSource.setDefaultTargetDataSource(writer);
+        return routingDataSource;
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        DataSource dataSource = routingDataSource(readerDataSource(), writerDataSource());
+        return new LazyConnectionDataSourceProxy(dataSource);
+    }
+}

--- a/src/main/java/coupon/config/RoutingDataSource.java
+++ b/src/main/java/coupon/config/RoutingDataSource.java
@@ -1,0 +1,17 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isCurrentTransactionReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if (isCurrentTransactionReadOnly) {
+            return DataSourceConfig.READER;
+        }
+        return DataSourceConfig.WRITER;
+    }
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,0 +1,107 @@
+package coupon.domain;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "coupon")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    private static final int MIN_DISCOUNT_RATE = 3;
+    private static final int MAX_DISCOUNT_RATE = 20;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private CouponName couponName;
+
+    @Embedded
+    private DiscountAmount discountAmount;
+
+    @Embedded
+    private MinimumOrderAmount minimumOrderAmount;
+
+    @Enumerated(value = EnumType.STRING)
+    private CouponCategory couponCategory;
+
+    private CouponPeriod couponPeriod;
+
+    private long issueLimit;
+
+    private long issueCount;
+
+    public Coupon(
+            CouponName couponName,
+            DiscountAmount discountAmount,
+            MinimumOrderAmount minimumOrderAmount,
+            CouponCategory couponCategory,
+            CouponPeriod couponPeriod,
+            long issueLimit,
+            long issueCount
+    ) {
+        validateAmountRate(discountAmount, minimumOrderAmount);
+
+        this.couponName = couponName;
+        this.discountAmount = discountAmount;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.couponCategory = couponCategory;
+        this.couponPeriod = couponPeriod;
+        this.issueLimit = issueLimit;
+        this.issueCount = issueCount;
+    }
+
+    public Coupon(
+            String couponName,
+            int discountAmount,
+            int minimumOrderAmount,
+            CouponCategory couponCategory,
+            LocalDateTime issueStartedAt,
+            LocalDateTime issueEndedAt,
+            long issueLimit,
+            long issueCount
+    ) {
+        this(
+                new CouponName(couponName),
+                new DiscountAmount(discountAmount),
+                new MinimumOrderAmount(minimumOrderAmount),
+                couponCategory,
+                new CouponPeriod(issueStartedAt, issueEndedAt),
+                issueLimit,
+                issueCount
+        );
+    }
+
+    public void issue() {
+        if (couponPeriod.isIssuable()) {
+            throw new IllegalArgumentException("쿠폰을 발급할 수 없는 시간입니다.");
+        }
+        if (issueLimit <= issueCount) {
+            throw new IllegalArgumentException("쿠폰을 더 이상 발급할 수 없습니다.");
+        }
+        this.issueCount++;
+    }
+
+    private void validateAmountRate(DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount) {
+        int discountRate = discountAmount.getAmount() * 100 / minimumOrderAmount.getAmount();
+
+        if (discountRate < MIN_DISCOUNT_RATE || MAX_DISCOUNT_RATE < discountRate) {
+            throw new IllegalArgumentException(
+                    "할인율은 " + MIN_DISCOUNT_RATE + "% 이상 " + MAX_DISCOUNT_RATE + "% 이하여야 합니다."
+            );
+        }
+    }
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -24,6 +25,7 @@ public class Coupon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_id", nullable = false)
     private Long id;
 
     @Embedded
@@ -36,12 +38,15 @@ public class Coupon {
     private MinimumOrderAmount minimumOrderAmount;
 
     @Enumerated(value = EnumType.STRING)
+    @Column(name = "category", nullable = false)
     private CouponCategory couponCategory;
 
     private CouponPeriod couponPeriod;
 
+    @Column(name = "issue_limit", nullable = false)
     private long issueLimit;
 
+    @Column(name = "issue_count", nullable = false)
     private long issueCount;
 
     public Coupon(

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -41,6 +41,7 @@ public class Coupon {
     @Column(name = "category", nullable = false)
     private CouponCategory couponCategory;
 
+    @Embedded
     private CouponPeriod couponPeriod;
 
     @Column(name = "issue_limit", nullable = false)

--- a/src/main/java/coupon/domain/CouponCategory.java
+++ b/src/main/java/coupon/domain/CouponCategory.java
@@ -1,0 +1,6 @@
+package coupon.domain;
+
+public enum CouponCategory {
+
+    FASHION, ELECTRONICS, FURNITURE, FOOD;
+}

--- a/src/main/java/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/domain/CouponName.java
@@ -1,0 +1,38 @@
+package coupon.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponName {
+
+    private static final int MAX_NAME_LENGTH = 30;
+
+    private String name;
+
+    public CouponName(String name) {
+        validateCouponName(name);
+        this.name = name;
+    }
+
+    private void validateCouponName(String name) {
+        validatePresence(name);
+        validateNameLength(name);
+    }
+
+    private void validatePresence(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("쿠폰 이름은 반드시 존재해야 합니다.");
+        }
+    }
+
+    private void validateNameLength(String name) {
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new IllegalArgumentException("쿠폰 이름 길이는 최대 30자 이하여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/domain/CouponName.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class CouponName {
 
     private static final int MAX_NAME_LENGTH = 30;
 
+    @Column(name = "name", nullable = false)
     private String name;
 
     public CouponName(String name) {

--- a/src/main/java/coupon/domain/CouponPeriod.java
+++ b/src/main/java/coupon/domain/CouponPeriod.java
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CouponPeriod {
 
-    @Column(name = "issue_started_at", nullable = false)
+    @Column(name = "issue_started_at", nullable = false, columnDefinition = "DATETIME(6)")
     private LocalDateTime issueStartedAt;
 
-    @Column(name = "issue_ended_at", nullable = false)
+    @Column(name = "issue_ended_at", nullable = false, columnDefinition = "DATETIME(6)")
     private LocalDateTime issueEndedAt;
 
     public CouponPeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {

--- a/src/main/java/coupon/domain/CouponPeriod.java
+++ b/src/main/java/coupon/domain/CouponPeriod.java
@@ -19,9 +19,9 @@ public class CouponPeriod {
     private LocalDateTime issueEndedAt;
 
     public CouponPeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {
+        validatePeriod(issueStartedAt, issueEndedAt);
         this.issueStartedAt = issueStartedAt;
         this.issueEndedAt = issueEndedAt;
-        validatePeriod(issueStartedAt, issueEndedAt);
     }
 
     private void validatePeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {

--- a/src/main/java/coupon/domain/CouponPeriod.java
+++ b/src/main/java/coupon/domain/CouponPeriod.java
@@ -1,0 +1,28 @@
+package coupon.domain;
+
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponPeriod {
+
+    private LocalDateTime issueStartedAt;
+    private LocalDateTime issueEndedAt;
+
+    public CouponPeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {
+        this.issueStartedAt = issueStartedAt;
+        this.issueEndedAt = issueEndedAt;
+        validatePeriod(issueStartedAt, issueEndedAt);
+    }
+
+    private void validatePeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {
+        if (issueStartedAt.isAfter(issueEndedAt)) {
+            throw new IllegalArgumentException("쿠폰의 발급 시작일은 종료일보다 이전이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/CouponPeriod.java
+++ b/src/main/java/coupon/domain/CouponPeriod.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -11,7 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CouponPeriod {
 
+    @Column(name = "issue_started_at", nullable = false)
     private LocalDateTime issueStartedAt;
+
+    @Column(name = "issue_ended_at", nullable = false)
     private LocalDateTime issueEndedAt;
 
     public CouponPeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {

--- a/src/main/java/coupon/domain/CouponPeriod.java
+++ b/src/main/java/coupon/domain/CouponPeriod.java
@@ -25,4 +25,8 @@ public class CouponPeriod {
             throw new IllegalArgumentException("쿠폰의 발급 시작일은 종료일보다 이전이어야 합니다.");
         }
     }
+
+    public boolean isIssuable() {
+        return issueStartedAt.isAfter(LocalDateTime.now()) || issueEndedAt.isBefore(LocalDateTime.now());
+    }
 }

--- a/src/main/java/coupon/domain/CouponRepository.java
+++ b/src/main/java/coupon/domain/CouponRepository.java
@@ -1,0 +1,6 @@
+package coupon.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/domain/DiscountAmount.java
@@ -1,0 +1,47 @@
+package coupon.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiscountAmount {
+
+    private static final int MIN_AMOUNT = 1000;
+    private static final int MAX_AMOUNT = 10000;
+    private static final int DEFAULT_UNIT = 500;
+
+    private int amount;
+
+    public DiscountAmount(int amount) {
+        validateAmount(amount);
+        this.amount = amount;
+    }
+
+    private void validateAmount(int amount) {
+        validateMinimumAmount(amount);
+        validateMaximumAmount(amount);
+        validateMultipleOf(amount);
+    }
+
+    private void validateMinimumAmount(int amount) {
+        if (amount < MIN_AMOUNT) {
+            throw new IllegalArgumentException("할인 금액은 " + MIN_AMOUNT + "원 이상이어야 합니다.");
+        }
+    }
+
+    private void validateMaximumAmount(int amount) {
+        if (amount > MAX_AMOUNT) {
+            throw new IllegalArgumentException("할인 금액은 " + MAX_AMOUNT + "원 이하여야 합니다.");
+        }
+    }
+
+    private void validateMultipleOf(int amount) {
+        if (amount % DEFAULT_UNIT != 0) {
+            throw new IllegalArgumentException("할인 금액은 " + DEFAULT_UNIT + "원 단위로만 설정할 수 있습니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/domain/DiscountAmount.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class DiscountAmount {
     private static final int MAX_AMOUNT = 10000;
     private static final int DEFAULT_UNIT = 500;
 
+    @Column(name = "discount_amount", nullable = false)
     private int amount;
 
     public DiscountAmount(int amount) {

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -1,0 +1,27 @@
+package coupon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String memberName;
+
+    public Member(String memberName) {
+        this.memberName = memberName;
+    }
+}

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,8 +18,10 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false)
     private Long id;
 
+    @Column(name = "name", nullable = false)
     private String memberName;
 
     public Member(String memberName) {

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,0 +1,61 @@
+package coupon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_coupon")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCoupon {
+
+    private static final long COUPON_USABLE_DAYS = 7;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private boolean used;
+
+    private LocalDateTime issuedAt;
+
+    private LocalDateTime useEndedAt;
+
+    public MemberCoupon(Coupon coupon, Member member, boolean used, LocalDateTime issuedAt, LocalDateTime useEndedAt) {
+        this.coupon = coupon;
+        this.member = member;
+        this.used = used;
+        this.issuedAt = issuedAt;
+        this.useEndedAt = useEndedAt;
+    }
+
+    public static MemberCoupon issue(Member member, Coupon coupon) {
+        coupon.issue();
+
+        MemberCoupon memberCoupon = new MemberCoupon();
+        memberCoupon.member = member;
+        memberCoupon.coupon = coupon;
+        memberCoupon.issuedAt = LocalDateTime.now();
+        memberCoupon.useEndedAt = memberCoupon.issuedAt.plusDays(COUPON_USABLE_DAYS);
+        memberCoupon.used = false;
+
+        return memberCoupon;
+    }
+}

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 public class MemberCoupon {
 
     private static final long COUPON_USABLE_DAYS = 7;
+    private static final LocalTime EXPIRATION_TIME = LocalTime.of(23, 59, 59, 999999000);
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,30 +39,17 @@ public class MemberCoupon {
     @Column(name = "used", nullable = false)
     private boolean used;
 
-    @Column(name = "issued_at", nullable = false)
+    @Column(name = "issued_at", nullable = false, columnDefinition = "DATETIME(6)")
     private LocalDateTime issuedAt;
 
-    @Column(name = "use_ended_at", nullable = false)
+    @Column(name = "use_ended_at", nullable = false, columnDefinition = "DATETIME(6)")
     private LocalDateTime useEndedAt;
 
-    public MemberCoupon(Coupon coupon, Member member, boolean used, LocalDateTime issuedAt, LocalDateTime useEndedAt) {
-        this.coupon = coupon;
+    public MemberCoupon(Member member, Coupon coupon) {
         this.member = member;
-        this.used = used;
-        this.issuedAt = issuedAt;
-        this.useEndedAt = useEndedAt;
-    }
-
-    public static MemberCoupon issue(Member member, Coupon coupon) {
-        coupon.issue();
-
-        MemberCoupon memberCoupon = new MemberCoupon();
-        memberCoupon.member = member;
-        memberCoupon.coupon = coupon;
-        memberCoupon.issuedAt = LocalDateTime.now();
-        memberCoupon.useEndedAt = memberCoupon.issuedAt.plusDays(COUPON_USABLE_DAYS);
-        memberCoupon.used = false;
-
-        return memberCoupon;
+        this.coupon = coupon;
+        this.used = false;
+        this.issuedAt = LocalDateTime.now();
+        this.useEndedAt = issuedAt.plusDays(COUPON_USABLE_DAYS).with(EXPIRATION_TIME);
     }
 }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -22,6 +23,7 @@ public class MemberCoupon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_coupon_id", nullable = false)
     private Long id;
 
     @ManyToOne
@@ -32,10 +34,13 @@ public class MemberCoupon {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Column(name = "used", nullable = false)
     private boolean used;
 
+    @Column(name = "issued_at", nullable = false)
     private LocalDateTime issuedAt;
 
+    @Column(name = "use_ended_at", nullable = false)
     private LocalDateTime useEndedAt;
 
     public MemberCoupon(Coupon coupon, Member member, boolean used, LocalDateTime issuedAt, LocalDateTime useEndedAt) {

--- a/src/main/java/coupon/domain/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/MemberCouponRepository.java
@@ -1,0 +1,6 @@
+package coupon.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+}

--- a/src/main/java/coupon/domain/MemberRepository.java
+++ b/src/main/java/coupon/domain/MemberRepository.java
@@ -1,0 +1,6 @@
+package coupon.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/domain/MinimumOrderAmount.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class MinimumOrderAmount {
     private static final int MIN_ORDER_AMOUNT = 5000;
     private static final int MAX_ORDER_AMOUNT = 100000;
 
+    @Column(name = "minimum_order_amount", nullable = false)
     private int amount;
 
     public MinimumOrderAmount(int amount) {

--- a/src/main/java/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/domain/MinimumOrderAmount.java
@@ -1,0 +1,39 @@
+package coupon.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MinimumOrderAmount {
+
+    private static final int MIN_ORDER_AMOUNT = 5000;
+    private static final int MAX_ORDER_AMOUNT = 100000;
+
+    private int amount;
+
+    public MinimumOrderAmount(int amount) {
+        validateAmount(amount);
+        this.amount = amount;
+    }
+
+    private void validateAmount(int amount) {
+        validateMinimumAmount(amount);
+        validateMaximumAmount(amount);
+    }
+
+    private void validateMinimumAmount(int amount) {
+        if (amount < MIN_ORDER_AMOUNT) {
+            throw new IllegalArgumentException("최소 주문 금액은 " + MIN_ORDER_AMOUNT + "원 이상이어야 합니다.");
+        }
+    }
+
+    private void validateMaximumAmount(int amount) {
+        if (amount > MAX_ORDER_AMOUNT) {
+            throw new IllegalArgumentException("최소 주문 금액은 " + MAX_ORDER_AMOUNT + "원 이하여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/domain/MinimumOrderAmount.java
@@ -23,17 +23,9 @@ public class MinimumOrderAmount {
     }
 
     private void validateAmount(int amount) {
-        validateMinimumAmount(amount);
-        validateMaximumAmount(amount);
-    }
-
-    private void validateMinimumAmount(int amount) {
         if (amount < MIN_ORDER_AMOUNT) {
             throw new IllegalArgumentException("최소 주문 금액은 " + MIN_ORDER_AMOUNT + "원 이상이어야 합니다.");
         }
-    }
-
-    private void validateMaximumAmount(int amount) {
         if (amount > MAX_ORDER_AMOUNT) {
             throw new IllegalArgumentException("최소 주문 금액은 " + MAX_ORDER_AMOUNT + "원 이하여야 합니다.");
         }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -27,7 +27,7 @@ public class CouponService {
     }
 
     private Coupon findFromWriter(long couponId) {
-        return dataSourceSupport.executeOnWriter(
+        return dataSourceSupport.executeWithNewTransaction(
                 () -> couponRepository.findById(couponId)
                         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: " + couponId))
         );

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,35 @@
+package coupon.service;
+
+import coupon.domain.Coupon;
+import coupon.domain.CouponRepository;
+import coupon.service.support.DataSourceSupport;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final DataSourceSupport dataSourceSupport;
+
+    @Transactional
+    public long create(Coupon coupon) {
+        couponRepository.save(coupon);
+        return coupon.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseGet(() -> findFromWriter(couponId));
+    }
+
+    private Coupon findFromWriter(long couponId) {
+        return dataSourceSupport.executeOnWriter(
+                () -> couponRepository.findById(couponId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다. couponId: " + couponId))
+        );
+    }
+}

--- a/src/main/java/coupon/service/support/DataSourceSupport.java
+++ b/src/main/java/coupon/service/support/DataSourceSupport.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DataSourceSupport {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public <T> T executeOnWriter(Supplier<T> supplier) {
+    public <T> T executeWithNewTransaction(Supplier<T> supplier) {
         return supplier.get();
     }
 }

--- a/src/main/java/coupon/service/support/DataSourceSupport.java
+++ b/src/main/java/coupon/service/support/DataSourceSupport.java
@@ -1,0 +1,15 @@
+package coupon.service.support;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DataSourceSupport {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public <T> T executeOnWriter(Supplier<T> supplier) {
+        return supplier.get();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
         hbm2ddl.auto: validate
         check_nullability: true

--- a/src/test/java/coupon/domain/CouponNameTest.java
+++ b/src/test/java/coupon/domain/CouponNameTest.java
@@ -31,7 +31,7 @@ class CouponNameTest {
     @DisplayName("쿠폰 이름이 30글자를 넘으면 예외를 발생시킨다.")
     @Test
     void throwsWhenTooLong() {
-        String name = "jazz".repeat(10);
+        String name = "j".repeat(31);
 
         assertThatThrownBy(() -> new CouponName(name))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/coupon/domain/CouponNameTest.java
+++ b/src/test/java/coupon/domain/CouponNameTest.java
@@ -1,0 +1,40 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class CouponNameTest {
+
+    @DisplayName("쿠폰 이름이 정상 생성된다.")
+    @Test
+    void createCouponNameSuccessfully() {
+        String name = "jazz coupon";
+
+        assertThatNoException()
+                .isThrownBy(() -> new CouponName(name));
+    }
+
+    @DisplayName("쿠폰 이름이 존재하지 않으면 예외를 발생시킨다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void throwsWhenNullAndEmpty(String name) {
+        assertThatThrownBy(() -> new CouponName(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 이름은 반드시 존재해야 합니다.");
+    }
+
+    @DisplayName("쿠폰 이름이 30글자를 넘으면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenTooLong() {
+        String name = "jazz".repeat(10);
+
+        assertThatThrownBy(() -> new CouponName(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 이름 길이는 최대 30자 이하여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/CouponPeriodTest.java
+++ b/src/test/java/coupon/domain/CouponPeriodTest.java
@@ -1,0 +1,41 @@
+package coupon.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CouponPeriodTest {
+
+    @DisplayName("쿠폰 발급 기간이 정상 생성된다.")
+    @Test
+    void createValidityPeriodSuccessfully() {
+        LocalDateTime issueStartedAt = LocalDateTime.now();
+        LocalDateTime issueEndedAt = issueStartedAt.plusDays(3);
+
+        assertThatNoException()
+                .isThrownBy(() -> new CouponPeriod(issueStartedAt, issueEndedAt));
+    }
+
+    @DisplayName("시작일이 종료일보다 늦으면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenStartDateIsAfterEndDate() {
+        LocalDateTime issueStartedAt = LocalDateTime.of(2024, 10, 16, 0, 0, 0);
+        LocalDateTime issueEndedAt = LocalDateTime.of(2024, 10, 15, 23, 59, 59);
+
+        assertThatThrownBy(() -> new CouponPeriod(issueStartedAt, issueEndedAt))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰의 발급 시작일은 종료일보다 이전이어야 합니다.");
+    }
+
+    @DisplayName("시작일과 종료일이 같으면 정상 생성된다.")
+    @Test
+    void createValidityPeriodWithSameDate() {
+        LocalDateTime sameDate = LocalDateTime.of(2024, 10, 17, 3, 0, 0);
+
+        assertThatNoException()
+                .isThrownBy(() -> new CouponPeriod(sameDate, sameDate));
+    }
+}

--- a/src/test/java/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/domain/CouponTest.java
@@ -1,0 +1,138 @@
+package coupon.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CouponTest {
+
+    @DisplayName("쿠폰이 정상적으로 생성된다.")
+    @Test
+    void createCouponSuccessfully() {
+        String couponName = "NakNak Coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 5000;
+        CouponCategory couponCategory = CouponCategory.FASHION;
+        LocalDateTime issueStartedAt = LocalDateTime.now();
+        LocalDateTime issueEndedAt = issueStartedAt.plusDays(3);
+        long issueLimit = 100;
+        long issueCount = 0;
+
+        assertThatNoException()
+                .isThrownBy(() -> new Coupon(
+                        couponName,
+                        discountAmount, minimumOrderAmount,
+                        couponCategory,
+                        issueStartedAt, issueEndedAt,
+                        issueLimit, issueCount)
+                );
+    }
+
+    @DisplayName("할인율이 3% 미만일 경우 예외를 발생시킨다.")
+    @Test
+    void throwsWhenDiscountRateIsBelowMin() {
+        String couponName = "Kyummi Coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 35000;
+        CouponCategory couponCategory = CouponCategory.FOOD;
+        LocalDateTime issueStartedAt = LocalDateTime.now();
+        LocalDateTime issueEndedAt = issueStartedAt.plusDays(3);
+        long issueLimit = 100;
+        long issueCount = 0;
+
+        assertThatThrownBy(
+                () -> new Coupon(
+                        couponName,
+                        discountAmount, minimumOrderAmount,
+                        couponCategory,
+                        issueStartedAt, issueEndedAt,
+                        issueLimit, issueCount
+                ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인율은 3% 이상 20% 이하여야 합니다.");
+    }
+
+    @DisplayName("할인율이 20% 초과할 경우 예외를 발생시킨다.")
+    @Test
+    void throwsWhenDiscountRateExceedsMax() {
+        String couponName = "ALPACA Coupon";
+        int discountAmount = 3000;
+        int minimumOrderAmount = 10000;
+        CouponCategory couponCategory = CouponCategory.FASHION;
+        LocalDateTime issueStartedAt = LocalDateTime.now();
+        LocalDateTime issueEndedAt = issueStartedAt.plusDays(3);
+        long issueLimit = 100;
+        long issueCount = 0;
+
+        assertThatThrownBy(
+                () -> new Coupon(
+                        couponName,
+                        discountAmount, minimumOrderAmount,
+                        couponCategory,
+                        issueStartedAt, issueEndedAt,
+                        issueLimit, issueCount
+                ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인율은 3% 이상 20% 이하여야 합니다.");
+    }
+
+    @DisplayName("쿠폰 발급이 정상적으로 이루어진다.")
+    @Test
+    void issueCouponSuccessfully() {
+        CouponName couponName = new CouponName("Jazz Coupon");
+        DiscountAmount discountAmount = new DiscountAmount(1000);
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount(5000);
+        CouponCategory couponCategory = CouponCategory.FASHION;
+        CouponPeriod couponPeriod = new CouponPeriod(LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
+        long issueLimit = 100;
+        long issueCount = 0;
+
+        Coupon coupon = new Coupon(couponName, discountAmount, minimumOrderAmount, couponCategory, couponPeriod,
+                issueLimit, issueCount);
+
+        assertThatNoException()
+                .isThrownBy(coupon::issue);
+    }
+
+    @DisplayName("쿠폰 발급이 불가능한 시간일 경우 예외를 발생시킨다.")
+    @Test
+    void throwsWhenCouponIsNotIssuable() {
+        CouponName couponName = new CouponName("Expired Coupon");
+        DiscountAmount discountAmount = new DiscountAmount(1000);
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount(5000);
+        CouponCategory couponCategory = CouponCategory.FOOD;
+        CouponPeriod couponPeriod = new CouponPeriod(LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().minusDays(1));
+        long issueLimit = 100;
+        long issueCount = 90;
+
+        Coupon coupon = new Coupon(couponName, discountAmount, minimumOrderAmount, couponCategory, couponPeriod,
+                issueLimit, issueCount);
+
+        assertThatThrownBy(coupon::issue)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰을 발급할 수 없는 시간입니다.");
+    }
+
+    @DisplayName("발급 한도를 초과하면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenIssueCountExceedsLimit() {
+        CouponName couponName = new CouponName("Limited Coupon");
+        DiscountAmount discountAmount = new DiscountAmount(1000);
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount(5000);
+        CouponCategory couponCategory = CouponCategory.FOOD;
+        CouponPeriod couponPeriod = new CouponPeriod(LocalDateTime.now().minusDays(1), LocalDateTime.now().plusDays(1));
+        long issueLimit = 100;
+        long issueCount = 100;
+
+        Coupon coupon = new Coupon(couponName, discountAmount, minimumOrderAmount, couponCategory, couponPeriod,
+                issueLimit, issueCount);
+
+        assertThatThrownBy(coupon::issue)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰을 더 이상 발급할 수 없습니다.");
+    }
+}

--- a/src/test/java/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/domain/DiscountAmountTest.java
@@ -1,0 +1,49 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscountAmountTest {
+
+    @DisplayName("할인 금액이 정상 생성된다.")
+    @Test
+    void createDiscountAmountSuccessfully() {
+        int validAmount = 1000;
+
+        assertThatNoException()
+                .isThrownBy(() -> new DiscountAmount(validAmount));
+    }
+
+    @DisplayName("할인 금액이 1,000원 미만이면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenAmountLessThanMin() {
+        int amount = 999;
+
+        assertThatThrownBy(() -> new DiscountAmount(amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 1000원 이상이어야 합니다.");
+    }
+
+    @DisplayName("할인 금액이 10,000원 초과하면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenAmountGraterThanMax() {
+        int amount = 10001;
+
+        assertThatThrownBy(() -> new DiscountAmount(amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 10000원 이하여야 합니다.");
+    }
+
+    @DisplayName("할인 금액이 500원 단위가 아니면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenAmountNotMultipleOfUnit() {
+        int amount = 1100;
+
+        assertThatThrownBy(() -> new DiscountAmount(amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 500원 단위로만 설정할 수 있습니다.");
+    }
+}

--- a/src/test/java/coupon/domain/MinimumOrderAmountTest.java
+++ b/src/test/java/coupon/domain/MinimumOrderAmountTest.java
@@ -1,0 +1,39 @@
+package coupon.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MinimumOrderAmountTest {
+
+    @DisplayName("최소 주문 금액이 정상 생성된다.")
+    @Test
+    void createMinimumOrderAmountSuccessfully() {
+        int validAmount = 5000;
+
+        assertThatNoException()
+                .isThrownBy(() -> new MinimumOrderAmount(validAmount));
+    }
+
+    @DisplayName("최소 주문 금액이 5,000원 미만이면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenAmountLessThanMin() {
+        int amount = 4999;
+
+        assertThatThrownBy(() -> new MinimumOrderAmount(amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 주문 금액은 5000원 이상이어야 합니다.");
+    }
+
+    @DisplayName("최소 주문 금액이 100,000원 초과하면 예외를 발생시킨다.")
+    @Test
+    void throwsWhenAmountGreaterThanMax() {
+        int amount = 100001;
+
+        assertThatThrownBy(() -> new MinimumOrderAmount(amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 주문 금액은 100000원 이하여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,35 @@
+package coupon.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import coupon.domain.Coupon;
+import coupon.domain.CouponCategory;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @DisplayName("복제 지연 테스트")
+    @Test
+    void replicationDelayTest() {
+        Coupon coupon = new Coupon(
+                "Jazz",
+                1000, 10000,
+                CouponCategory.FOOD,
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                100, 0);
+
+        couponService.create(coupon);
+        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+        assertThat(savedCoupon).isNotNull();
+    }
+}


### PR DESCRIPTION
안녕하세요 켬미! 처음 인사드리는 것 같네요 😀
같은 팀 배키한테 물어보니 소문난 실력자시라고 칭찬이 자자하더라구요 많이 배워가겠습니다. 👍

이번 미션은 Source-Replica DB 간 발생하는 복제 지연에 대해 어떻게 대처할 수 있을지 생각해보는 미션이었어요.
결론을 먼저 말씀드리면 Replica를 조회했을 때 미스 발생 시 Source에서 데이터를 한 번 더 조회하는 방식으로 문제를 해결했습니다.

`쿠폰이 존재하지 않는다.` 는 사용자 경험상 부적절하다고 판단했고, 조회 시도를 했을 때 어떻게든 복제 지연을 해결하여 데이터를 반환해야 한다고 판단했습니다. 지연이 얼마나 발생할지는 네트워크 혼잡도와 현재 데이터베이스 상황에 따라 다르므로, 복제 지연 시간과 사용자의 쿠폰 발급->조회 행동 사이의 시간 차이를 예상할 수 없다고 생각했습니다. 그래서 시간을 예측해서 요청을 대기시키거나 하는 방법은 선택하지 않았습니다.

가장 먼저 생각한 해결 방법은 `Source를 한 번 더 조회`하는 방법과 `MySQL의 반동기 복제 방식을 사용`하는 방법 인데요. 반동기 복제 방식은 최소 한 개의 Replica에 복제 트랜잭션을 전송을 보장해주는 방식이므로 현재처럼 Source-Replica가 1대1로 구성된 환경에서도 의미가 있습니다. 하지만 복제 트랜잭션 처리시간이 길어진다는 것과 확장성을 고려했을 때 좋은 해결 방법은 아니라 생각했습니다.

추가로 새로운 `Redis` 기술 스택을 도입할 수도 있는데요, 현재 해결해야 하는 문제 상황과 가장 간단하게 해결할 수 있는 방법을 고민해 봤을 때 오버 엔지니어링이라고 생각했습니다. 빠르게 데이터를 읽어와야 하는 상황이나 트래픽이 몰려 Source DB에 부하가 증가할 경우 Redis를 사용하는 방법도 의미있는 선택지가 될 것 같습니다.

원하실 때 편하게 리뷰 주세요!
감사합니다.