### PR TITLE
[1단계 - DB 복제와 캐시] 미아(이종미) 미션 제출합니다.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         ipv4_address: 172.20.0.10
     volumes:
       - ./data/writer:/var/lib/mysql
+      - ./init/schema.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_writer
     restart: always
     environment:
@@ -30,6 +31,7 @@ services:
         ipv4_address: 172.20.0.11
     volumes:
       - ./data/reader:/var/lib/mysql
+      - ./init/schema.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_reader
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -1,0 +1,41 @@
+CREATE DATABASE IF NOT EXISTS coupon;
+USE coupon;
+
+CREATE TABLE IF NOT EXISTS coupon
+(
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name                VARCHAR(30) NOT NULL,
+    discount_amount     INT         NOT NULL,
+    minimum_order_price INT         NOT NULL,
+    category            VARCHAR(20) NOT NULL,
+    issue_started_at    DATETIME(6) NOT NULL,
+    issue_ended_at      DATETIME(6) NOT NULL,
+    created_at          DATETIME(6) NOT NULL,
+    updated_at          DATETIME(6) NOT NULL
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS member
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name       VARCHAR(255) NOT NULL,
+    created_at DATETIME(6)  NOT NULL,
+    updated_at DATETIME(6)  NOT NULL
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE IF NOT EXISTS member_coupon
+(
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    coupon_id    BIGINT  NOT NULL,
+    member_id    BIGINT  NOT NULL,
+    used         BOOLEAN NOT NULL,
+    issued_at    DATETIME(6),
+    use_ended_at DATETIME(6),
+    CONSTRAINT fk_member_coupon_coupon_id FOREIGN KEY (coupon_id) REFERENCES coupon (id),
+    CONSTRAINT fk_member_coupon_member_id FOREIGN KEY (member_id) REFERENCES member (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/docker/reader/docker-entrypoint.sh
+++ b/docker/reader/docker-entrypoint.sh
@@ -2,7 +2,13 @@
 set -e
 
 echo "Waiting for master to be ready..."
-sleep 30
+
+while ! mysqladmin ping -h 172.20.0.10 --silent; do
+    echo "Waiting for MySQL master to be ready..."
+    sleep 2
+done
+
+echo "MySQL master is ready!"
 
 ## get log file and position
 master_log_file=$(mysql -uroot -p'root' -h 172.20.0.10 -S /var/run/mysqld/mysqld.sock -e "SHOW MASTER STATUS\G" | grep 'File:' | awk '{print $2}')

--- a/src/main/java/coupon/config/DataSourceKey.java
+++ b/src/main/java/coupon/config/DataSourceKey.java
@@ -1,0 +1,7 @@
+package coupon.config;
+
+public enum DataSourceKey {
+    READER,
+    WRITER,
+    ;
+}

--- a/src/main/java/coupon/config/DataSourceRouter.java
+++ b/src/main/java/coupon/config/DataSourceRouter.java
@@ -1,0 +1,16 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class DataSourceRouter extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isTransactionReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        if (isTransactionReadOnly) {
+            return DataSourceKey.READER;
+        }
+        return DataSourceKey.WRITER;
+    }
+}

--- a/src/main/java/coupon/config/DatasourceConfig.java
+++ b/src/main/java/coupon/config/DatasourceConfig.java
@@ -1,0 +1,52 @@
+package coupon.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class DatasourceConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    public DataSource dataSourceRouter() {
+        DataSourceRouter dataSourceRouter = new DataSourceRouter();
+
+        Map<Object, Object> dataSources = new HashMap<>();
+        dataSources.put(DataSourceKey.WRITER, writerDataSource());
+        dataSources.put(DataSourceKey.READER, readerDataSource());
+
+        dataSourceRouter.setTargetDataSources(dataSources);
+        dataSourceRouter.setDefaultTargetDataSource(writerDataSource());
+
+        return dataSourceRouter;
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource() {
+        return new LazyConnectionDataSourceProxy(dataSourceRouter());
+    }
+}

--- a/src/main/java/coupon/config/JpaAuditingConfig.java
+++ b/src/main/java/coupon/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package coupon.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/coupon/config/TransactionManagerConfig.java
+++ b/src/main/java/coupon/config/TransactionManagerConfig.java
@@ -1,0 +1,18 @@
+package coupon.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class TransactionManagerConfig {
+
+    @Bean
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory);
+        return jpaTransactionManager;
+    }
+}

