### PR TITLE
[1단계 - 복제 지연] 카키(서현준) 미션 제출합니다.

### DIFF
--- a/src/main/java/coupon/config/ReplicationDataSourceConfig.java
+++ b/src/main/java/coupon/config/ReplicationDataSourceConfig.java
@@ -1,0 +1,51 @@
+package coupon.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import javax.sql.DataSource;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Slf4j
+@Configuration
+public class ReplicationDataSourceConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writeDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource(DataSource replicationRouteDataSource) {
+        return new LazyConnectionDataSourceProxy(replicationRouteDataSource);
+    }
+
+    @Bean
+    public DataSource replicationRouteDataSource(
+            @Qualifier("writeDataSource") DataSource writeDataSource,
+            @Qualifier("readDataSource") DataSource readDataSource
+    ) {
+        HashMap<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(ReplicationType.WRITE, writeDataSource);
+        dataSourceMap.put(ReplicationType.READ, readDataSource);
+
+        ReplicationDataSourceRouter replicationDataSourceRouter = new ReplicationDataSourceRouter();
+        replicationDataSourceRouter.setTargetDataSources(dataSourceMap);
+        replicationDataSourceRouter.setDefaultTargetDataSource(writeDataSource);
+        return replicationDataSourceRouter;
+    }
+}

--- a/src/main/java/coupon/config/ReplicationDataSourceRouter.java
+++ b/src/main/java/coupon/config/ReplicationDataSourceRouter.java
@@ -1,0 +1,18 @@
+package coupon.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+public class ReplicationDataSourceRouter extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isTransactionActive = TransactionSynchronizationManager.isActualTransactionActive();
+        boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        ReplicationType type = ReplicationType.of(isTransactionActive, readOnly);
+        log.info("(트랜잭션 활성화 여부 : {}) (readOnly : {}) => {} DB 연결", isTransactionActive, readOnly, type);
+        return type;
+    }
+}

