### PR TITLE
[1단계 - DB 복제와 캐시] 위브(김기범) 미션 제출합니다.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,10 +12,12 @@ services:
         ipv4_address: 172.20.0.10
     volumes:
       - ./data/writer:/var/lib/mysql
+      - ./init:/docker-entrypoint-initdb.d
     container_name: mysql_writer
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root
+      LANG: C.UTF-8
       TZ: Asia/Seoul
 
   mysql_reader:
@@ -30,9 +32,11 @@ services:
         ipv4_address: 172.20.0.11
     volumes:
       - ./data/reader:/var/lib/mysql
+      - ./init:/docker-entrypoint-initdb.d
     container_name: mysql_reader
     environment:
       MYSQL_ROOT_PASSWORD: root
+      LANG: C.UTF-8
       TZ: Asia/Seoul
     depends_on:
       - mysql_writer

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ./data/writer:/var/lib/mysql
       - ./init:/docker-entrypoint-initdb.d
+      - ./writer:/docker-entrypoint
     container_name: mysql_writer
     restart: always
     environment:
@@ -33,6 +34,7 @@ services:
     volumes:
       - ./data/reader:/var/lib/mysql
       - ./init:/docker-entrypoint-initdb.d
+      - ./reader:/docker-entrypoint
     container_name: mysql_reader
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -1,0 +1,33 @@
+CREATE DATABASE IF NOT EXISTS coupon;
+USE coupon;
+
+CREATE TABLE IF NOT EXISTS member
+(
+    id   BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS coupon
+(
+    id                   BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name                 VARCHAR(255) NOT NULL,
+    discount_amount      VARCHAR(255) NOT NULL,
+    minimum_order_amount VARCHAR(255) NOT NULL,
+    discount_rate        BIGINT       NOT NULL,
+    category             VARCHAR(15)  NOT NULL,
+    start_at             DATETIME     NOT NULL,
+    end_at               DATETIME     NOT NULL
+) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS member_coupon
+(
+    id         BIGINT   NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    coupon_id  BIGINT   NOT NULL,
+    member_id  BIGINT   NOT NULL,
+    isUsed     BOOLEAN  NOT NULL,
+    issued_at  DATETIME NOT NULL,
+    expired_at DATETIME NOT NULL,
+
+    FOREIGN KEY (coupon_id) REFERENCES coupon (id) ON DELETE CASCADE,
+    FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE
+) ENGINE = InnoDB;

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -1,0 +1,65 @@
+package coupon.config;
+
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+public class DataSourceConfig {
+
+    private static final String WRITER_DATA_SOURCE_BEAN_NAME = "writerDataSource";
+    private static final String READER_DATA_SOURCE_BEAN_NAME = "readerDataSource";
+    private static final String WRITER_DATA_SOURCE_PREFIX = "coupon.datasource.writer";
+    private static final String READER_DATA_SOURCE_PREFIX = "coupon.datasource.reader";
+    private static final String ROUTING_DATA_SOURCE = "routingDataSource";
+
+    @Primary
+    @Bean(name = WRITER_DATA_SOURCE_BEAN_NAME)
+    @ConfigurationProperties(prefix = WRITER_DATA_SOURCE_PREFIX)
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(name = READER_DATA_SOURCE_BEAN_NAME)
+    @ConfigurationProperties(prefix = READER_DATA_SOURCE_PREFIX)
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean(name = ROUTING_DATA_SOURCE)
+    public DataSource routingDataSource(
+            @Qualifier(WRITER_DATA_SOURCE_BEAN_NAME) DataSource writerDataSourceType,
+            @Qualifier(READER_DATA_SOURCE_BEAN_NAME) DataSource readerDataSourceType
+    ) {
+
+        ReplicationRoutingDataSource routingDataSource = new ReplicationRoutingDataSource();
+
+        Map<Object, Object> dataSources = new HashMap<>();
+
+        dataSources.put(DataSourceType.WRITER, writerDataSourceType);
+        dataSources.put(DataSourceType.READER, readerDataSourceType);
+
+        routingDataSource.setTargetDataSources(dataSources);
+        routingDataSource.setDefaultTargetDataSource(writerDataSourceType);
+
+        return routingDataSource;
+    }
+
+    @Bean(name = "dataSource")
+    public DataSource dataSource(@Qualifier(ROUTING_DATA_SOURCE) DataSource routingDataSourceType) {
+        return new LazyConnectionDataSourceProxy(routingDataSourceType);
+    }
+}

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -22,7 +22,6 @@ public class DataSourceConfig {
     private static final String READER_DATA_SOURCE_PREFIX = "coupon.datasource.reader";
     private static final String ROUTING_DATA_SOURCE = "routingDataSource";
 
-    @Primary
     @Bean(name = WRITER_DATA_SOURCE_BEAN_NAME)
     @ConfigurationProperties(prefix = WRITER_DATA_SOURCE_PREFIX)
     public DataSource writerDataSource() {
@@ -58,6 +57,7 @@ public class DataSourceConfig {
         return routingDataSource;
     }
 
+    @Primary
     @Bean(name = "dataSource")
     public DataSource dataSource(@Qualifier(ROUTING_DATA_SOURCE) DataSource routingDataSourceType) {
         return new LazyConnectionDataSourceProxy(routingDataSourceType);

--- a/src/main/java/coupon/config/DataSourceType.java
+++ b/src/main/java/coupon/config/DataSourceType.java
@@ -1,0 +1,7 @@
+package coupon.config;
+
+public enum DataSourceType {
+
+    WRITER, READER
+
+}

--- a/src/main/java/coupon/config/ReplicationRoutingDataSource.java
+++ b/src/main/java/coupon/config/ReplicationRoutingDataSource.java
@@ -1,0 +1,18 @@
+package coupon.config;
+
+import static coupon.config.DataSourceType.READER;
+import static coupon.config.DataSourceType.WRITER;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return READER;
+        }
+        return WRITER;
+    }
+}

--- a/src/main/java/coupon/domain/Category.java
+++ b/src/main/java/coupon/domain/Category.java
@@ -1,0 +1,9 @@
+package coupon.domain;
+
+public enum Category {
+
+    FASHION,
+    ELECTRONICS,
+    FURNITURE,
+    FOOD,
+}

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -1,0 +1,65 @@
+package coupon.domain.coupon;
+
+import coupon.domain.Category;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/*
+*회원에게 발급하는 쿠폰의 이름, 할인 금액, 최소 주문 금액 등 쿠폰의 설정에 해당하는 내용을 관리한다. 다음과 같은 제약사항을 갖는다.
+발급 기간
+시작일은 종료일보다 이전이어야 한다. 시작일과 종료일이 같다면, 해당 일에만 발급할 수 있는 쿠폰이 된다.
+시작일 00:00:00.000000 부터 발급할 수 있다.
+종료일 23:59:59.999999 까지 발급할 수 있다.
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private CouponName couponName;
+
+    @Embedded
+    private DiscountAmount discountAmount;
+
+    @Embedded
+    private MinimumOrderAmount minimumOrderAmount;
+
+    @Embedded
+    private DiscountRate discountRate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private IssueDuration issueDuration;
+
+    public Coupon(
+            CouponName couponName,
+            DiscountAmount discountAmount,
+            MinimumOrderAmount minimumOrderAmount,
+            Category category,
+            IssueDuration issueDuration
+    ) {
+        this.couponName = couponName;
+        this.discountAmount = discountAmount;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.discountRate = new DiscountRate(discountAmount, minimumOrderAmount);
+        this.category = category;
+        this.issueDuration = issueDuration;
+    }
+}

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -9,11 +9,13 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "coupon")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Coupon {
@@ -38,7 +40,7 @@ public class Coupon {
     @Column(nullable = false)
     private Category category;
 
-    @Column(nullable = false)
+    @Embedded
     private IssueDuration issueDuration;
 
     public Coupon(

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -13,13 +13,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/*
-*회원에게 발급하는 쿠폰의 이름, 할인 금액, 최소 주문 금액 등 쿠폰의 설정에 해당하는 내용을 관리한다. 다음과 같은 제약사항을 갖는다.
-발급 기간
-시작일은 종료일보다 이전이어야 한다. 시작일과 종료일이 같다면, 해당 일에만 발급할 수 있는 쿠폰이 된다.
-시작일 00:00:00.000000 부터 발급할 수 있다.
-종료일 23:59:59.999999 까지 발급할 수 있다.
- */
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -1,0 +1,32 @@
+package coupon.domain.coupon;
+
+import coupon.exception.CouponException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CouponName {
+
+    private static final int COUPON_NAME_MAX_LENGTH = 30;
+
+    @Column(name = "name", nullable = false)
+    private String value;
+
+
+    public CouponName(String name) {
+        validate(name);
+        this.value = name;
+    }
+
+    private void validate(String name) {
+        if (Strings.isBlank(name) || name.length() > COUPON_NAME_MAX_LENGTH) {
+            throw new CouponException("쿠폰 이름은 30글자 이하로 반드시 존재 해야합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/DiscountAmount.java
+++ b/src/main/java/coupon/domain/coupon/DiscountAmount.java
@@ -1,0 +1,47 @@
+package coupon.domain.coupon;
+
+import coupon.exception.CouponException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiscountAmount {
+
+    private static final BigDecimal MIN_VALUE = new BigDecimal("1000");
+    private static final BigDecimal MAX_VALUE = new BigDecimal("30000");
+    private static final BigDecimal UNIT = new BigDecimal("500");
+
+    @Column(name = "discount_amount", nullable = false)
+    private BigDecimal value;
+
+    public DiscountAmount(String discountAmount) {
+        this.value = new BigDecimal(discountAmount);
+        validateRange();
+        validateValueDivisibleByUnit();
+    }
+
+    private void validateRange() {
+        if (value.compareTo(MIN_VALUE) < 0 || value.compareTo(MAX_VALUE) > 0) {
+            throw new CouponException(String.format(
+                    "할인금액은 %s원 이상 %s원 미만입니다.",
+                    MIN_VALUE.toPlainString(),
+                    MAX_VALUE.toPlainString())
+            );
+        }
+    }
+
+    private void validateValueDivisibleByUnit() {
+        if (value.remainder(UNIT).compareTo(BigDecimal.ZERO) != 0) {
+            throw new CouponException(String.format(
+                    "할인금액은 %s원 단위입니다.",
+                    UNIT.toPlainString()
+            ));
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/DiscountRate.java
+++ b/src/main/java/coupon/domain/coupon/DiscountRate.java
@@ -1,0 +1,48 @@
+package coupon.domain.coupon;
+
+import coupon.exception.CouponException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiscountRate {
+
+    private static final int MINIMUM_DISCOUNT_RATE = 3;
+    private static final int MAXIMUM_DISCOUNT_RATE = 20;
+
+    @Column(name = "discount_rate", nullable = false)
+    private int value;
+
+    public DiscountRate(DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount) {
+        int discountRate = calculateDiscountRate(discountAmount, minimumOrderAmount);
+        validateRange(discountRate);
+        this.value = discountRate;
+    }
+
+    private int calculateDiscountRate(DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount) {
+        BigDecimal discountAmountValue = discountAmount.getValue();
+        BigDecimal minimumOrderAmountValue = minimumOrderAmount.getValue();
+
+        BigDecimal discountRate = discountAmountValue.divide(minimumOrderAmountValue, 3, RoundingMode.DOWN)
+                .multiply(BigDecimal.valueOf(100));
+
+        return discountRate.toBigInteger().intValue();
+    }
+
+    private void validateRange(int discountRate) {
+        if (discountRate < MINIMUM_DISCOUNT_RATE || discountRate > MAXIMUM_DISCOUNT_RATE) {
+            throw new CouponException(String.format(
+                    "할인율은 %d%% 이상 %d%% 이하 입니다.",
+                    MINIMUM_DISCOUNT_RATE,
+                    MAXIMUM_DISCOUNT_RATE
+            ));
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/IssueDuration.java
+++ b/src/main/java/coupon/domain/coupon/IssueDuration.java
@@ -13,10 +13,10 @@ import lombok.NoArgsConstructor;
 @Getter
 public class IssueDuration {
 
-    @Column(nullable = false)
+    @Column(name = "start_at", nullable = false)
     private LocalDateTime startAt;
 
-    @Column(nullable = false)
+    @Column(name = "end_at", nullable = false)
     private LocalDateTime endAt;
 
     public IssueDuration(LocalDateTime startAt, LocalDateTime endAt) {

--- a/src/main/java/coupon/domain/coupon/IssueDuration.java
+++ b/src/main/java/coupon/domain/coupon/IssueDuration.java
@@ -1,0 +1,33 @@
+package coupon.domain.coupon;
+
+import coupon.exception.CouponException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class IssueDuration {
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endAt;
+
+    public IssueDuration(LocalDateTime startAt, LocalDateTime endAt) {
+        validatePeriod(startAt, endAt);
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    private void validatePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+        if (endAt.isBefore(startAt) || endAt.isEqual(startAt)) {
+            throw new CouponException("쿠폰 발급 종료일은 시작일 보다 이후 입니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/coupon/MemberCoupon.java
@@ -1,0 +1,49 @@
+package coupon.domain.coupon;
+
+import coupon.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberCoupon {
+
+    private static final int AVAILABLE_PERIOD_DAYS = 7;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Coupon coupon;
+
+    @ManyToOne(optional = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private boolean isUsed;
+
+    @Column(nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    public MemberCoupon(Coupon coupon, Member member, LocalDateTime issuedAt) {
+        this.coupon = coupon;
+        this.member = member;
+        this.isUsed = false;
+        this.issuedAt = issuedAt;
+        this.expiredAt = issuedAt.plusDays(AVAILABLE_PERIOD_DAYS).truncatedTo(ChronoUnit.DAYS);
+    }
+}

--- a/src/main/java/coupon/domain/coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/coupon/MemberCoupon.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
@@ -14,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "member_coupon")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class MemberCoupon {
@@ -33,10 +35,10 @@ public class MemberCoupon {
     @Column(nullable = false)
     private boolean isUsed;
 
-    @Column(nullable = false)
+    @Column(name = "issued_at", nullable = false)
     private LocalDateTime issuedAt;
 
-    @Column(nullable = false)
+    @Column(name = "expired_at", nullable = false)
     private LocalDateTime expiredAt;
 
     public MemberCoupon(Coupon coupon, Member member, LocalDateTime issuedAt) {

--- a/src/main/java/coupon/domain/coupon/MinimumOrderAmount.java
+++ b/src/main/java/coupon/domain/coupon/MinimumOrderAmount.java
@@ -1,0 +1,37 @@
+package coupon.domain.coupon;
+
+import coupon.exception.CouponException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MinimumOrderAmount {
+
+    private static final BigDecimal MIN_VALUE = new BigDecimal("5000");
+    private static final BigDecimal MAX_VALUE = new BigDecimal("100000");
+
+    @Column(name = "minimum_order_amount", nullable = false)
+    private BigDecimal value;
+
+    public MinimumOrderAmount(String minimumOrderAmount) {
+        this.value = new BigDecimal(minimumOrderAmount);
+        validateRange();
+    }
+
+    private void validateRange() {
+        if (value.compareTo(MIN_VALUE) < 0 || value.compareTo(MAX_VALUE) > 0) {
+            throw new CouponException(String.format(
+                    "최소 주문 금액은 %s 이상 %s 미만입니다.",
+                    MIN_VALUE.toPlainString(),
+                    MAX_VALUE.toPlainString())
+            );
+        }
+    }
+}
+

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -5,11 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -1,0 +1,27 @@
+package coupon.domain.member;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private MemberName memberName;
+
+    public Member(MemberName memberName) {
+        this.memberName = memberName;
+    }
+}

--- a/src/main/java/coupon/domain/member/MemberName.java
+++ b/src/main/java/coupon/domain/member/MemberName.java
@@ -1,0 +1,29 @@
+package coupon.domain.member;
+
+import coupon.exception.CouponException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.Strings;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberName {
+
+    @Column(name = "name", nullable = false)
+    private String value;
+
+    public MemberName(String name) {
+        validate(name);
+        this.value = name;
+    }
+
+    private void validate(String name) {
+        if (Strings.isBlank(name)) {
+            throw new CouponException("회원 이름은 필수입니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/exception/CouponException.java
+++ b/src/main/java/coupon/exception/CouponException.java
@@ -1,0 +1,8 @@
+package coupon.exception;
+
+public class CouponException extends RuntimeException {
+
+    public CouponException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/repository/CouponRepository.java
@@ -1,0 +1,8 @@
+package coupon.repository;
+
+import coupon.domain.coupon.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+    
+}

--- a/src/main/java/coupon/repository/RepositoryMethod.java
+++ b/src/main/java/coupon/repository/RepositoryMethod.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+@FunctionalInterface
+public interface RepositoryMethod<T> {
+
+    T execute();
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,27 @@
+package coupon.service;
+
+import coupon.domain.coupon.Coupon;
+import coupon.repository.CouponRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public CouponService(CouponRepository couponRepository) {
+        this.couponRepository = couponRepository;
+    }
+
+    @Transactional
+    public void create(Coupon coupon) {
+        couponRepository.save(coupon);
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(Long couponId) {
+        return couponRepository.findById(couponId)
+                .orElse(null);
+    }
+}

--- a/src/main/java/coupon/service/RoutingMasterTemplate.java
+++ b/src/main/java/coupon/service/RoutingMasterTemplate.java
@@ -1,0 +1,16 @@
+package coupon.service;
+
+import coupon.repository.RepositoryMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class RoutingMasterTemplate {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public <T> T apply(RepositoryMethod<T> repositoryMethod) {
+        return repositoryMethod.execute();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,12 +10,13 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
+    show-sql: true
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,11 +12,15 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: update
+        hbm2ddl.auto: validate
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
     show-sql: true
+    defer-datasource-initialization: true
+    sql:
+      init:
+        mode: always
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: update
+        hbm2ddl.auto: none
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
@@ -20,7 +20,7 @@ spring:
     defer-datasource-initialization: true
     sql:
       init:
-        mode: always
+        mode: never
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/test/java/coupon/DataSourceRoutingTest.java
+++ b/src/test/java/coupon/DataSourceRoutingTest.java
@@ -1,0 +1,48 @@
+package coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.config.DataSourceType;
+import coupon.config.ReplicationRoutingDataSource;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+public class DataSourceRoutingTest {
+
+    private static final String TEST_METHOD_NAME = "determineCurrentLookupKey";
+
+    @DisplayName("읽기 전용 트랜잭션이 아니면, Writer DB 데이터소스가 바운딩된다.")
+    @Test
+    @Transactional(readOnly = false)
+    void writeOnlyTransactionTest() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        ReplicationRoutingDataSource replicationRoutingDataSource = new ReplicationRoutingDataSource();
+
+        Method determineCurrentLookupKey = ReplicationRoutingDataSource.class.getDeclaredMethod(TEST_METHOD_NAME);
+        determineCurrentLookupKey.setAccessible(true);
+
+        DataSourceType dataSourceType = (DataSourceType) determineCurrentLookupKey
+                .invoke(replicationRoutingDataSource);
+
+        assertThat(dataSourceType).isEqualTo(DataSourceType.WRITER);
+    }
+
+    @Test
+    @DisplayName("읽기전용 트랜잭션이면 reader DB 데이터소스가 바운딩된다.")
+    @Transactional(readOnly = true)
+    void readOnlyTransactionTest() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        ReplicationRoutingDataSource replicationRoutingDataSource = new ReplicationRoutingDataSource();
+
+        Method determineCurrentLookupKey = ReplicationRoutingDataSource.class.getDeclaredMethod(TEST_METHOD_NAME);
+        determineCurrentLookupKey.setAccessible(true);
+
+        DataSourceType dataSourceType = (DataSourceType) determineCurrentLookupKey
+                .invoke(replicationRoutingDataSource);
+
+        assertThat(dataSourceType).isEqualTo(DataSourceType.READER);
+    }
+}

--- a/src/test/java/coupon/domain/coupon/CouponNameTest.java
+++ b/src/test/java/coupon/domain/coupon/CouponNameTest.java
@@ -1,0 +1,30 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CouponNameTest {
+
+    @DisplayName("쿠폰 이름을 생성한다.")
+    @Test
+    void create() {
+        assertThatCode(() -> new CouponName("쿠폰이름"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("쿠폰 이름은 30글자 이하로 반드시 존재해야한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"1234567890123456789012345678901"})
+    void create_Fail(String name) {
+        assertThatThrownBy(() -> new CouponName(name))
+                .isInstanceOf(CouponException.class);
+    }
+}

--- a/src/test/java/coupon/domain/coupon/DiscountAmountTest.java
+++ b/src/test/java/coupon/domain/coupon/DiscountAmountTest.java
@@ -14,15 +14,15 @@ class DiscountAmountTest {
     @DisplayName("할인 금액을 생성한다.")
     @ParameterizedTest
     @ValueSource(strings = {"1000", "10000"})
-    void create() {
-        assertThatCode(() -> new DiscountAmount("10000"))
+    void create(String discountAmount) {
+        assertThatCode(() -> new DiscountAmount(discountAmount))
                 .doesNotThrowAnyException();
     }
 
     @DisplayName("할인 금액이 500원 단위가 아니면 예외가 발생한다.")
     @Test
     void create_Fail1() {
-        assertThatThrownBy(() -> new DiscountAmount("1012"))
+        assertThatThrownBy(() -> new DiscountAmount("501"))
                 .isInstanceOf(CouponException.class);
     }
 

--- a/src/test/java/coupon/domain/coupon/DiscountAmountTest.java
+++ b/src/test/java/coupon/domain/coupon/DiscountAmountTest.java
@@ -1,0 +1,36 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiscountAmountTest {
+
+    @DisplayName("할인 금액을 생성한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"1000", "10000"})
+    void create() {
+        assertThatCode(() -> new DiscountAmount("10000"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("할인 금액이 500원 단위가 아니면 예외가 발생한다.")
+    @Test
+    void create_Fail1() {
+        assertThatThrownBy(() -> new DiscountAmount("1012"))
+                .isInstanceOf(CouponException.class);
+    }
+
+    @DisplayName("할인 금액이 천원 미만, 만원 초과면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"999", "10001"})
+    void create_Fail2(String discountAmount) {
+        assertThatThrownBy(() -> new DiscountAmount(discountAmount))
+                .isInstanceOf(CouponException.class);
+    }
+}

--- a/src/test/java/coupon/domain/coupon/DiscountRateTest.java
+++ b/src/test/java/coupon/domain/coupon/DiscountRateTest.java
@@ -13,7 +13,7 @@ class DiscountRateTest {
     @Test
     void create() {
         DiscountAmount discountAmount = new DiscountAmount("1000");
-        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("30000");
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("33333");
 
         assertThatCode(() -> new DiscountRate(discountAmount, minimumOrderAmount))
                 .doesNotThrowAnyException();
@@ -23,7 +23,7 @@ class DiscountRateTest {
     @Test
     void create_Fail1() {
         DiscountAmount discountAmount = new DiscountAmount("1000");
-        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("40000");
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("33334");
 
         assertThatThrownBy(() -> new DiscountRate(discountAmount, minimumOrderAmount))
                 .isInstanceOf(CouponException.class);
@@ -32,8 +32,9 @@ class DiscountRateTest {
     @DisplayName("할인율이 20% 초과이면 예외가 발생한다.")
     @Test
     void create_Fail2() {
-        DiscountAmount discountAmount = new DiscountAmount("8000");
-        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("38000");
+        //case - 할인율 21%
+        DiscountAmount discountAmount = new DiscountAmount("10500");
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("50000");
 
         assertThatThrownBy(() -> new DiscountRate(discountAmount, minimumOrderAmount))
                 .isInstanceOf(CouponException.class);

--- a/src/test/java/coupon/domain/coupon/DiscountRateTest.java
+++ b/src/test/java/coupon/domain/coupon/DiscountRateTest.java
@@ -1,0 +1,43 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscountRateTest {
+
+    @DisplayName("할인율을 생성한다.")
+    @Test
+    void create() {
+        DiscountAmount discountAmount = new DiscountAmount("1000");
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("30000");
+
+        assertThatCode(() -> new DiscountRate(discountAmount, minimumOrderAmount))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("할인율이 3% 미만이면 예외가 발생한다.")
+    @Test
+    void create_Fail1() {
+        DiscountAmount discountAmount = new DiscountAmount("1000");
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("40000");
+
+        assertThatThrownBy(() -> new DiscountRate(discountAmount, minimumOrderAmount))
+                .isInstanceOf(CouponException.class);
+    }
+
+    @DisplayName("할인율이 20% 초과이면 예외가 발생한다.")
+    @Test
+    void create_Fail2() {
+        DiscountAmount discountAmount = new DiscountAmount("8000");
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount("38000");
+
+        assertThatThrownBy(() -> new DiscountRate(discountAmount, minimumOrderAmount))
+                .isInstanceOf(CouponException.class);
+    }
+
+
+}

--- a/src/test/java/coupon/domain/coupon/IssueDurationTest.java
+++ b/src/test/java/coupon/domain/coupon/IssueDurationTest.java
@@ -1,0 +1,29 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.exception.CouponException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class IssueDurationTest {
+
+    @DisplayName("발급 기간을 생성한다.")
+    @Test
+    void create() {
+        assertThatCode(() -> new IssueDuration(
+                LocalDateTime.of(2024, 1, 1, 1, 0, 0),
+                LocalDateTime.of(2024, 1, 1, 1, 0, 1)))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("종료일이 시작일 보다 이후가 아니면 예외가 발생한다.")
+    @Test
+    void create_Fail() {
+        assertThatCode(() -> new IssueDuration(
+                LocalDateTime.of(2024, 1, 1, 1, 0, 0),
+                LocalDateTime.of(2024, 1, 1, 1, 0, 0)))
+                .isInstanceOf(CouponException.class);
+    }
+}

--- a/src/test/java/coupon/domain/coupon/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/coupon/MemberCouponTest.java
@@ -1,0 +1,59 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.domain.Category;
+import coupon.domain.member.Member;
+import coupon.domain.member.MemberName;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberCouponTest {
+
+    private Coupon coupon;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        coupon = new Coupon(
+                new CouponName("쿠폰1"),
+                new DiscountAmount("1000"),
+                new MinimumOrderAmount("30000"),
+                Category.ELECTRONICS,
+                new IssueDuration(LocalDateTime.of(2024, 10, 1, 0, 0, 0), LocalDateTime.of(2024, 10, 31, 0, 0, 0))
+        );
+
+        member = new Member(new MemberName("wiib"));
+    }
+
+    @DisplayName("회원 쿠폰 생성한다.")
+    @Test
+    void create() {
+        assertThatCode(() -> new MemberCoupon(coupon, member, LocalDateTime.of(2024, 10, 10, 0, 0, 0)))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("회원 쿠폰 만료일자는 발급 일자를 포함한 7일 후 이다.")
+    @Test
+    void checkExpiredAt() {
+        LocalDateTime issuedAt = LocalDateTime.of(2024, 10, 10, 12, 0, 0);
+        MemberCoupon memberCoupon = new MemberCoupon(coupon, member, issuedAt);
+
+        LocalDateTime actual = memberCoupon.getExpiredAt();
+        LocalDateTime expected = LocalDateTime.of(2024, 10, 17, 0, 0, 0);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @DisplayName("처음 생성된 회원 쿠폰은 아직 미사용이다.")
+    @Test
+    void checkIsUsed() {
+        LocalDateTime issuedAt = LocalDateTime.of(2024, 10, 10, 12, 0, 0);
+        MemberCoupon memberCoupon = new MemberCoupon(coupon, member, issuedAt);
+
+        assertThat(memberCoupon.isUsed()).isFalse();
+    }
+}

--- a/src/test/java/coupon/domain/coupon/MinimumOrderAmountTest.java
+++ b/src/test/java/coupon/domain/coupon/MinimumOrderAmountTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class MinimumOrderAmountTest {
 
-    @DisplayName("할인 금액을 생성한다.")
+    @DisplayName("최소 주문 금액을 생성한다.")
     @ParameterizedTest
     @ValueSource(strings = {"5000", "100000"})
-    void create() {
-        assertThatCode(() -> new MinimumOrderAmount("5000"))
+    void create(String minimumOrderAmount) {
+        assertThatCode(() -> new MinimumOrderAmount(minimumOrderAmount))
                 .doesNotThrowAnyException();
     }
 

--- a/src/test/java/coupon/domain/coupon/MinimumOrderAmountTest.java
+++ b/src/test/java/coupon/domain/coupon/MinimumOrderAmountTest.java
@@ -1,0 +1,29 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MinimumOrderAmountTest {
+
+    @DisplayName("할인 금액을 생성한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"5000", "100000"})
+    void create() {
+        assertThatCode(() -> new MinimumOrderAmount("5000"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("최소 주문 금액이 5000원 미만, 100,000원 초과면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"4999", "100001"})
+    void create_Fail2(String minimumOrderAmount) {
+        assertThatThrownBy(() -> new MinimumOrderAmount(minimumOrderAmount))
+                .isInstanceOf(CouponException.class);
+    }
+
+}

--- a/src/test/java/coupon/domain/member/MemberNameTest.java
+++ b/src/test/java/coupon/domain/member/MemberNameTest.java
@@ -1,0 +1,27 @@
+package coupon.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class MemberNameTest {
+
+    @DisplayName("회원명을 생성한다.")
+    @Test
+    void create() {
+        assertThatCode(() -> new MemberName("wiib"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("회원명이 비어있으면 예외가 발생한다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void create_Fail(String name) {
+        assertThatCode(() -> new MemberName(name))
+                .isInstanceOf(CouponException.class);
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,38 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.domain.Category;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.CouponName;
+import coupon.domain.coupon.DiscountAmount;
+import coupon.domain.coupon.IssueDuration;
+import coupon.domain.coupon.MinimumOrderAmount;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @DisplayName("복제지연 테스트")
+    @Test
+    void replicationLag() {
+        Coupon coupon = new Coupon(
+                new CouponName("쿠폰1"),
+                new DiscountAmount("1000"),
+                new MinimumOrderAmount("30000"),
+                Category.ELECTRONICS,
+                new IssueDuration(LocalDateTime.of(2024, 10, 1, 0, 0, 0), LocalDateTime.of(2024, 10, 31, 0, 0, 0))
+        );
+        couponService.create(coupon);
+        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+
+        assertThat(savedCoupon).isNotNull();
+    }
+}


### PR DESCRIPTION
안녕하세요 로빈 
마지막 미션 리뷰 잘 부탁드립니다.

제가 선택한 방식은 
Reader 조회 -> lag로 조회x -> writer 조회 -> 조회가 안되면 예외

replica의 장점 일부와 가용성을 포기하는 방식이지만, 데이터 정합성이 중요한 조회 작업에서 사용할만한 방식이라고 생각해서 위 방식을 택했습니다.

제가 생각한 후보군은 다음과 같아요.

1. 반동기 및 동기로 복제
복제 방식을 반동기 및 동기로 하게 된다면, 저장 트랜잭션의 connection 점유가 길어질 것 같아요.
다만, 데이터 정합성을 맞추기 위한 가장 좋은 방법이라고도 생각해요. 이 방식은 코드 레벨에서의 해결이 아니라서 일단은 제외했어요.
2. 데이터 정합성이 중요한 조회는 무조건 Writer에서 조회
쿠폰 도메인을 잠깐 내려놓고 생각하면, 특정 비즈니스에 따라서는 데이터 정합성이 매우 중요한 조회작업이 있을 것 같아요.
이러한 조회작업에 한해서 무조건 writerDB에서 조회하도록 한다면 복제 지연으로 인한 데이터 조회 실패를 해결할 수 있을 것 같아요. 다만 복제의 장점인 조회작업과 쓰기작업의 분산은 큰 폭으로 포기해야 될 것 같아요.
만약 위를 구현한다면 spring의 AOP를 활용할 것 같아요.  
현재는 조회 작업이 하나라서, 결국은 모든 작업을 writerDB에서 작업하는 형태가 될 것 같아 채택하지 않았습니다.

혹시 제가 잘못 알고 있거나, 의문스러운 부분이 있으면 편하게 코멘트 남겨주세요.