--- a/src/main/java/coupon/domain/BaseTime.java
+++ b/src/main/java/coupon/domain/BaseTime.java
@@ -13,10 +13,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseTime {
 
     @CreatedDate
-    @Column(updatable = false, nullable = false)
+    @Column(name = "created_at", updatable = false, nullable = false, columnDefinition = "datetime(6)")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(nullable = false)
+    @Column(name = "updated_at", nullable = false, columnDefinition = "datetime(6)")
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/coupon/domain/BaseTime.java
+++ b/src/main/java/coupon/domain/BaseTime.java
@@ -1,0 +1,22 @@
+package coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/coupon/domain/Category.java
+++ b/src/main/java/coupon/domain/Category.java
@@ -1,0 +1,9 @@
+package coupon.domain;
+
+public enum Category {
+    FASHION,
+    ELECTRONICS,
+    FURNITURE,
+    FOOD,
+    ;
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,0 +1,106 @@
+package coupon.domain;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseTime {
+
+    private static final int NAME_MAX_LENGTH = 30;
+    private static final int DISCOUNT_AMOUNT_UNIT = 500;
+    private static final int DISCOUNT_AMOUNT_MINIMUM = 1_000;
+    private static final int DISCOUNT_AMOUNT_MAXIMUM = 10_000;
+    private static final int MINIMUM_ORDER_PRICE_MINIMUM = 5_000;
+    private static final int MINIMUM_ORDER_PRICE_MAXIMUM = 100_000;
+    private static final int DISCOUNT_RATE_MINIMUM = 3;
+    private static final int DISCOUNT_RATE_MAXIMUM = 20;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "discount_amount", nullable = false)
+    private int discountAmount;
+
+    @Column(name = "minimum_order_price", nullable = false)
+    private int minimumOrderPrice;
+
+    @Column(name = "category", columnDefinition = "varchar(20)")
+    @Enumerated(value = EnumType.STRING)
+    private Category category;
+
+    @Column(name = "issue_started_at", columnDefinition = "DATETIME(6)")
+    private LocalDateTime issueStartedAt;
+
+    @Column(name = "issue_ended_at", columnDefinition = "DATETIME(6)")
+    private LocalDateTime issueEndedAt;
+
+    public Coupon(String name, int discountAmount, int minimumOrderPrice, Category category,
+                  LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {
+        validateName(name);
+        validateDiscountAmount(discountAmount);
+        validateMinimumOrderPrice(minimumOrderPrice);
+        validateDiscountRate(discountAmount, minimumOrderPrice);
+        validateIssuePeriod(issueStartedAt, issueEndedAt);
+        this.name = name;
+        this.discountAmount = discountAmount;
+        this.minimumOrderPrice = minimumOrderPrice;
+        this.category = category;
+        this.issueStartedAt = issueStartedAt;
+        this.issueEndedAt = issueEndedAt;
+    }
+
+    private void validateName(String name) {
+        if (name == null || name.isBlank() || name.length() > NAME_MAX_LENGTH) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_COUPON_NAME);
+        }
+    }
+
+    private void validateDiscountAmount(int discountAmount) {
+        if (discountAmount % DISCOUNT_AMOUNT_UNIT != 0) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_UNIT);
+        }
+
+        if (discountAmount < DISCOUNT_AMOUNT_MINIMUM || discountAmount > DISCOUNT_AMOUNT_MAXIMUM) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_RANGE);
+        }
+    }
+
+    private void validateMinimumOrderPrice(int minimumOrderPrice) {
+        if (minimumOrderPrice < MINIMUM_ORDER_PRICE_MINIMUM || minimumOrderPrice > MINIMUM_ORDER_PRICE_MAXIMUM) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_MINIMUM_ORDER_PRICE_RANGE);
+        }
+    }
+
+    private void validateDiscountRate(int discountAmount, int minimumOrderPrice) {
+        int discountRate = discountAmount * 100 / minimumOrderPrice;
+        if (discountRate < DISCOUNT_RATE_MINIMUM || discountRate > DISCOUNT_RATE_MAXIMUM) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_DISCOUNT_RATE_RANGE);
+        }
+    }
+
+    private void validateIssuePeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {
+        if (issueStartedAt.isAfter(issueEndedAt)) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_ISSUE_PERIOD);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -44,14 +44,14 @@ public class Coupon extends BaseTime {
     @Column(name = "minimum_order_price", nullable = false)
     private int minimumOrderPrice;
 
-    @Column(name = "category", columnDefinition = "varchar(20)")
+    @Column(name = "category", nullable = false, columnDefinition = "varchar(20)")
     @Enumerated(value = EnumType.STRING)
     private Category category;
 
-    @Column(name = "issue_started_at", columnDefinition = "DATETIME(6)")
+    @Column(name = "issue_started_at", nullable = false, columnDefinition = "datetime(6)")
     private LocalDateTime issueStartedAt;
 
-    @Column(name = "issue_ended_at", columnDefinition = "DATETIME(6)")
+    @Column(name = "issue_ended_at", nullable = false, columnDefinition = "datetime(6)")
     private LocalDateTime issueEndedAt;
 
     public Coupon(String name, int discountAmount, int minimumOrderPrice, Category category,

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -1,0 +1,30 @@
+package coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    public Member(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,0 +1,62 @@
+package coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "member_coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCoupon {
+
+    private static final int COUPON_USABLE_DAYS = 7;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @JoinColumn(name = "coupon_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Coupon coupon;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(name = "used", nullable = false, columnDefinition = "boolean")
+    private boolean used;
+
+    @Column(name = "issued_at", columnDefinition = "datetime(6)")
+    private LocalDateTime issuedAt;
+
+    @Column(name = "use_ended_at", columnDefinition = "datetime(6)")
+    private LocalDateTime useEndedAt;
+
+    public MemberCoupon(Coupon coupon, Member member, boolean used) {
+        LocalDateTime now = LocalDateTime.now();
+        this.coupon = coupon;
+        this.member = member;
+        this.used = used;
+        this.issuedAt = now;
+        this.useEndedAt = now.plusDays(COUPON_USABLE_DAYS);
+    }
+
+    public boolean isAvailable(LocalDateTime time) {
+        LocalDate endDate = useEndedAt.toLocalDate();
+        LocalDate otherDate = time.toLocalDate();
+        return endDate.isBefore(otherDate) || endDate.equals(otherDate);
+    }
+}

--- a/src/main/java/coupon/domain/vo/DiscountAmount.java
+++ b/src/main/java/coupon/domain/vo/DiscountAmount.java
@@ -1,0 +1,41 @@
+package coupon.domain.vo;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class DiscountAmount {
+
+    private static final int UNIT = 500;
+    private static final int MINIMUM_VALUE = 1_000;
+    private static final int MAXIMUM_VALUE = 10_000;
+
+    @Column(name = "discount_amount", nullable = false)
+    private int value;
+
+    public DiscountAmount(int value) {
+        validateValue(value);
+        this.value = value;
+    }
+
+    private void validateValue(int discountAmount) {
+        if (discountAmount % UNIT != 0) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_UNIT);
+        }
+
+        if (discountAmount < MINIMUM_VALUE || discountAmount > MAXIMUM_VALUE) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_RANGE);
+        }
+    }
+
+    public int calculateDiscountRate(int orderPrice) {
+        return value * 100 / orderPrice;
+    }
+}