--- a/src/main/java/coupon/config/ReplicationDataSourceRouter.java
+++ b/src/main/java/coupon/config/ReplicationDataSourceRouter.java
@@ -11,7 +11,7 @@ public class ReplicationDataSourceRouter extends AbstractRoutingDataSource {
     protected Object determineCurrentLookupKey() {
         boolean isTransactionActive = TransactionSynchronizationManager.isActualTransactionActive();
         boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
-        ReplicationType type = ReplicationType.of(isTransactionActive, readOnly);
+        ReplicationType type = ReplicationType.from(readOnly);
         log.info("(트랜잭션 활성화 여부 : {}) (readOnly : {}) => {} DB 연결", isTransactionActive, readOnly, type);
         return type;
     }

--- a/src/main/java/coupon/config/ReplicationType.java
+++ b/src/main/java/coupon/config/ReplicationType.java
@@ -1,21 +1,22 @@
 package coupon.config;
 
 import java.util.Arrays;
-import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 public enum ReplicationType {
 
-    READ((transactionActive, readOnly) -> transactionActive && readOnly),
-    WRITE((transactionActive, readOnly) -> !transactionActive || !readOnly);
+    READ((readOnly) -> true),
+    WRITE((readOnly) -> false);
 
-    private final BiPredicate<Boolean, Boolean> condition;
+    private final Predicate<Boolean> condition;
 
-    ReplicationType(BiPredicate<Boolean, Boolean> condition) {
+    ReplicationType(Predicate<Boolean> condition) {
         this.condition = condition;
     }
-    public static ReplicationType of(boolean transactionActive, boolean readOnly) {
+
+    public static ReplicationType from(boolean readOnly) {
         return Arrays.stream(values())
-                .filter(replicationType -> replicationType.condition.test(transactionActive, readOnly))
+                .filter(replicationType -> replicationType.condition.test(readOnly))
                 .findAny()
                 .orElseThrow(() -> new IllegalStateException("조건에 맞는 ReplicationType이 존재하지 않습니다."));
     }

--- a/src/main/java/coupon/config/ReplicationType.java
+++ b/src/main/java/coupon/config/ReplicationType.java
@@ -1,0 +1,22 @@
+package coupon.config;
+
+import java.util.Arrays;
+import java.util.function.BiPredicate;
+
+public enum ReplicationType {
+
+    READ((transactionActive, readOnly) -> transactionActive && readOnly),
+    WRITE((transactionActive, readOnly) -> !transactionActive || !readOnly);
+
+    private final BiPredicate<Boolean, Boolean> condition;
+
+    ReplicationType(BiPredicate<Boolean, Boolean> condition) {
+        this.condition = condition;
+    }
+    public static ReplicationType of(boolean transactionActive, boolean readOnly) {
+        return Arrays.stream(values())
+                .filter(replicationType -> replicationType.condition.test(transactionActive, readOnly))
+                .findAny()
+                .orElseThrow(() -> new IllegalStateException("조건에 맞는 ReplicationType이 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/coupon/config/ReplicationType.java
+++ b/src/main/java/coupon/config/ReplicationType.java
@@ -5,8 +5,8 @@ import java.util.function.Predicate;
 
 public enum ReplicationType {
 
-    READ((readOnly) -> true),
-    WRITE((readOnly) -> false);
+    READ((readOnly) -> readOnly),
+    WRITE((readOnly) -> !readOnly);
 
     private final Predicate<Boolean> condition;
 

--- a/src/main/java/coupon/coupon/business/CouponService.java
+++ b/src/main/java/coupon/coupon/business/CouponService.java
@@ -1,0 +1,28 @@
+package coupon.coupon.business;
+
+import coupon.coupon.domain.Coupon;
+import coupon.coupon.persistence.CouponReader;
+import coupon.coupon.persistence.CouponWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponWriter couponWriter;
+    private final CouponReader couponReader;
+    private final TransactionRouter transactionRouter;
+
+    public void create(Coupon coupon) {
+        couponWriter.create(coupon);
+    }
+
+    public Coupon getCoupon(long couponId) {
+        try {
+            return couponReader.getCoupon(couponId);
+        } catch (IllegalArgumentException exception) {
+            return transactionRouter.route(() -> couponReader.getCoupon(couponId));
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/business/CouponService.java
+++ b/src/main/java/coupon/coupon/business/CouponService.java
@@ -4,8 +4,10 @@ import coupon.coupon.domain.Coupon;
 import coupon.coupon.persistence.CouponReader;
 import coupon.coupon.persistence.CouponWriter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CouponService {
@@ -22,6 +24,7 @@ public class CouponService {
         try {
             return couponReader.getCoupon(couponId);
         } catch (IllegalArgumentException exception) {
+            log.error("(읽기 DB 복제 지연 오류 발생 : {}) 쓰기 DB 조회", exception.getMessage());
             return transactionRouter.route(() -> couponReader.getCoupon(couponId));
         }
     }

--- a/src/main/java/coupon/coupon/business/TransactionRouter.java
+++ b/src/main/java/coupon/coupon/business/TransactionRouter.java
@@ -1,0 +1,14 @@
+package coupon.coupon.business;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class TransactionRouter {
+
+    @Transactional
+    public <T> T route(Supplier<T> supplier) {
+        return supplier.get();
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -1,0 +1,39 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Embedded
+    private CouponName name;
+
+    @Embedded
+    private DiscountAmount discountAmount;
+
+    @Embedded
+    private DiscountRate discountRate;
+
+    @Embedded
+    private OrderPrice orderPrice;
+
+    @Enumerated(value = EnumType.STRING)
+    private CouponCategory couponCategory;
+
+    @Embedded
+    private IssuePeriod issuePeriod;
+}

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -1,5 +1,6 @@
 package coupon.coupon.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -34,6 +35,7 @@ public class Coupon {
     @Embedded
     private OrderPrice orderPrice;
 
+    @Column(columnDefinition = "VARCHAR(255)")
     @Enumerated(value = EnumType.STRING)
     private CouponCategory category;
 

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -5,18 +5,21 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Coupon {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Embedded
@@ -32,8 +35,24 @@ public class Coupon {
     private OrderPrice orderPrice;
 
     @Enumerated(value = EnumType.STRING)
-    private CouponCategory couponCategory;
+    private CouponCategory category;
 
     @Embedded
     private IssuePeriod issuePeriod;
+
+    public Coupon(
+            CouponName name,
+            DiscountAmount discountAmount,
+            DiscountRate discountRate,
+            OrderPrice orderPrice,
+            CouponCategory category,
+            IssuePeriod issuePeriod
+    ) {
+        this.name = name;
+        this.discountAmount = discountAmount;
+        this.discountRate = discountRate;
+        this.orderPrice = orderPrice;
+        this.category = category;
+        this.issuePeriod = issuePeriod;
+    }
 }

--- a/src/main/java/coupon/coupon/domain/CouponCategory.java
+++ b/src/main/java/coupon/coupon/domain/CouponCategory.java
@@ -1,0 +1,17 @@
+package coupon.coupon.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CouponCategory {
+
+    FASHION("패션"),
+    HOME_APPLIANCE("가전"),
+    FURNITURE("가구"),
+    FOOD("식품"),
+    ;
+
+    private final String value;
+}

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -1,0 +1,36 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponName {
+
+    public static final int COUPON_NAME_LENGTH = 30;
+
+    @Column(nullable = false, name = "name")
+    private String value;
+
+    public CouponName(String value) {
+        validateNameIsBlank(value);
+        validateNameLength(value);
+        this.value = value;
+    }
+
+    private void validateNameIsBlank(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("쿠폰 이름은 반드시 필요 합니다.");
+        }
+    }
+
+    private void validateNameLength(String value) {
+        if (value.length() > COUPON_NAME_LENGTH) {
+            throw new IllegalArgumentException("쿠폰 이름은 최대 30자 이하이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -16,12 +16,12 @@ public class DiscountAmount {
     public static final int DISCOUNT_AMOUNT_UNIT = 500;
 
     @Column(nullable = false, name = "discount_amount")
-    private int amount;
+    private int value;
 
     public DiscountAmount(int value) {
         validateDiscountAmount(value);
         validateDiscountAmountUnit(value);
-        this.amount = value;
+        this.value = value;
     }
 
     private void validateDiscountAmount(int value) {

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DiscountAmount {
 
-    public static final int MIN_DISCOUNT_AMOUNT = 1000;
-    public static final int MAX_DISCOUNT_AMOUNT = 10000;
+    public static final int MIN_DISCOUNT_AMOUNT = 1_000;
+    public static final int MAX_DISCOUNT_AMOUNT = 10_000;
     public static final int DISCOUNT_AMOUNT_UNIT = 500;
 
     @Column(nullable = false, name = "discount_amount")

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -1,0 +1,39 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiscountAmount {
+
+    public static final int MIN_DISCOUNT_AMOUNT = 1000;
+    public static final int MAX_DISCOUNT_AMOUNT = 10000;
+    public static final int DISCOUNT_AMOUNT_UNIT = 500;
+
+    @Column(nullable = false, name = "discount_amount")
+    private int amount;
+
+    public DiscountAmount(int value) {
+        validateDiscountAmount(value);
+        validateDiscountAmountUnit(value);
+        this.amount = value;
+    }
+
+    private void validateDiscountAmount(int value) {
+        if (value < MIN_DISCOUNT_AMOUNT || value > MAX_DISCOUNT_AMOUNT) {
+            throw new IllegalArgumentException(
+                    String.format("할인 금액은 %d원 이상, %d원 이하이어야 합니다.", MIN_DISCOUNT_AMOUNT, MAX_DISCOUNT_AMOUNT));
+        }
+    }
+
+    private void validateDiscountAmountUnit(int value) {
+        if (value % DISCOUNT_AMOUNT_UNIT != 0) {
+            throw new IllegalArgumentException(String.format("할인 금액은 %d원 단위로 설정할 수 있습니다.", DISCOUNT_AMOUNT_UNIT));
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/domain/DiscountRate.java
+++ b/src/main/java/coupon/coupon/domain/DiscountRate.java
@@ -1,0 +1,37 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiscountRate {
+
+    private static final int MIN_DISCOUNT_RATE = 3;
+    private static final int MAX_DISCOUNT_RATE = 20;
+
+    @Column(nullable = false, name = "discount_rate")
+    private int value;
+
+    public DiscountRate(int discountAmount, int minOrderPrice) {
+        int discountRate = calculateDiscountRate(discountAmount, minOrderPrice);
+        validateDiscountRate(discountRate);
+        this.value = discountRate;
+    }
+
+    private void validateDiscountRate(int discountRate) {
+        if (discountRate < MIN_DISCOUNT_RATE || discountRate > MAX_DISCOUNT_RATE) {
+            throw new IllegalArgumentException(
+                    String.format("할인율은 %d%% 이상, %d%% 이하이어야 합니다.", MIN_DISCOUNT_RATE, MAX_DISCOUNT_RATE)
+            );
+        }
+    }
+
+    private int calculateDiscountRate(int discountAmount, int minOrderPrice) {
+        return (int) (((double) discountAmount / minOrderPrice) * 100);
+    }
+}

--- a/src/main/java/coupon/coupon/domain/IssuePeriod.java
+++ b/src/main/java/coupon/coupon/domain/IssuePeriod.java
@@ -1,0 +1,32 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IssuePeriod {
+
+    @Column(nullable = false, name = "issue_start_at", columnDefinition = "DATETIME(6)")
+    private LocalDateTime startAt;
+
+    @Column(nullable = false, name = "issue_end_at", columnDefinition = "DATETIME(6)")
+    private LocalDateTime endAt;
+
+    public IssuePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+        validateIssuePeriod(startAt, endAt);
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    private void validateIssuePeriod(LocalDateTime startAt, LocalDateTime endAt) {
+        if (startAt.isAfter(endAt)) {
+            throw new IllegalArgumentException("쿠폰 발급 시작일은 종료일보다 이전이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -10,12 +10,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MemberCoupon {
 
     @Id

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -1,0 +1,49 @@
+package coupon.coupon.domain;
+
+import coupon.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    @Column(nullable = false)
+    private boolean used;
+
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    private LocalDateTime issueAt;
+
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    private LocalDateTime expiredAt;
+
+    public MemberCoupon(Member member, Coupon coupon) {
+        this.member = member;
+        this.coupon = coupon;
+        this.used = false;
+        this.issueAt = LocalDateTime.now();
+        this.expiredAt = issueAt.plusDays(7).withHour(23).withMinute(59).withSecond(59).withNano(999999);
+    }
+}

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -46,6 +46,6 @@ public class MemberCoupon {
         this.coupon = coupon;
         this.used = false;
         this.issueAt = LocalDateTime.now();
-        this.expiredAt = issueAt.plusDays(7).withHour(23).withMinute(59).withSecond(59).withNano(999999);
+        this.expiredAt = issueAt.plusDays(7).withHour(23).withMinute(59).withSecond(59).withNano(999999000);
     }
 }

--- a/src/main/java/coupon/coupon/domain/OrderPrice.java
+++ b/src/main/java/coupon/coupon/domain/OrderPrice.java
@@ -1,0 +1,32 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderPrice {
+
+    public static final int MIN_ORDER_PRICE = 5_000;
+    public static final int MAX_ORDER_PRICE = 100_000;
+
+    @Column(nullable = false, name = "order_price")
+    private int value;
+
+    public OrderPrice(int value) {
+        validateMinOrderPrice(value);
+        this.value = value;
+    }
+
+    private void validateMinOrderPrice(int value) {
+        if (value < MIN_ORDER_PRICE || value > MAX_ORDER_PRICE) {
+            throw new IllegalArgumentException(
+                    String.format("최소 주문 금액은 %d원 이상, %d원 이하이어야 합니다.", MIN_ORDER_PRICE, MAX_ORDER_PRICE)
+            );
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/persistence/CouponReader.java
+++ b/src/main/java/coupon/coupon/persistence/CouponReader.java
@@ -1,0 +1,21 @@
+package coupon.coupon.persistence;
+
+import coupon.coupon.domain.Coupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CouponReader {
+
+    private final CouponRepository couponRepository;
+
+    public Coupon getCoupon(long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(() ->
+                        new IllegalArgumentException(String.format("%d와 일치하는 쿠폰이 존재하지 않습니다.", couponId))
+                );
+    }
+}

--- a/src/main/java/coupon/coupon/persistence/CouponRepository.java
+++ b/src/main/java/coupon/coupon/persistence/CouponRepository.java
@@ -1,0 +1,8 @@
+package coupon.coupon.persistence;
+
+import coupon.coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+}

--- a/src/main/java/coupon/coupon/persistence/CouponWriter.java
+++ b/src/main/java/coupon/coupon/persistence/CouponWriter.java
@@ -1,0 +1,18 @@
+package coupon.coupon.persistence;
+
+import coupon.coupon.domain.Coupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class CouponWriter {
+
+    private final CouponRepository couponRepository;
+
+    public void create(Coupon coupon) {
+        couponRepository.save(coupon);
+    }
+}

--- a/src/main/java/coupon/member/domain/Member.java
+++ b/src/main/java/coupon/member/domain/Member.java
@@ -1,0 +1,25 @@
+package coupon.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,14 +21,14 @@ coupon.datasource:
   writer:
     type: com.zaxxer.hikari.HikariDataSource
     driverClassName: com.mysql.cj.jdbc.Driver
-    jdbcUrl: jdbc:mysql://localhost:33306/coupon?characterEncoding=UTF-8&serverTimezone=UTC
+    jdbcUrl: jdbc:mysql://localhost:33306/coupon?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: root
     maximumPoolSize: 10
   reader:
     type: com.zaxxer.hikari.HikariDataSource
     driverClassName: com.mysql.cj.jdbc.Driver
-    jdbcUrl: jdbc:mysql://localhost:33307/coupon?characterEncoding=UTF-8&serverTimezone=UTC
+    jdbcUrl: jdbc:mysql://localhost:33307/coupon?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: root
     maximumPoolSize: 10

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     hibernate:
       naming:
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE coupon;
+CREATE DATABASE IF NOT EXISTS coupon;
 USE coupon;
 
 CREATE TABLE IF NOT EXISTS member
@@ -11,10 +11,10 @@ CREATE TABLE IF NOT EXISTS coupon
 (
     id              BIGINT AUTO_INCREMENT PRIMARY KEY,
     name            VARCHAR(255) NOT NULL,
-    discount_amount INT,
-    discount_rate   INT,
-    order_price     INT          NOT NULL,
-    category VARCHAR(255)  NOT NULL,
+    discount_amount INT NOT NULL,
+    discount_rate   INT NOT NULL,
+    order_price     INT NOT NULL,
+    category VARCHAR(255) NOT NULL,
     issue_start_at  DATETIME(6) NOT NULL,
     issue_end_at    DATETIME(6) NOT NULL,
     CHECK (category IN ('FASHION', 'HOME_APPLIANCE', 'FURNITURE', 'FOOD'))
@@ -23,8 +23,8 @@ CREATE TABLE IF NOT EXISTS coupon
 CREATE TABLE IF NOT EXISTS member_coupon
 (
     id         BIGINT AUTO_INCREMENT PRIMARY KEY,
-    member_id  BIGINT,
-    coupon_id  BIGINT,
+    member_id  BIGINT NOT NULL,
+    coupon_id  BIGINT NOT NULL,
     used       BOOLEAN NOT NULL,
     issue_at   DATETIME(6) NOT NULL,
     expired_at DATETIME(6) NOT NULL,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,33 @@
+CREATE DATABASE coupon;
+USE coupon;
+
+CREATE TABLE IF NOT EXISTS member
+(
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS coupon
+(
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name            VARCHAR(255) NOT NULL,
+    discount_amount INT,
+    discount_rate   INT,
+    order_price     INT          NOT NULL,
+    category VARCHAR(255)  NOT NULL,
+    issue_start_at  DATETIME(6) NOT NULL,
+    issue_end_at    DATETIME(6) NOT NULL,
+    CHECK (category IN ('FASHION', 'HOME_APPLIANCE', 'FURNITURE', 'FOOD'))
+);
+
+CREATE TABLE IF NOT EXISTS member_coupon
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT,
+    coupon_id  BIGINT,
+    used       BOOLEAN NOT NULL,
+    issue_at   DATETIME(6) NOT NULL,
+    expired_at DATETIME(6) NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES member (id),
+    FOREIGN KEY (coupon_id) REFERENCES coupon (id)
+);

--- a/src/test/java/coupon/coupon/common/Fixture.java
+++ b/src/test/java/coupon/coupon/common/Fixture.java
@@ -1,0 +1,34 @@
+package coupon.coupon.common;
+
+import coupon.coupon.domain.Coupon;
+import coupon.coupon.domain.CouponCategory;
+import coupon.coupon.domain.CouponName;
+import coupon.coupon.domain.DiscountAmount;
+import coupon.coupon.domain.DiscountRate;
+import coupon.coupon.domain.IssuePeriod;
+import coupon.coupon.domain.OrderPrice;
+
+public class Fixture {
+
+    public static final CouponName BIG_SALE_COUPON_NAME = new CouponName("초대박 할인");
+    public static final DiscountAmount DISCOUNT_AMOUNT_2000 = new DiscountAmount(2000);
+    public static final OrderPrice ORDER_PRICE_10000 = new OrderPrice(10000);
+    public static final DiscountRate DISCOUNT_RATE_20 = new DiscountRate(
+            DISCOUNT_AMOUNT_2000.getAmount(),
+            ORDER_PRICE_10000.getValue()
+    );
+
+    private Fixture() {
+    }
+
+    public static Coupon generateBigSaleFashionCoupon(IssuePeriod issuePeriod) {
+        return new Coupon(
+                BIG_SALE_COUPON_NAME,
+                DISCOUNT_AMOUNT_2000,
+                DISCOUNT_RATE_20,
+                ORDER_PRICE_10000,
+                CouponCategory.FASHION,
+                issuePeriod
+        );
+    }
+}

--- a/src/test/java/coupon/coupon/common/Fixture.java
+++ b/src/test/java/coupon/coupon/common/Fixture.java
@@ -14,7 +14,7 @@ public class Fixture {
     public static final DiscountAmount DISCOUNT_AMOUNT_2000 = new DiscountAmount(2000);
     public static final OrderPrice ORDER_PRICE_10000 = new OrderPrice(10000);
     public static final DiscountRate DISCOUNT_RATE_20 = new DiscountRate(
-            DISCOUNT_AMOUNT_2000.getAmount(),
+            DISCOUNT_AMOUNT_2000.getValue(),
             ORDER_PRICE_10000.getValue()
     );
 

--- a/src/test/java/coupon/coupon/domain/CouponNameTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponNameTest.java
@@ -1,0 +1,45 @@
+package coupon.coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CouponNameTest {
+
+    @DisplayName("쿠폰 이름이 비어 있으면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void invalidCouponName(String name) {
+        assertThatThrownBy(() -> new CouponName(name))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("쿠폰 이름이 존재하면 예외가 발생하지 않는다.")
+    @Test
+    void validCouponName() {
+        assertThatCode(() -> new CouponName("kaki"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("쿠폰 이름이 정해진 길이 제한을 초과하면 예외가 발생한다.")
+    @Test
+    void invalidCouponNameLength() {
+        String name = "a".repeat(CouponName.COUPON_NAME_LENGTH + 1);
+
+        assertThatThrownBy(() -> new CouponName(name))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("쿠폰 이름이 정해진 길이 제한을 초과하지 않으면 예외가 발생하지 않는다.")
+    @Test
+    void validCouponNameLength() {
+        String name = "a".repeat(CouponName.COUPON_NAME_LENGTH);
+
+        assertThatCode(() -> new CouponName(name))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
@@ -1,0 +1,42 @@
+package coupon.coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiscountAmountTest {
+
+    @DisplayName("할인 금액이 정해진 할인 금액 범위를 벗어나면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {DiscountAmount.MIN_DISCOUNT_AMOUNT - 1, DiscountAmount.MAX_DISCOUNT_AMOUNT + 1})
+    void invalidOrderPrice(int discountAmount) {
+        assertThatThrownBy(() -> new DiscountAmount(discountAmount))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("할인 금액이 정해진 할인 금액 범위를 벗어나지 않으면 예외가 발생하지 않는다.")
+    @ParameterizedTest
+    @ValueSource(ints = {DiscountAmount.MIN_DISCOUNT_AMOUNT, DiscountAmount.MAX_DISCOUNT_AMOUNT})
+    void validOrderPrice(int discountAmount) {
+        assertThatCode(() -> new DiscountAmount(discountAmount))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("할인 금액이 정해진 할인 금액 단위로 나누어지지 않으면 예외가 발생한다.")
+    @Test
+    void invalidDiscountAmountUnit() {
+        assertThatCode(() -> new DiscountAmount((DiscountAmount.DISCOUNT_AMOUNT_UNIT * 2) + 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("할인 금액이 정해진 할인 금액 단위로 나누어지면 예외가 발생하지 않는다.")
+    @Test
+    void validDiscountAmountUnit() {
+        assertThatCode(() -> new DiscountAmount(DiscountAmount.DISCOUNT_AMOUNT_UNIT * 2))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/coupon/coupon/domain/DiscountRateTest.java
+++ b/src/test/java/coupon/coupon/domain/DiscountRateTest.java
@@ -1,0 +1,27 @@
+package coupon.coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class DiscountRateTest {
+
+    @DisplayName("할인율이 3보다 작거나 20보다 크면 예외가 발생한다.")
+    @ParameterizedTest
+    @CsvSource({"200, 10000", "2100, 10000"})
+    void invalidDiscountRate(int discountAmount, int minOrderPrice) { // 할인율 = (할인금액 / 최소주문금액) * 100
+        assertThatThrownBy(() -> new DiscountRate(discountAmount, minOrderPrice))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("할인율이 3이상, 20이하이면 예외가 발생하지 않는다.")
+    @ParameterizedTest
+    @CsvSource({"300, 10000", "2000, 10000"})
+    void validDiscountRate(int discountAmount, int minOrderPrice) { // 할인율 = (할인금액 / 최소주문금액) * 100
+        assertThatCode(() -> new DiscountRate(discountAmount, minOrderPrice))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/coupon/coupon/domain/IssuePeriodTest.java
+++ b/src/test/java/coupon/coupon/domain/IssuePeriodTest.java
@@ -1,0 +1,37 @@
+package coupon.coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class IssuePeriodTest {
+
+    private LocalDateTime startAt;
+
+    @BeforeEach
+    void initDate() {
+        startAt = LocalDateTime.now();
+    }
+
+    @DisplayName("쿠폰 발급 시작일이 종료일보다 이후이면 예외가 발생한다.")
+    @Test
+    void invalidIssuePeriod() {
+        LocalDateTime endAt = startAt.minusDays(1L);
+
+        assertThatThrownBy(() -> new IssuePeriod(startAt, endAt))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("쿠폰 발급 시작일이 종료일보다 이전이면 예외가 발생하지 않는다.")
+    @Test
+    void validIssuePeriod() {
+        LocalDateTime endAt = startAt.plusDays(1L);
+
+        assertThatCode(() -> new IssuePeriod(startAt, endAt))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/coupon/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/coupon/domain/MemberCouponTest.java
@@ -30,6 +30,6 @@ class MemberCouponTest {
         assertThat(expiredAt.getHour()).isEqualTo(23);
         assertThat(expiredAt.getMinute()).isEqualTo(59);
         assertThat(expiredAt.getSecond()).isEqualTo(59);
-        assertThat(expiredAt.getNano()).isEqualTo(999999);
+        assertThat(expiredAt.getNano()).isEqualTo(999999000);
     }
 }

--- a/src/test/java/coupon/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/coupon/domain/MemberCouponTest.java
@@ -1,0 +1,35 @@
+package coupon.coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.member.domain.Member;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class MemberCouponTest {
+
+    @Mock
+    private Member member;
+
+    @Mock
+    private Coupon coupon;
+
+    @Test
+    @DisplayName("만료일은 발급일로부터 7일 후 23:59:59.999999로 설정된다.")
+    void checkExpirationDate() {
+        MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
+
+        LocalDateTime issueAt = memberCoupon.getIssueAt();
+        LocalDateTime expiredAt = memberCoupon.getExpiredAt();
+
+        assertThat(expiredAt).isAfter(issueAt);
+        assertThat(ChronoUnit.DAYS.between(issueAt, expiredAt)).isEqualTo(7);
+        assertThat(expiredAt.getHour()).isEqualTo(23);
+        assertThat(expiredAt.getMinute()).isEqualTo(59);
+        assertThat(expiredAt.getSecond()).isEqualTo(59);
+        assertThat(expiredAt.getNano()).isEqualTo(999999);
+    }
+}

--- a/src/test/java/coupon/coupon/domain/OrderPriceTest.java
+++ b/src/test/java/coupon/coupon/domain/OrderPriceTest.java
@@ -1,0 +1,27 @@
+package coupon.coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OrderPriceTest {
+
+    @DisplayName("주문 금액이 정해진 주문 금액 범위를 벗어나면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {OrderPrice.MIN_ORDER_PRICE - 1, OrderPrice.MAX_ORDER_PRICE + 1})
+    void invalidOrderPrice(int price) {
+        assertThatThrownBy(() -> new OrderPrice(price))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("주문 금액이 정해진 주문 금액 범위를 안이라면 예외가 발생하지 않는다.")
+    @ParameterizedTest
+    @ValueSource(ints = {OrderPrice.MIN_ORDER_PRICE, OrderPrice.MAX_ORDER_PRICE})
+    void validOrderPrice(int price) {
+        assertThatCode(() -> new OrderPrice(price))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/coupon/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/coupon/service/CouponServiceTest.java
@@ -2,6 +2,7 @@ package coupon.coupon.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import coupon.coupon.business.CouponService;
 import coupon.coupon.common.Fixture;
 import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.IssuePeriod;
@@ -9,8 +10,9 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 public class CouponServiceTest {
 
     @Autowired

--- a/src/test/java/coupon/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/coupon/service/CouponServiceTest.java
@@ -1,0 +1,27 @@
+package coupon.coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.coupon.common.Fixture;
+import coupon.coupon.domain.Coupon;
+import coupon.coupon.domain.IssuePeriod;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Test
+    void 복제지연테스트() {
+        IssuePeriod issuePeriod = new IssuePeriod(LocalDateTime.now(), LocalDateTime.now().plusDays(1L));
+        Coupon coupon = Fixture.generateBigSaleFashionCoupon(issuePeriod);
+        couponService.create(coupon);
+        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+        assertThat(savedCoupon).isNotNull();
+    }
+}


### PR DESCRIPTION
안녕하세요 리건 ~ 이렇게 뵙는건 처음이네요 반가워요 ㅎㅎ 😄
복제 지연 문제를 해결하기 위해
read db에 데이터가 존재하지 않으면 write db에서 읽도록 해결을 했는데요
이 부분을 하나의 Service에서 처리를 하게 되면 코드가 복잡해져서
최근에 본 "토스 지속 성장 가능한 코드를 만들어가는 방법" 영상과 같이 읽기 담당 클래스와 쓰기 담당 클리새를 분리하고
이 클래스들을 CouponService에 의존성 주입해 사용하는 방식으로 설계를 해봤어요
잘 부탁드려요 리건 ~ ! 🙇🏼‍♂️🙇🏼‍♂️

### 고려했던 구현 방식들

- 동기 방식
복제 지연 시간이 고정되어 있고 알고 있다는 전제하에 가능한 방식이라 생각했고
쿠폰 생성 응답 시간도 늦어진다는 점을 고려해 적용하지 않았어요

- 인 메모리 DB 사용
현재 같이 실행되고 있는 redis를 사용하는 방식도 생각해봤지만
조회 성능 개선 목적이 아닌 복제 지연을 해결하기 위한 방법으로는 적합하지 않다고 생각했습니다

- 현재 방식
현재로써는 위 문제점이 없는
read DB에서 조회 시 데이터가 없으면 wrtie db에서 읽어 오는 방식이 가장 적합하다고 생각했어요
이로 인해 발생할 수 있는 문제는 뭐가 있을 시 생각이 안나서 한번 생각을 해봐야할 것 같아요 ..