--- a/src/main/java/coupon/domain/vo/IssuePeriod.java
+++ b/src/main/java/coupon/domain/vo/IssuePeriod.java
@@ -1,0 +1,34 @@
+package coupon.domain.vo;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class IssuePeriod {
+
+    @Column(name = "issue_started_at", nullable = false, columnDefinition = "datetime(6)")
+    private LocalDateTime issueStartedAt;
+
+    @Column(name = "issue_ended_at", nullable = false, columnDefinition = "datetime(6)")
+    private LocalDateTime issueEndedAt;
+
+    public IssuePeriod(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {
+        validate(issueStartedAt, issueEndedAt);
+        this.issueStartedAt = issueStartedAt;
+        this.issueEndedAt = issueEndedAt;
+    }
+
+    private void validate(LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {
+        if (issueStartedAt.isAfter(issueEndedAt)) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_ISSUE_PERIOD);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/vo/MinimumOrderPrice.java
+++ b/src/main/java/coupon/domain/vo/MinimumOrderPrice.java
@@ -1,0 +1,32 @@
+package coupon.domain.vo;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class MinimumOrderPrice {
+
+    private static final int MINIMUM_VALUE = 5_000;
+    private static final int MAXIMUM_VALUE = 100_000;
+
+    @Column(name = "minimum_order_price", nullable = false)
+    private int value;
+
+    public MinimumOrderPrice(int value) {
+        validateValue(value);
+        this.value = value;
+    }
+
+    private void validateValue(int minimumOrderPrice) {
+        if (minimumOrderPrice < MINIMUM_VALUE || minimumOrderPrice > MAXIMUM_VALUE) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_MINIMUM_ORDER_PRICE_RANGE);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/vo/Name.java
+++ b/src/main/java/coupon/domain/vo/Name.java
@@ -1,0 +1,31 @@
+package coupon.domain.vo;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Name {
+
+    private static final int MAX_LENGTH = 30;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String value;
+
+    public Name(String value) {
+        validateValue(value);
+        this.value = value;
+    }
+
+    private void validateValue(String name) {
+        if (name == null || name.isBlank() || name.length() > MAX_LENGTH) {
+            throw new GlobalCustomException(ErrorMessage.INVALID_COUPON_NAME);
+        }
+    }
+}

--- a/src/main/java/coupon/exception/ErrorMessage.java
+++ b/src/main/java/coupon/exception/ErrorMessage.java
@@ -14,6 +14,8 @@ public enum ErrorMessage {
     INVALID_MINIMUM_ORDER_PRICE_RANGE("쿠폰의 최소 주문 금액은 5,000원 이상 100,000원 이하입니다.", HttpStatus.BAD_REQUEST),
     INVALID_DISCOUNT_RATE_RANGE("쿠폰의 할인율은 3% 이상 20% 이하입니다.", HttpStatus.BAD_REQUEST),
     INVALID_ISSUE_PERIOD("쿠폰 발급 시작일은 종료일 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
+
+    COUPON_NOT_FOUND("쿠폰이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String message;

--- a/src/main/java/coupon/exception/ErrorMessage.java
+++ b/src/main/java/coupon/exception/ErrorMessage.java
@@ -1,0 +1,21 @@
+package coupon.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorMessage {
+
+    INVALID_COUPON_NAME("쿠폰 이름은 30자 이하입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_COUPON_DISCOUNT_AMOUNT_UNIT("쿠폰 할인금액은 500원 단위입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_COUPON_DISCOUNT_AMOUNT_RANGE("쿠폰 할인금액은 1,000원 이상 10,000원 이하입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_MINIMUM_ORDER_PRICE_RANGE("쿠폰의 최소 주문 금액은 5,000원 이상 100,000원 이하입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_DISCOUNT_RATE_RANGE("쿠폰의 할인율은 3% 이상 20% 이하입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_ISSUE_PERIOD("쿠폰 발급 시작일은 종료일 이전이어야 합니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/coupon/exception/GlobalCustomException.java
+++ b/src/main/java/coupon/exception/GlobalCustomException.java
@@ -1,0 +1,18 @@
+package coupon.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GlobalCustomException extends RuntimeException {
+    private final ErrorMessage errorMessage;
+
+    public GlobalCustomException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorMessage.getHttpStatus();
+    }
+}

--- a/src/main/java/coupon/exception/GlobalExceptionHandler.java
+++ b/src/main/java/coupon/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package coupon.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(GlobalCustomException.class)
+    public ResponseEntity<ProblemDetail> handleGlobalCustomException(GlobalCustomException e) {
+        HttpStatus httpStatus = e.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(ProblemDetail.forStatusAndDetail(httpStatus, e.getMessage()));
+    }
+}

--- a/src/main/java/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+import coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+import coupon.domain.MemberCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+}

--- a/src/main/java/coupon/repository/MemberRepository.java
+++ b/src/main/java/coupon/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+import coupon.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,33 @@
+package coupon.service;
+
+import coupon.domain.Coupon;
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import coupon.repository.CouponRepository;
+import coupon.util.WriterDbReader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final WriterDbReader writerDbReader;
+
+    @Transactional
+    public void create(Coupon coupon) {
+        couponRepository.save(coupon);
+    }
+
+    public Coupon getCoupon(Long id) {
+        return couponRepository.findById(id)
+                .orElseGet(() -> getCouponWithWriterDb(id));
+    }
+
+    private Coupon getCouponWithWriterDb(Long id) {
+        return writerDbReader.read(() -> couponRepository.findById(id))
+                .orElseThrow(() -> new GlobalCustomException(ErrorMessage.COUPON_NOT_FOUND));
+    }
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -23,6 +23,11 @@ public class CouponService {
 
     public Coupon getCoupon(Long id) {
         return couponRepository.findById(id)
+                .orElseThrow(() -> new GlobalCustomException(ErrorMessage.COUPON_NOT_FOUND));
+    }
+
+    public Coupon getCouponInReplicationLag(Long id) {
+        return couponRepository.findById(id)
                 .orElseGet(() -> getCouponWithWriterDb(id));
     }
 

--- a/src/main/java/coupon/util/WriterDbReader.java
+++ b/src/main/java/coupon/util/WriterDbReader.java
@@ -1,0 +1,14 @@
+package coupon.util;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class WriterDbReader {
+
+    @Transactional
+    public <T> T read(Supplier<T> supplier) {
+        return supplier.get();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
         hbm2ddl.auto: validate
         check_nullability: true

--- a/src/test/java/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/domain/CouponTest.java
@@ -1,0 +1,87 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CouponTest {
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "30자가 넘는 유효하지 않은 쿠폰 이름 예시입니다!!!!"})
+    @DisplayName("쿠폰 이름은 30자 이하다.")
+    void validateName(String invalidName) {
+        assertThatThrownBy(
+                () -> new Coupon(invalidName, 1000, 5_000, Category.FASHION, LocalDateTime.now(), LocalDateTime.now()))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_COUPON_NAME.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1_020, 9_877})
+    @DisplayName("쿠폰 할인금액은 500원 단위다.")
+    void validateDiscountAmountUnit(int invalidDiscountAmount) {
+        assertThatThrownBy(
+                () -> new Coupon("쿠폰이름", invalidDiscountAmount, 5_000, Category.FASHION, LocalDateTime.now(),
+                        LocalDateTime.now()))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_UNIT.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 10_500})
+    @DisplayName("쿠폰 할인금액은 1,000원 이상 10,000원 이하다.")
+    void validateDiscountAmountRange(int invalidDiscountAmount) {
+        assertThatThrownBy(
+                () -> new Coupon("쿠폰이름", invalidDiscountAmount, 5_000, Category.FASHION, LocalDateTime.now(),
+                        LocalDateTime.now()))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_RANGE.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 110_000})
+    @DisplayName("쿠폰의 최소 주문 금액은 5,000원 이상 100,000원 이하다.")
+    void validateMinimumOrderPrice(int invalidMinimumOrderPrice) {
+        assertThatThrownBy(
+                () -> new Coupon("쿠폰이름", 1_000, invalidMinimumOrderPrice, Category.FASHION, LocalDateTime.now(),
+                        LocalDateTime.now()))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_MINIMUM_ORDER_PRICE_RANGE.getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "2500, 5000",
+            "1000, 100000"
+    })
+    @DisplayName("쿠폰의 할인율은 3% 이상 20% 이하다.")
+    void validateDiscountRate(int discountAmount, int minimumOrderPrice) {
+        assertThatThrownBy(
+                () -> new Coupon("쿠폰이름", discountAmount, minimumOrderPrice, Category.FASHION, LocalDateTime.now(),
+                        LocalDateTime.now()))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_DISCOUNT_RATE_RANGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 시작일은 종료일 이전이다.")
+    void validateIssuePeriod() {
+        LocalDateTime issueStartedAt = LocalDateTime.now().plusDays(1);
+        LocalDateTime issueEndedAt = LocalDateTime.now();
+
+        assertThatThrownBy(
+                () -> new Coupon("쿠폰이름", 1_000, 30_000, Category.FASHION, issueStartedAt,
+                        issueEndedAt))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_ISSUE_PERIOD.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/domain/CouponTest.java
@@ -2,61 +2,18 @@ package coupon.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import coupon.domain.vo.DiscountAmount;
+import coupon.domain.vo.IssuePeriod;
+import coupon.domain.vo.MinimumOrderPrice;
+import coupon.domain.vo.Name;
 import coupon.exception.ErrorMessage;
 import coupon.exception.GlobalCustomException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class CouponTest {
-
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(strings = {"", " ", "30자가 넘는 유효하지 않은 쿠폰 이름 예시입니다!!!!"})
-    @DisplayName("쿠폰 이름은 30자 이하다.")
-    void validateName(String invalidName) {
-        assertThatThrownBy(
-                () -> new Coupon(invalidName, 1000, 5_000, Category.FASHION, LocalDateTime.now(), LocalDateTime.now()))
-                .isInstanceOf(GlobalCustomException.class)
-                .hasMessage(ErrorMessage.INVALID_COUPON_NAME.getMessage());
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {1_020, 9_877})
-    @DisplayName("쿠폰 할인금액은 500원 단위다.")
-    void validateDiscountAmountUnit(int invalidDiscountAmount) {
-        assertThatThrownBy(
-                () -> new Coupon("쿠폰이름", invalidDiscountAmount, 5_000, Category.FASHION, LocalDateTime.now(),
-                        LocalDateTime.now()))
-                .isInstanceOf(GlobalCustomException.class)
-                .hasMessage(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_UNIT.getMessage());
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {500, 10_500})
-    @DisplayName("쿠폰 할인금액은 1,000원 이상 10,000원 이하다.")
-    void validateDiscountAmountRange(int invalidDiscountAmount) {
-        assertThatThrownBy(
-                () -> new Coupon("쿠폰이름", invalidDiscountAmount, 5_000, Category.FASHION, LocalDateTime.now(),
-                        LocalDateTime.now()))
-                .isInstanceOf(GlobalCustomException.class)
-                .hasMessage(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_RANGE.getMessage());
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {500, 110_000})
-    @DisplayName("쿠폰의 최소 주문 금액은 5,000원 이상 100,000원 이하다.")
-    void validateMinimumOrderPrice(int invalidMinimumOrderPrice) {
-        assertThatThrownBy(
-                () -> new Coupon("쿠폰이름", 1_000, invalidMinimumOrderPrice, Category.FASHION, LocalDateTime.now(),
-                        LocalDateTime.now()))
-                .isInstanceOf(GlobalCustomException.class)
-                .hasMessage(ErrorMessage.INVALID_MINIMUM_ORDER_PRICE_RANGE.getMessage());
-    }
 
     @ParameterizedTest
     @CsvSource({
@@ -64,24 +21,15 @@ class CouponTest {
             "1000, 100000"
     })
     @DisplayName("쿠폰의 할인율은 3% 이상 20% 이하다.")
-    void validateDiscountRate(int discountAmount, int minimumOrderPrice) {
+    void validateDiscountRate(int invalidDiscountAmount, int invalidMinimumOrderPrice) {
+        Name name = new Name("쿠폰이름");
+        DiscountAmount discountAmount = new DiscountAmount(invalidDiscountAmount);
+        MinimumOrderPrice minimumOrderPrice = new MinimumOrderPrice(invalidMinimumOrderPrice);
+        IssuePeriod issuePeriod = new IssuePeriod(LocalDateTime.now(), LocalDateTime.now());
+
         assertThatThrownBy(
-                () -> new Coupon("쿠폰이름", discountAmount, minimumOrderPrice, Category.FASHION, LocalDateTime.now(),
-                        LocalDateTime.now()))
+                () -> new Coupon(name, discountAmount, minimumOrderPrice, Category.FASHION, issuePeriod))
                 .isInstanceOf(GlobalCustomException.class)
                 .hasMessage(ErrorMessage.INVALID_DISCOUNT_RATE_RANGE.getMessage());
-    }
-
-    @Test
-    @DisplayName("쿠폰 발급 시작일은 종료일 이전이다.")
-    void validateIssuePeriod() {
-        LocalDateTime issueStartedAt = LocalDateTime.now().plusDays(1);
-        LocalDateTime issueEndedAt = LocalDateTime.now();
-
-        assertThatThrownBy(
-                () -> new Coupon("쿠폰이름", 1_000, 30_000, Category.FASHION, issueStartedAt,
-                        issueEndedAt))
-                .isInstanceOf(GlobalCustomException.class)
-                .hasMessage(ErrorMessage.INVALID_ISSUE_PERIOD.getMessage());
     }
 }

--- a/src/test/java/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/MemberCouponTest.java
@@ -1,0 +1,33 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberCouponTest {
+
+    private Coupon coupon;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        this.coupon = new Coupon("쿠폰이름", 1_000, 30_000, Category.FASHION, LocalDateTime.now(),
+                LocalDateTime.now());
+        this.member = new Member("미아");
+    }
+
+    @Test
+    @DisplayName("회원에게 발급된 쿠폰은 발급일 포함 7일 동안 사용 가능하다.")
+    void createUseEndedAt() {
+        MemberCoupon memberCoupon = new MemberCoupon(coupon, member, false);
+        LocalDateTime useTime = LocalDateTime.now().plusDays(7);
+
+        boolean isAvailable = memberCoupon.isAvailable(useTime);
+
+        assertThat(isAvailable).isTrue();
+    }
+
+}

--- a/src/test/java/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/MemberCouponTest.java
@@ -2,6 +2,10 @@ package coupon.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import coupon.domain.vo.DiscountAmount;
+import coupon.domain.vo.IssuePeriod;
+import coupon.domain.vo.MinimumOrderPrice;
+import coupon.domain.vo.Name;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,8 +18,12 @@ class MemberCouponTest {
 
     @BeforeEach
     void setUp() {
-        this.coupon = new Coupon("쿠폰이름", 1_000, 30_000, Category.FASHION, LocalDateTime.now(),
-                LocalDateTime.now());
+        Name name = new Name("쿠폰이름");
+        DiscountAmount discountAmount = new DiscountAmount(1_000);
+        MinimumOrderPrice minimumOrderPrice = new MinimumOrderPrice(30_000);
+        IssuePeriod issuePeriod = new IssuePeriod(LocalDateTime.now(), LocalDateTime.now());
+
+        this.coupon = new Coupon(name, discountAmount, minimumOrderPrice, Category.FASHION, issuePeriod);
         this.member = new Member("미아");
     }
 

--- a/src/test/java/coupon/domain/vo/DiscountAmountTest.java
+++ b/src/test/java/coupon/domain/vo/DiscountAmountTest.java
@@ -1,0 +1,30 @@
+package coupon.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiscountAmountTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {1_020, 9_877})
+    @DisplayName("쿠폰 할인금액은 500원 단위다.")
+    void validateDiscountAmountUnit(int invalidDiscountAmount) {
+        assertThatThrownBy(() -> new DiscountAmount(invalidDiscountAmount))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_UNIT.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 10_500})
+    @DisplayName("쿠폰 할인금액은 1,000원 이상 10,000원 이하다.")
+    void validateDiscountAmountRange(int invalidDiscountAmount) {
+        assertThatThrownBy(() -> new DiscountAmount(invalidDiscountAmount))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_COUPON_DISCOUNT_AMOUNT_RANGE.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/vo/IssuePeriodTest.java
+++ b/src/test/java/coupon/domain/vo/IssuePeriodTest.java
@@ -1,0 +1,23 @@
+package coupon.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class IssuePeriodTest {
+
+    @Test
+    @DisplayName("쿠폰 발급 시작일은 종료일 이전이다.")
+    void validateIssuePeriod() {
+        LocalDateTime issueStartedAt = LocalDateTime.now().plusDays(1);
+        LocalDateTime issueEndedAt = LocalDateTime.now();
+
+        assertThatThrownBy(() -> new IssuePeriod(issueStartedAt, issueEndedAt))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_ISSUE_PERIOD.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/vo/MinimumOrderPriceTest.java
+++ b/src/test/java/coupon/domain/vo/MinimumOrderPriceTest.java
@@ -1,0 +1,21 @@
+package coupon.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MinimumOrderPriceTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 110_000})
+    @DisplayName("쿠폰의 최소 주문 금액은 5,000원 이상 100,000원 이하다.")
+    void validateMinimumOrderPrice(int invalidMinimumOrderPrice) {
+        assertThatThrownBy(() -> new MinimumOrderPrice(invalidMinimumOrderPrice))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_MINIMUM_ORDER_PRICE_RANGE.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/vo/NameTest.java
+++ b/src/test/java/coupon/domain/vo/NameTest.java
@@ -1,0 +1,23 @@
+package coupon.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.ErrorMessage;
+import coupon.exception.GlobalCustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NameTest {
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " ", "30자가 넘는 유효하지 않은 쿠폰 이름 예시입니다!!!!"})
+    @DisplayName("쿠폰 이름은 30자 이하다.")
+    void validateName(String invalidName) {
+        assertThatThrownBy(() -> new Name(invalidName))
+                .isInstanceOf(GlobalCustomException.class)
+                .hasMessage(ErrorMessage.INVALID_COUPON_NAME.getMessage());
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,30 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.domain.Category;
+import coupon.domain.Coupon;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Test
+    @DisplayName("복제 지연으로 쿠폰이 조회되지 않는 현상을 방지한다.")
+    void occurReplicationLag() {
+        Coupon coupon = new Coupon("쿠폰이름", 1_000, 30_000, Category.FASHION, LocalDateTime.now(),
+                LocalDateTime.now());
+
+        couponService.create(coupon);
+        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+
+        assertThat(savedCoupon).isNotNull();
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -23,7 +23,7 @@ class CouponServiceTest {
                 LocalDateTime.now());
 
         couponService.create(coupon);
-        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+        Coupon savedCoupon = couponService.getCouponInReplicationLag(coupon.getId());
 
         assertThat(savedCoupon).isNotNull();
     }

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import coupon.domain.Category;
 import coupon.domain.Coupon;
+import coupon.domain.vo.DiscountAmount;
+import coupon.domain.vo.IssuePeriod;
+import coupon.domain.vo.MinimumOrderPrice;
+import coupon.domain.vo.Name;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,8 +23,12 @@ class CouponServiceTest {
     @Test
     @DisplayName("복제 지연으로 쿠폰이 조회되지 않는 현상을 방지한다.")
     void occurReplicationLag() {
-        Coupon coupon = new Coupon("쿠폰이름", 1_000, 30_000, Category.FASHION, LocalDateTime.now(),
-                LocalDateTime.now());
+        Name name = new Name("쿠폰이름");
+        DiscountAmount discountAmount = new DiscountAmount(1_000);
+        MinimumOrderPrice minimumOrderPrice = new MinimumOrderPrice(30_000);
+        IssuePeriod issuePeriod = new IssuePeriod(LocalDateTime.now(), LocalDateTime.now());
+
+        Coupon coupon = new Coupon(name, discountAmount, minimumOrderPrice, Category.FASHION, issuePeriod);
 
         couponService.create(coupon);
         Coupon savedCoupon = couponService.getCouponInReplicationLag(coupon.getId());


### PR DESCRIPTION
안녕하세요 짱수!! 미션에서 처음 만나네요 ☺️ 반갑습니다!

저는 복제 지연 문제를 **reader db에서 데이터가 존재하지 않는다면 writer db에서 데이터를 조회하도록** 했습니다. 쿠폰을 생성하고 조회하는 행위는 쿠폰 생성자 뿐만 아니라 다른 관리자들이 존재한다면 충분히 일어날 수 있는 일이라고 생각합니다. 쿠폰 서비스의 확장성을 고려한다면 부하 분산과 가용성을 위해 도입한 replica set을 유지하면서 어떻게 해결할 수 있는지 고민했어요!

바쁠텐데 여유있게 리뷰 주세요 🙇🏻‍♀️ 잘부탁드립니다!