### PR TITLE
[1단계 - DB 복제와 캐시] 리니(이예린) 미션 제출합니다.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: coupon
       TZ: Asia/Seoul
 
   mysql_reader:
@@ -33,6 +34,7 @@ services:
     container_name: mysql_reader
     environment:
       MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: coupon
       TZ: Asia/Seoul
     depends_on:
       - mysql_writer

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -1,0 +1,74 @@
+package coupon.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import com.zaxxer.hikari.HikariDataSource;
+
+@Configuration
+public class DataSourceConfig {
+
+    protected static final String WRITER = "writer";
+    protected static final String READER = "reader";
+    private static final String WRITER_DATA_SOURCE = "writerDataSource";
+    private static final String READER_DATA_SOURCE = "readerDataSource";
+    private static final String ROUTING_DATA_SOURCE = "routingDataSource";
+
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    @Bean(name = READER_DATA_SOURCE)
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    @Bean(name = WRITER_DATA_SOURCE)
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @DependsOn({WRITER_DATA_SOURCE, READER_DATA_SOURCE})
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier(WRITER_DATA_SOURCE) DataSource writerDataSource,
+            @Qualifier(READER_DATA_SOURCE) DataSource readerDataSource
+    ) {
+        DynamicRoutingDataSource routingDataSource = new DynamicRoutingDataSource();
+        Map<Object, Object> dataSourceMap = createDataSourceMap(writerDataSource, readerDataSource);
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(writerDataSource);
+
+        return routingDataSource;
+    }
+
+    private Map<Object, Object> createDataSourceMap(DataSource writer, DataSource reader) {
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(WRITER, writer);
+        dataSourceMap.put(READER, reader);
+        return dataSourceMap;
+    }
+
+    @DependsOn({ROUTING_DATA_SOURCE})
+    @Primary
+    @Bean
+    public DataSource dataSource(@Qualifier(ROUTING_DATA_SOURCE) DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory);
+        return jpaTransactionManager;
+    }
+}

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -14,7 +14,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
-import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 public class DataSourceConfig {
@@ -28,13 +27,13 @@ public class DataSourceConfig {
     @ConfigurationProperties(prefix = "coupon.datasource.reader")
     @Bean(name = READER_DATA_SOURCE)
     public DataSource readerDataSource() {
-        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+        return DataSourceBuilder.create().build();
     }
 
     @ConfigurationProperties(prefix = "coupon.datasource.writer")
     @Bean(name = WRITER_DATA_SOURCE)
     public DataSource writerDataSource() {
-        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+        return DataSourceBuilder.create().build();
     }
 
     @DependsOn({WRITER_DATA_SOURCE, READER_DATA_SOURCE})

--- a/src/main/java/coupon/config/DynamicRoutingDataSource.java
+++ b/src/main/java/coupon/config/DynamicRoutingDataSource.java
@@ -1,0 +1,18 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import static coupon.config.DataSourceConfig.READER;
+import static coupon.config.DataSourceConfig.WRITER;
+
+public class DynamicRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return READER;
+        }
+        return WRITER;
+    }
+}

--- a/src/main/java/coupon/coupon/CouponException.java
+++ b/src/main/java/coupon/coupon/CouponException.java
@@ -1,0 +1,8 @@
+package coupon.coupon;
+
+public class CouponException extends RuntimeException {
+
+    public CouponException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Category.java
+++ b/src/main/java/coupon/coupon/domain/Category.java
@@ -1,0 +1,9 @@
+package coupon.coupon.domain;
+
+public enum Category {
+    FASHION,
+    ELECTRONICS,
+    FURNITURE,
+    FOOD,
+    ;
+}

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -16,9 +16,9 @@ import coupon.coupon.CouponException;
 @Entity
 public class Coupon {
 
+    public static final String CATEGORY_NON_NULL_MESSAGE = "카테고리를 선택해주세요.";
     private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
     private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
-    public static final String CATEGORY_NON_NULL_MESSAGE = "카테고리를 선택해주세요";
     private static final String DISCOUNT_RATE_MESSAGE = String.format(
             "할인율은 %s%% 이상, %s%% 이하이어야 합니다.",
             MINIMUM_DISCOUNT_RATE.toPlainString(),
@@ -49,10 +49,11 @@ public class Coupon {
 
     public Coupon(CouponName name, DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount, Category category, Term term) {
         validateDiscountRate(discountAmount, minimumOrderAmount);
+        validateCategoryNull(category);
         this.name = name;
         this.discountAmount = discountAmount;
         this.minimumOrderAmount = minimumOrderAmount;
-        this.category = Objects.requireNonNull(category, CATEGORY_NON_NULL_MESSAGE);
+        this.category = category;
         this.term = term;
     }
 
@@ -60,6 +61,12 @@ public class Coupon {
         BigDecimal discountRate = discountAmount.getDiscountRate(minimumOrderAmount);
         if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {
             throw new CouponException(DISCOUNT_RATE_MESSAGE);
+        }
+    }
+
+    private void validateCategoryNull(Category category) {
+        if (Objects.isNull(category)) {
+            throw new CouponException(CATEGORY_NON_NULL_MESSAGE);
         }
     }
 

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -3,18 +3,39 @@ package coupon.coupon.domain;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import coupon.coupon.CouponException;
 
+@Entity
 public class Coupon {
 
     private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
     private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
 
-    private final CouponName name;
-    private final DiscountAmount discountAmount;
-    private final MinimumOrderAmount minimumOrderAmount;
-    private final Category category;
-    private final Term term;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private CouponName name;
+    @Embedded
+    private DiscountAmount discountAmount;
+    @Embedded
+    private MinimumOrderAmount minimumOrderAmount;
+    @Enumerated(EnumType.STRING)
+    private Category category;
+    @Embedded
+    private Term term;
+
+    protected Coupon() {
+
+    }
 
     public Coupon(String name, long discountAmount, long minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
         this(new CouponName(name), new DiscountAmount(discountAmount), new MinimumOrderAmount(minimumOrderAmount), category, new Term(startAt, endAt));
@@ -36,5 +57,29 @@ public class Coupon {
         if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {
             throw new CouponException("할인율은 3% 이상, 20% 이하이어야 합니다.");
         }
+    }
+
+    public String getName() {
+        return name.getCouponName();
+    }
+
+    public DiscountAmount getDiscountAmount() {
+        return discountAmount;
+    }
+
+    public MinimumOrderAmount getMinimumOrderAmount() {
+        return minimumOrderAmount;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public LocalDate getStartAt() {
+        return term.getStartAt();
+    }
+
+    public LocalDate getEndAt() {
+        return term.getEndAt();
     }
 }

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -14,35 +14,27 @@ public class Coupon {
     private final DiscountAmount discountAmount;
     private final MinimumOrderAmount minimumOrderAmount;
     private final Category category;
-    private final LocalDate startAt;
-    private final LocalDate endAt;
+    private final Term term;
 
     public Coupon(String name, long discountAmount, long minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
-        this(new CouponName(name), new DiscountAmount(discountAmount), new MinimumOrderAmount(minimumOrderAmount), category, startAt, endAt);
+        this(new CouponName(name), new DiscountAmount(discountAmount), new MinimumOrderAmount(minimumOrderAmount), category, new Term(startAt, endAt));
     }
 
-    public Coupon(CouponName name, DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
+    public Coupon(CouponName name, DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount, Category category, Term term) {
         validateDiscountRate(discountAmount, minimumOrderAmount);
-        validateTerm(startAt, endAt);
         this.name = name;
         this.discountAmount = discountAmount;
         this.minimumOrderAmount = minimumOrderAmount;
         this.category = category;
-        this.startAt = startAt;
-        this.endAt = endAt;
+        this.term = term;
     }
 
     private void validateDiscountRate(DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount) {
-        BigDecimal discountRate = discountAmount.getDiscountAmount().multiply(BigDecimal.valueOf(100))
+        BigDecimal discountRate = discountAmount.getDiscountAmount()
+                .multiply(BigDecimal.valueOf(100))
                 .divide(minimumOrderAmount.getMinimumOrderAmount(), 0, RoundingMode.DOWN);
         if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {
             throw new CouponException("할인율은 3% 이상, 20% 이하이어야 합니다.");
-        }
-    }
-
-    private void validateTerm(LocalDate startAt, LocalDate endAt) {
-        if (endAt.isBefore(startAt)) {
-            throw new CouponException("종료일이 시작일보다 앞설 수 없습니다.");
         }
     }
 }

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -21,7 +21,6 @@ public class Coupon {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @Embedded
     private CouponName name;
     @Embedded

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -1,7 +1,6 @@
 package coupon.coupon.domain;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Objects;
 import jakarta.persistence.Column;
@@ -42,7 +41,6 @@ public class Coupon {
     private Term term;
 
     protected Coupon() {
-
     }
 
     public Coupon(String name, long discountAmount, long minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
@@ -59,9 +57,7 @@ public class Coupon {
     }
 
     private void validateDiscountRate(DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount) {
-        BigDecimal discountRate = discountAmount.getDiscountAmount()
-                .multiply(BigDecimal.valueOf(100))
-                .divide(minimumOrderAmount.getMinimumOrderAmount(), 0, RoundingMode.DOWN);
+        BigDecimal discountRate = discountAmount.getDiscountRate(minimumOrderAmount);
         if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {
             throw new CouponException(DISCOUNT_RATE_MESSAGE);
         }

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -59,6 +59,10 @@ public class Coupon {
         }
     }
 
+    public long getId() {
+        return id;
+    }
+
     public String getName() {
         return name.getCouponName();
     }

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -17,6 +17,11 @@ public class Coupon {
 
     private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
     private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
+    private static final String DISCOUNT_RATE_MESSAGE = String.format(
+            "할인율은 %s%% 이상, %s%% 이하이어야 합니다.",
+            MINIMUM_DISCOUNT_RATE.toPlainString(),
+            MAXIMUM_DISCOUNT_RATE.toPlainString()
+    );
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,7 +59,7 @@ public class Coupon {
                 .multiply(BigDecimal.valueOf(100))
                 .divide(minimumOrderAmount.getMinimumOrderAmount(), 0, RoundingMode.DOWN);
         if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {
-            throw new CouponException("할인율은 3% 이상, 20% 이하이어야 합니다.");
+            throw new CouponException(DISCOUNT_RATE_MESSAGE);
         }
     }
 

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -7,24 +7,21 @@ import coupon.coupon.CouponException;
 
 public class Coupon {
 
-    private static final BigDecimal MIN_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(5000);
-    private static final BigDecimal MAX_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(100000);
     private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
     private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
 
     private final CouponName name;
     private final DiscountAmount discountAmount;
-    private final BigDecimal minimumOrderAmount;
+    private final MinimumOrderAmount minimumOrderAmount;
     private final Category category;
     private final LocalDate startAt;
     private final LocalDate endAt;
 
     public Coupon(String name, long discountAmount, long minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
-        this(new CouponName(name), new DiscountAmount(discountAmount), BigDecimal.valueOf(minimumOrderAmount), category, startAt, endAt);
+        this(new CouponName(name), new DiscountAmount(discountAmount), new MinimumOrderAmount(minimumOrderAmount), category, startAt, endAt);
     }
 
-    public Coupon(CouponName name, DiscountAmount discountAmount, BigDecimal minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
-        validateMinimumOrderAmount(minimumOrderAmount);
+    public Coupon(CouponName name, DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
         validateDiscountRate(discountAmount, minimumOrderAmount);
         validateTerm(startAt, endAt);
         this.name = name;
@@ -35,21 +32,9 @@ public class Coupon {
         this.endAt = endAt;
     }
 
-
-    private void validateMinimumOrderAmount(BigDecimal minimumOrderAmount) {
-        validateRangeOfMinimumOrderAmount(minimumOrderAmount);
-    }
-
-    private void validateRangeOfMinimumOrderAmount(BigDecimal minimumOrderAmount) {
-        if (minimumOrderAmount.compareTo(MIN_OF_MINIMUM_ORDER_AMOUNT) < 0 || (minimumOrderAmount.compareTo(MAX_OF_MINIMUM_ORDER_AMOUNT) > 0)) {
-            throw new CouponException("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
-        }
-    }
-
-    private void validateDiscountRate(DiscountAmount discountAmount, BigDecimal minimumOrderAmount) {
-        BigDecimal discountRate = discountAmount.getDiscountAmount()
-                .multiply(BigDecimal.valueOf(100))
-                .divide(minimumOrderAmount, 0, RoundingMode.DOWN);
+    private void validateDiscountRate(DiscountAmount discountAmount, MinimumOrderAmount minimumOrderAmount) {
+        BigDecimal discountRate = discountAmount.getDiscountAmount().multiply(BigDecimal.valueOf(100))
+                .divide(minimumOrderAmount.getMinimumOrderAmount(), 0, RoundingMode.DOWN);
         if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {
             throw new CouponException("할인율은 3% 이상, 20% 이하이어야 합니다.");
         }

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -3,12 +3,10 @@ package coupon.coupon.domain;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.util.Objects;
 import coupon.coupon.CouponException;
 
 public class Coupon {
 
-    private static final int MAX_LENGTH = 30;
     private static final BigDecimal UNIT = BigDecimal.valueOf(500);
     private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
     private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
@@ -17,7 +15,7 @@ public class Coupon {
     private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
     private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
 
-    private final String name;
+    private final CouponName name;
     private final BigDecimal discountAmount;
     private final BigDecimal minimumOrderAmount;
     private final Category category;
@@ -25,11 +23,10 @@ public class Coupon {
     private final LocalDate endAt;
 
     public Coupon(String name, long discountAmount, long minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
-        this(name, BigDecimal.valueOf(discountAmount), BigDecimal.valueOf(minimumOrderAmount), category, startAt, endAt);
+        this(new CouponName(name), BigDecimal.valueOf(discountAmount), BigDecimal.valueOf(minimumOrderAmount), category, startAt, endAt);
     }
 
-    public Coupon(String name, BigDecimal discountAmount, BigDecimal minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
-        validateName(name);
+    public Coupon(CouponName name, BigDecimal discountAmount, BigDecimal minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
         validateDiscountAmount(discountAmount);
         validateMinimumOrderAmount(minimumOrderAmount);
         validateDiscountRate(discountAmount, minimumOrderAmount);
@@ -42,22 +39,6 @@ public class Coupon {
         this.endAt = endAt;
     }
 
-    private void validateName(String name) {
-        validateNull(name);
-        validateNameLength(name);
-    }
-
-    private void validateNull(String name) {
-        if (Objects.isNull(name)) {
-            throw new CouponException("쿠폰 이름이 누락되었습니다.");
-        }
-    }
-
-    private void validateNameLength(String name) {
-        if (name.isEmpty() || name.length() > MAX_LENGTH) {
-            throw new CouponException("쿠폰은 30자 이하의 이름을 설정해주세요.");
-        }
-    }
 
     private void validateDiscountAmount(BigDecimal discountAmount) {
         validateUnit(discountAmount);

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -1,0 +1,103 @@
+package coupon.coupon.domain;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.Objects;
+import coupon.coupon.CouponException;
+
+public class Coupon {
+
+    private static final int MAX_LENGTH = 30;
+    private static final BigDecimal UNIT = BigDecimal.valueOf(500);
+    private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
+    private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
+    private static final BigDecimal MIN_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(5000);
+    private static final BigDecimal MAX_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(100000);
+    private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
+    private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
+
+    private final String name;
+    private final BigDecimal discountAmount;
+    private final BigDecimal minimumOrderAmount;
+    private final Category category;
+    private final LocalDate startAt;
+    private final LocalDate endAt;
+
+    public Coupon(String name, long discountAmount, long minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
+        this(name, BigDecimal.valueOf(discountAmount), BigDecimal.valueOf(minimumOrderAmount), category, startAt, endAt);
+    }
+
+    public Coupon(String name, BigDecimal discountAmount, BigDecimal minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
+        validateName(name);
+        validateDiscountAmount(discountAmount);
+        validateMinimumOrderAmount(minimumOrderAmount);
+        validateDiscountRate(discountAmount, minimumOrderAmount);
+        validateTerm(startAt, endAt);
+        this.name = name;
+        this.discountAmount = discountAmount;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.category = category;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    private void validateName(String name) {
+        validateNull(name);
+        validateNameLength(name);
+    }
+
+    private void validateNull(String name) {
+        if (Objects.isNull(name)) {
+            throw new CouponException("쿠폰 이름이 누락되었습니다.");
+        }
+    }
+
+    private void validateNameLength(String name) {
+        if (name.isEmpty() || name.length() > MAX_LENGTH) {
+            throw new CouponException("쿠폰은 30자 이하의 이름을 설정해주세요.");
+        }
+    }
+
+    private void validateDiscountAmount(BigDecimal discountAmount) {
+        validateUnit(discountAmount);
+        validateRangeOfDiscountAmount(discountAmount);
+    }
+
+    private void validateUnit(BigDecimal discountAmount) {
+        if (!discountAmount.remainder(UNIT).equals(BigDecimal.ZERO)) {
+            throw new CouponException("할인 금액은 500원 단위로 설정할 수 있습니다.");
+        }
+    }
+
+    private void validateRangeOfDiscountAmount(BigDecimal discountAmount) {
+        if (discountAmount.compareTo(MINIMUM_DISCOUNT_AMOUNT) < 0 || discountAmount.compareTo(MAXIMUM_DISCOUNT_AMOUNT) > 0) {
+            throw new CouponException("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+        }
+    }
+
+    private void validateMinimumOrderAmount(BigDecimal minimumOrderAmount) {
+        validateRangeOfMinimumOrderAmount(minimumOrderAmount);
+    }
+
+    private void validateRangeOfMinimumOrderAmount(BigDecimal minimumOrderAmount) {
+        if (minimumOrderAmount.compareTo(MIN_OF_MINIMUM_ORDER_AMOUNT) < 0 || (minimumOrderAmount.compareTo(MAX_OF_MINIMUM_ORDER_AMOUNT) > 0)) {
+            throw new CouponException("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
+        }
+    }
+
+    private void validateDiscountRate(BigDecimal discountAmount, BigDecimal minimumOrderAmount) {
+        BigDecimal discountRate = discountAmount
+                .multiply(BigDecimal.valueOf(100))
+                .divide(minimumOrderAmount, 0, RoundingMode.DOWN);
+        if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {
+            throw new CouponException("할인율은 3% 이상, 20% 이하이어야 합니다.");
+        }
+    }
+
+    private void validateTerm(LocalDate startAt, LocalDate endAt) {
+        if (endAt.isBefore(startAt)) {
+            throw new CouponException("종료일이 시작일보다 앞설 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -3,6 +3,8 @@ package coupon.coupon.domain;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.Objects;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -17,6 +19,7 @@ public class Coupon {
 
     private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
     private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
+    public static final String CATEGORY_NON_NULL_MESSAGE = "카테고리를 선택해주세요";
     private static final String DISCOUNT_RATE_MESSAGE = String.format(
             "할인율은 %s%% 이상, %s%% 이하이어야 합니다.",
             MINIMUM_DISCOUNT_RATE.toPlainString(),
@@ -33,6 +36,7 @@ public class Coupon {
     @Embedded
     private MinimumOrderAmount minimumOrderAmount;
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Category category;
     @Embedded
     private Term term;
@@ -50,7 +54,7 @@ public class Coupon {
         this.name = name;
         this.discountAmount = discountAmount;
         this.minimumOrderAmount = minimumOrderAmount;
-        this.category = category;
+        this.category = Objects.requireNonNull(category, CATEGORY_NON_NULL_MESSAGE);
         this.term = term;
     }
 

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -7,27 +7,23 @@ import coupon.coupon.CouponException;
 
 public class Coupon {
 
-    private static final BigDecimal UNIT = BigDecimal.valueOf(500);
-    private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
-    private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
     private static final BigDecimal MIN_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(5000);
     private static final BigDecimal MAX_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(100000);
     private static final BigDecimal MINIMUM_DISCOUNT_RATE = BigDecimal.valueOf(3);
     private static final BigDecimal MAXIMUM_DISCOUNT_RATE = BigDecimal.valueOf(20);
 
     private final CouponName name;
-    private final BigDecimal discountAmount;
+    private final DiscountAmount discountAmount;
     private final BigDecimal minimumOrderAmount;
     private final Category category;
     private final LocalDate startAt;
     private final LocalDate endAt;
 
     public Coupon(String name, long discountAmount, long minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
-        this(new CouponName(name), BigDecimal.valueOf(discountAmount), BigDecimal.valueOf(minimumOrderAmount), category, startAt, endAt);
+        this(new CouponName(name), new DiscountAmount(discountAmount), BigDecimal.valueOf(minimumOrderAmount), category, startAt, endAt);
     }
 
-    public Coupon(CouponName name, BigDecimal discountAmount, BigDecimal minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
-        validateDiscountAmount(discountAmount);
+    public Coupon(CouponName name, DiscountAmount discountAmount, BigDecimal minimumOrderAmount, Category category, LocalDate startAt, LocalDate endAt) {
         validateMinimumOrderAmount(minimumOrderAmount);
         validateDiscountRate(discountAmount, minimumOrderAmount);
         validateTerm(startAt, endAt);
@@ -40,23 +36,6 @@ public class Coupon {
     }
 
 
-    private void validateDiscountAmount(BigDecimal discountAmount) {
-        validateUnit(discountAmount);
-        validateRangeOfDiscountAmount(discountAmount);
-    }
-
-    private void validateUnit(BigDecimal discountAmount) {
-        if (!discountAmount.remainder(UNIT).equals(BigDecimal.ZERO)) {
-            throw new CouponException("할인 금액은 500원 단위로 설정할 수 있습니다.");
-        }
-    }
-
-    private void validateRangeOfDiscountAmount(BigDecimal discountAmount) {
-        if (discountAmount.compareTo(MINIMUM_DISCOUNT_AMOUNT) < 0 || discountAmount.compareTo(MAXIMUM_DISCOUNT_AMOUNT) > 0) {
-            throw new CouponException("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
-        }
-    }
-
     private void validateMinimumOrderAmount(BigDecimal minimumOrderAmount) {
         validateRangeOfMinimumOrderAmount(minimumOrderAmount);
     }
@@ -67,8 +46,8 @@ public class Coupon {
         }
     }
 
-    private void validateDiscountRate(BigDecimal discountAmount, BigDecimal minimumOrderAmount) {
-        BigDecimal discountRate = discountAmount
+    private void validateDiscountRate(DiscountAmount discountAmount, BigDecimal minimumOrderAmount) {
+        BigDecimal discountRate = discountAmount.getDiscountAmount()
                 .multiply(BigDecimal.valueOf(100))
                 .divide(minimumOrderAmount, 0, RoundingMode.DOWN);
         if (discountRate.compareTo(MINIMUM_DISCOUNT_RATE) < 0 || discountRate.compareTo(MAXIMUM_DISCOUNT_RATE) > 0) {

--- a/src/main/java/coupon/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/coupon/domain/Coupon.java
@@ -62,28 +62,4 @@ public class Coupon {
     public long getId() {
         return id;
     }
-
-    public String getName() {
-        return name.getCouponName();
-    }
-
-    public DiscountAmount getDiscountAmount() {
-        return discountAmount;
-    }
-
-    public MinimumOrderAmount getMinimumOrderAmount() {
-        return minimumOrderAmount;
-    }
-
-    public Category getCategory() {
-        return category;
-    }
-
-    public LocalDate getStartAt() {
-        return term.getStartAt();
-    }
-
-    public LocalDate getEndAt() {
-        return term.getEndAt();
-    }
 }

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -1,13 +1,18 @@
 package coupon.coupon.domain;
 
 import java.util.Objects;
+import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
+@Embeddable
 public class CouponName {
 
     private static final int MAX_LENGTH = 30;
 
-    private final String name;
+    private String name;
+
+    protected CouponName() {
+    }
 
     public CouponName(String name) {
         validate(name);
@@ -44,5 +49,9 @@ public class CouponName {
     @Override
     public int hashCode() {
         return Objects.hash(name);
+    }
+
+    public String getCouponName() {
+        return name;
     }
 }

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -52,8 +52,4 @@ public class CouponName {
     public int hashCode() {
         return Objects.hash(name);
     }
-
-    public String getCouponName() {
-        return name;
-    }
 }

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -33,7 +33,7 @@ public class CouponName {
     }
 
     private void validateNameLength(String name) {
-        if (name.isEmpty() || name.length() > MAX_LENGTH) {
+        if (name.isBlank() || name.length() > MAX_LENGTH) {
             throw new CouponException("쿠폰은 30자 이하의 이름을 설정해주세요.");
         }
     }

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -1,0 +1,33 @@
+package coupon.coupon.domain;
+
+import java.util.Objects;
+import coupon.coupon.CouponException;
+
+public class CouponName {
+
+    private static final int MAX_LENGTH = 30;
+
+    private final String name;
+
+    public CouponName(String name) {
+        validate(name);
+        this.name = name;
+    }
+
+    private void validate(String name) {
+        validateNull(name);
+        validateNameLength(name);
+    }
+
+    private void validateNull(String name) {
+        if (Objects.isNull(name)) {
+            throw new CouponException("쿠폰 이름이 누락되었습니다.");
+        }
+    }
+
+    private void validateNameLength(String name) {
+        if (name.isEmpty() || name.length() > MAX_LENGTH) {
+            throw new CouponException("쿠폰은 30자 이하의 이름을 설정해주세요.");
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -1,6 +1,7 @@
 package coupon.coupon.domain;
 
 import java.util.Objects;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
@@ -9,6 +10,7 @@ public class CouponName {
 
     private static final int MAX_LENGTH = 30;
 
+    @Column(nullable = false, length = 30)
     private String name;
 
     protected CouponName() {

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -9,8 +9,9 @@ import coupon.coupon.CouponException;
 public class CouponName {
 
     private static final int MAX_LENGTH = 30;
+    private static final String NAME_LENGTH_MESSAGE = String.format("쿠폰은 %d자 이하의 이름을 설정해주세요.", MAX_LENGTH);
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = MAX_LENGTH)
     private String name;
 
     protected CouponName() {
@@ -34,7 +35,7 @@ public class CouponName {
 
     private void validateNameLength(String name) {
         if (name.isBlank() || name.length() > MAX_LENGTH) {
-            throw new CouponException("쿠폰은 30자 이하의 이름을 설정해주세요.");
+            throw new CouponException(NAME_LENGTH_MESSAGE);
         }
     }
 

--- a/src/main/java/coupon/coupon/domain/CouponName.java
+++ b/src/main/java/coupon/coupon/domain/CouponName.java
@@ -30,4 +30,19 @@ public class CouponName {
             throw new CouponException("쿠폰은 30자 이하의 이름을 설정해주세요.");
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        CouponName that = (CouponName) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
 }

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -2,15 +2,20 @@ package coupon.coupon.domain;
 
 import java.math.BigDecimal;
 import java.util.Objects;
+import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
+@Embeddable
 public class DiscountAmount {
 
     private static final BigDecimal UNIT = BigDecimal.valueOf(500);
     private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
     private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
 
-    private final BigDecimal discountAmount;
+    private BigDecimal discountAmount;
+
+    protected DiscountAmount() {
+    }
 
     public DiscountAmount(long discountAmount) {
         this(BigDecimal.valueOf(discountAmount));

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -1,6 +1,7 @@
 package coupon.coupon.domain;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import coupon.coupon.CouponException;
 
 public class DiscountAmount {
@@ -35,6 +36,21 @@ public class DiscountAmount {
         if (discountAmount.compareTo(MINIMUM_DISCOUNT_AMOUNT) < 0 || discountAmount.compareTo(MAXIMUM_DISCOUNT_AMOUNT) > 0) {
             throw new CouponException("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DiscountAmount that = (DiscountAmount) o;
+        return Objects.equals(discountAmount, that.discountAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(discountAmount);
     }
 
     public BigDecimal getDiscountAmount() {

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -2,6 +2,7 @@ package coupon.coupon.domain;
 
 import java.math.BigDecimal;
 import java.util.Objects;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
@@ -12,6 +13,7 @@ public class DiscountAmount {
     private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
     private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
 
+    @Column(nullable = false)
     private BigDecimal discountAmount;
 
     protected DiscountAmount() {

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -12,6 +12,12 @@ public class DiscountAmount {
     private static final BigDecimal UNIT = BigDecimal.valueOf(500);
     private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
     private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
+    private static final String DISCOUNT_AMOUNT_UNIT_MESSAGE = String.format("할인 금액은 %d원 단위로 설정할 수 있습니다.", UNIT);
+    private static final String DISCOUNT_AMOUNT_RANGE_MESSAGE = String.format(
+            "할인 금액은 %s원 이상, %s원 이하이어야 합니다.",
+            MINIMUM_DISCOUNT_AMOUNT.toPlainString(),
+            MAXIMUM_DISCOUNT_AMOUNT.toPlainString()
+    );
 
     @Column(nullable = false)
     private BigDecimal discountAmount;
@@ -35,13 +41,13 @@ public class DiscountAmount {
 
     private void validateUnit(BigDecimal discountAmount) {
         if (!discountAmount.remainder(UNIT).equals(BigDecimal.ZERO)) {
-            throw new CouponException("할인 금액은 500원 단위로 설정할 수 있습니다.");
+            throw new CouponException(DISCOUNT_AMOUNT_UNIT_MESSAGE);
         }
     }
 
     private void validateRangeOfDiscountAmount(BigDecimal discountAmount) {
         if (discountAmount.compareTo(MINIMUM_DISCOUNT_AMOUNT) < 0 || discountAmount.compareTo(MAXIMUM_DISCOUNT_AMOUNT) > 0) {
-            throw new CouponException("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+            throw new CouponException(DISCOUNT_AMOUNT_RANGE_MESSAGE);
         }
     }
 

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -13,7 +13,7 @@ public class DiscountAmount {
     private static final BigDecimal UNIT = BigDecimal.valueOf(500);
     private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
     private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
-    private static final String DISCOUNT_AMOUNT_UNIT_MESSAGE = String.format("할인 금액은 %d원 단위로 설정할 수 있습니다.", UNIT);
+    private static final String DISCOUNT_AMOUNT_UNIT_MESSAGE = String.format("할인 금액은 %s원 단위로 설정할 수 있습니다.", UNIT);
     private static final String DISCOUNT_AMOUNT_RANGE_MESSAGE = String.format(
             "할인 금액은 %s원 이상, %s원 이하이어야 합니다.",
             MINIMUM_DISCOUNT_AMOUNT.toPlainString(),

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -1,6 +1,7 @@
 package coupon.coupon.domain;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Objects;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
@@ -29,7 +30,7 @@ public class DiscountAmount {
         this(BigDecimal.valueOf(discountAmount));
     }
 
-    public DiscountAmount(BigDecimal discountAmount) {
+    private DiscountAmount(BigDecimal discountAmount) {
         validate(discountAmount);
         this.discountAmount = discountAmount;
     }
@@ -51,6 +52,11 @@ public class DiscountAmount {
         }
     }
 
+    public BigDecimal getDiscountRate(MinimumOrderAmount minimumOrderAmount) {
+        return discountAmount.multiply(BigDecimal.valueOf(100))
+                .divide(minimumOrderAmount.getMinimumOrderAmount(), 0, RoundingMode.DOWN);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -64,9 +70,5 @@ public class DiscountAmount {
     @Override
     public int hashCode() {
         return Objects.hash(discountAmount);
-    }
-
-    public BigDecimal getDiscountAmount() {
-        return discountAmount;
     }
 }

--- a/src/main/java/coupon/coupon/domain/DiscountAmount.java
+++ b/src/main/java/coupon/coupon/domain/DiscountAmount.java
@@ -1,0 +1,43 @@
+package coupon.coupon.domain;
+
+import java.math.BigDecimal;
+import coupon.coupon.CouponException;
+
+public class DiscountAmount {
+
+    private static final BigDecimal UNIT = BigDecimal.valueOf(500);
+    private static final BigDecimal MINIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(1000);
+    private static final BigDecimal MAXIMUM_DISCOUNT_AMOUNT = BigDecimal.valueOf(10000);
+
+    private final BigDecimal discountAmount;
+
+    public DiscountAmount(long discountAmount) {
+        this(BigDecimal.valueOf(discountAmount));
+    }
+
+    public DiscountAmount(BigDecimal discountAmount) {
+        validate(discountAmount);
+        this.discountAmount = discountAmount;
+    }
+
+    private void validate(BigDecimal discountAmount) {
+        validateUnit(discountAmount);
+        validateRangeOfDiscountAmount(discountAmount);
+    }
+
+    private void validateUnit(BigDecimal discountAmount) {
+        if (!discountAmount.remainder(UNIT).equals(BigDecimal.ZERO)) {
+            throw new CouponException("할인 금액은 500원 단위로 설정할 수 있습니다.");
+        }
+    }
+
+    private void validateRangeOfDiscountAmount(BigDecimal discountAmount) {
+        if (discountAmount.compareTo(MINIMUM_DISCOUNT_AMOUNT) < 0 || discountAmount.compareTo(MAXIMUM_DISCOUNT_AMOUNT) > 0) {
+            throw new CouponException("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+        }
+    }
+
+    public BigDecimal getDiscountAmount() {
+        return discountAmount;
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Member.java
+++ b/src/main/java/coupon/coupon/domain/Member.java
@@ -1,0 +1,21 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    protected Member() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Member.java
+++ b/src/main/java/coupon/coupon/domain/Member.java
@@ -14,8 +14,4 @@ public class Member {
 
     protected Member() {
     }
-
-    public Long getId() {
-        return id;
-    }
 }

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -2,6 +2,7 @@ package coupon.coupon.domain;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,10 +25,13 @@ public class MemberCoupon {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(nullable = false)
     private boolean used;
 
+    @Column(nullable = false)
     private LocalDateTime issuedAt;
 
+    @Column(nullable = false)
     private LocalDateTime expiredAt;
 
     protected MemberCoupon() {

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -54,20 +54,8 @@ public class MemberCoupon {
         return issuedAt.plusDays(7).with(LocalTime.of(23, 59, 59, 999_999_000));
     }
 
-    public Long getId() {
-        return id;
-    }
-
     public Coupon getCoupon() {
         return coupon;
-    }
-
-    public Member getMember() {
-        return member;
-    }
-
-    public boolean isUsed() {
-        return used;
     }
 
     public LocalDateTime getIssuedAt() {

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -18,11 +18,11 @@ public class MemberCoupon {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "coupon_id")
+    @JoinColumn(nullable = false, name = "coupon_id")
     private Coupon coupon;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(nullable = false, name = "member_id")
     private Member member;
 
     @Column(nullable = false)

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -38,11 +38,6 @@ public class MemberCoupon {
     }
 
     public MemberCoupon(Coupon coupon, Member member) {
-        this(null, coupon, member);
-    }
-
-    private MemberCoupon(Long id, Coupon coupon, Member member) {
-        this.id = id;
         this.coupon = coupon;
         this.member = member;
         this.used = false;

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -1,0 +1,76 @@
+package coupon.coupon.domain;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class MemberCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private boolean used;
+
+    private LocalDateTime issuedAt;
+
+    private LocalDateTime expiredAt;
+
+    protected MemberCoupon() {
+    }
+
+    public MemberCoupon(Coupon coupon, Member member) {
+        this(null, coupon, member);
+    }
+
+    private MemberCoupon(Long id, Coupon coupon, Member member) {
+        this.id = id;
+        this.coupon = coupon;
+        this.member = member;
+        this.used = false;
+        this.issuedAt = LocalDateTime.now();
+        this.expiredAt = calculateExpiredAt(this.issuedAt);
+    }
+
+    private LocalDateTime calculateExpiredAt(LocalDateTime issuedAt) {
+        return issuedAt.plusDays(7).with(LocalTime.of(23, 59, 59, 999_999_000));
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Coupon getCoupon() {
+        return coupon;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public boolean isUsed() {
+        return used;
+    }
+
+    public LocalDateTime getIssuedAt() {
+        return issuedAt;
+    }
+
+    public LocalDateTime getExpiredAt() {
+        return expiredAt;
+    }
+}

--- a/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
@@ -2,6 +2,7 @@ package coupon.coupon.domain;
 
 import java.math.BigDecimal;
 import java.util.Objects;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
@@ -11,6 +12,7 @@ public class MinimumOrderAmount {
     private static final BigDecimal MIN_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(5000);
     private static final BigDecimal MAX_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(100000);
 
+    @Column(nullable = false)
     private BigDecimal minimumOrderAmount;
 
     protected MinimumOrderAmount() {

--- a/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
@@ -2,14 +2,19 @@ package coupon.coupon.domain;
 
 import java.math.BigDecimal;
 import java.util.Objects;
+import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
+@Embeddable
 public class MinimumOrderAmount {
 
     private static final BigDecimal MIN_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(5000);
     private static final BigDecimal MAX_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(100000);
 
-    private final BigDecimal minimumOrderAmount;
+    private BigDecimal minimumOrderAmount;
+
+    protected MinimumOrderAmount() {
+    }
 
     public MinimumOrderAmount(long minimumOrderAmount) {
         this(BigDecimal.valueOf(minimumOrderAmount));

--- a/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
@@ -11,6 +11,11 @@ public class MinimumOrderAmount {
 
     private static final BigDecimal MIN_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(5000);
     private static final BigDecimal MAX_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(100000);
+    private static final String MINIMUM_ORDER_AMOUNT_RANGE_MESSAGE = String.format(
+            "최소 주문 금액은 %s원 이상, %s원 이하이어야 합니다.",
+            MIN_OF_MINIMUM_ORDER_AMOUNT.toPlainString(),
+            MAX_OF_MINIMUM_ORDER_AMOUNT.toPlainString()
+    );
 
     @Column(nullable = false)
     private BigDecimal minimumOrderAmount;
@@ -29,7 +34,7 @@ public class MinimumOrderAmount {
 
     private void validateRangeOfMinimumOrderAmount(BigDecimal minimumOrderAmount) {
         if (minimumOrderAmount.compareTo(MIN_OF_MINIMUM_ORDER_AMOUNT) < 0 || (minimumOrderAmount.compareTo(MAX_OF_MINIMUM_ORDER_AMOUNT) > 0)) {
-            throw new CouponException("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
+            throw new CouponException(MINIMUM_ORDER_AMOUNT_RANGE_MESSAGE);
         }
     }
 

--- a/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
@@ -1,6 +1,7 @@
 package coupon.coupon.domain;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 import coupon.coupon.CouponException;
 
 public class MinimumOrderAmount {
@@ -23,6 +24,21 @@ public class MinimumOrderAmount {
         if (minimumOrderAmount.compareTo(MIN_OF_MINIMUM_ORDER_AMOUNT) < 0 || (minimumOrderAmount.compareTo(MAX_OF_MINIMUM_ORDER_AMOUNT) > 0)) {
             throw new CouponException("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MinimumOrderAmount that = (MinimumOrderAmount) o;
+        return Objects.equals(minimumOrderAmount, that.minimumOrderAmount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minimumOrderAmount);
     }
 
     public BigDecimal getMinimumOrderAmount() {

--- a/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
+++ b/src/main/java/coupon/coupon/domain/MinimumOrderAmount.java
@@ -1,0 +1,31 @@
+package coupon.coupon.domain;
+
+import java.math.BigDecimal;
+import coupon.coupon.CouponException;
+
+public class MinimumOrderAmount {
+
+    private static final BigDecimal MIN_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(5000);
+    private static final BigDecimal MAX_OF_MINIMUM_ORDER_AMOUNT = BigDecimal.valueOf(100000);
+
+    private final BigDecimal minimumOrderAmount;
+
+    public MinimumOrderAmount(long minimumOrderAmount) {
+        this(BigDecimal.valueOf(minimumOrderAmount));
+    }
+
+    public MinimumOrderAmount(BigDecimal minimumOrderAmount) {
+        validateRangeOfMinimumOrderAmount(minimumOrderAmount);
+        this.minimumOrderAmount = minimumOrderAmount;
+    }
+
+    private void validateRangeOfMinimumOrderAmount(BigDecimal minimumOrderAmount) {
+        if (minimumOrderAmount.compareTo(MIN_OF_MINIMUM_ORDER_AMOUNT) < 0 || (minimumOrderAmount.compareTo(MAX_OF_MINIMUM_ORDER_AMOUNT) > 0)) {
+            throw new CouponException("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
+        }
+    }
+
+    public BigDecimal getMinimumOrderAmount() {
+        return minimumOrderAmount;
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -1,14 +1,17 @@
-
 package coupon.coupon.domain;
 
 import java.time.LocalDate;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
 @Embeddable
 public class Term {
 
+    @Column(nullable = false)
     private LocalDate startAt;
+
+    @Column(nullable = false)
     private LocalDate endAt;
 
     protected Term() {

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -8,8 +8,11 @@ import coupon.coupon.CouponException;
 @Embeddable
 public class Term {
 
-    private final LocalDate startAt;
-    private final LocalDate endAt;
+    private LocalDate startAt;
+    private LocalDate endAt;
+
+    protected Term() {
+    }
 
     public Term(LocalDate startAt, LocalDate endAt) {
         validateTerm(startAt, endAt);

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -28,12 +28,4 @@ public class Term {
             throw new CouponException("종료일이 시작일보다 앞설 수 없습니다.");
         }
     }
-
-    public LocalDate getStartAt() {
-        return startAt;
-    }
-
-    public LocalDate getEndAt() {
-        return endAt;
-    }
 }

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -8,6 +8,8 @@ import coupon.coupon.CouponException;
 @Embeddable
 public class Term {
 
+    private static final String TERM_MESSAGE = "종료일이 시작일보다 앞설 수 없습니다.";
+
     @Column(nullable = false)
     private LocalDate startAt;
 
@@ -25,7 +27,7 @@ public class Term {
 
     private void validateTerm(LocalDate startAt, LocalDate endAt) {
         if (endAt.isBefore(startAt)) {
-            throw new CouponException("종료일이 시작일보다 앞설 수 없습니다.");
+            throw new CouponException(TERM_MESSAGE);
         }
     }
 }

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -2,8 +2,10 @@
 package coupon.coupon.domain;
 
 import java.time.LocalDate;
+import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
 
+@Embeddable
 public class Term {
 
     private final LocalDate startAt;
@@ -19,5 +21,13 @@ public class Term {
         if (endAt.isBefore(startAt)) {
             throw new CouponException("종료일이 시작일보다 앞설 수 없습니다.");
         }
+    }
+
+    public LocalDate getStartAt() {
+        return startAt;
+    }
+
+    public LocalDate getEndAt() {
+        return endAt;
     }
 }

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -1,0 +1,23 @@
+
+package coupon.coupon.domain;
+
+import java.time.LocalDate;
+import coupon.coupon.CouponException;
+
+public class Term {
+
+    private final LocalDate startAt;
+    private final LocalDate endAt;
+
+    public Term(LocalDate startAt, LocalDate endAt) {
+        validateTerm(startAt, endAt);
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
+
+    private void validateTerm(LocalDate startAt, LocalDate endAt) {
+        if (endAt.isBefore(startAt)) {
+            throw new CouponException("종료일이 시작일보다 앞설 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -1,6 +1,7 @@
 package coupon.coupon.domain;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
@@ -11,21 +12,25 @@ public class Term {
     private static final String TERM_MESSAGE = "종료일이 시작일보다 앞설 수 없습니다.";
 
     @Column(nullable = false)
-    private LocalDate startAt;
+    private LocalDateTime startAt;
 
     @Column(nullable = false)
-    private LocalDate endAt;
+    private LocalDateTime endAt;
 
     protected Term() {
     }
 
     public Term(LocalDate startAt, LocalDate endAt) {
+        this(startAt.atTime(0, 0, 0, 0), endAt.atTime(23, 59, 59, 999_999_000));
+    }
+
+    private Term(LocalDateTime startAt, LocalDateTime endAt) {
         validateTerm(startAt, endAt);
         this.startAt = startAt;
         this.endAt = endAt;
     }
 
-    private void validateTerm(LocalDate startAt, LocalDate endAt) {
+    private void validateTerm(LocalDateTime startAt, LocalDateTime endAt) {
         if (endAt.isBefore(startAt)) {
             throw new CouponException(TERM_MESSAGE);
         }

--- a/src/main/java/coupon/coupon/domain/Term.java
+++ b/src/main/java/coupon/coupon/domain/Term.java
@@ -2,6 +2,7 @@ package coupon.coupon.domain;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import coupon.coupon.CouponException;
@@ -9,6 +10,7 @@ import coupon.coupon.CouponException;
 @Embeddable
 public class Term {
 
+    public static final String TERM_DATE_NULL_MESSAGE = "시작 날짜와 끝 날짜를 설정해주세요";
     private static final String TERM_MESSAGE = "종료일이 시작일보다 앞설 수 없습니다.";
 
     @Column(nullable = false)
@@ -21,16 +23,19 @@ public class Term {
     }
 
     public Term(LocalDate startAt, LocalDate endAt) {
-        this(startAt.atTime(0, 0, 0, 0), endAt.atTime(23, 59, 59, 999_999_000));
-    }
-
-    private Term(LocalDateTime startAt, LocalDateTime endAt) {
+        validateNull(startAt, endAt);
         validateTerm(startAt, endAt);
-        this.startAt = startAt;
-        this.endAt = endAt;
+        this.startAt = startAt.atTime(0, 0, 0, 0);
+        this.endAt = endAt.atTime(23, 59, 59, 999_999_000);
     }
 
-    private void validateTerm(LocalDateTime startAt, LocalDateTime endAt) {
+    private void validateNull(LocalDate startAt, LocalDate endAt) {
+        if (Objects.isNull(startAt) || Objects.isNull(endAt)) {
+            throw new CouponException(TERM_DATE_NULL_MESSAGE);
+        }
+    }
+
+    private void validateTerm(LocalDate startAt, LocalDate endAt) {
         if (endAt.isBefore(startAt)) {
             throw new CouponException(TERM_MESSAGE);
         }

--- a/src/main/java/coupon/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/coupon/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package coupon.coupon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import coupon.coupon.domain.Coupon;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -21,6 +21,7 @@ public class CouponService {
         couponRepository.save(coupon);
     }
 
+    @Transactional
     public Coupon getCoupon(long id) {
         return couponRepository.findById(id)
                 .orElseThrow(() -> new CouponException("요청하신 쿠폰을 찾을 수 없어요."));

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -1,0 +1,28 @@
+package coupon.coupon.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import coupon.coupon.CouponException;
+import coupon.coupon.domain.Coupon;
+import coupon.coupon.repository.CouponRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public CouponService(CouponRepository couponRepository) {
+        this.couponRepository = couponRepository;
+    }
+
+    @Transactional
+    public void create(Coupon coupon) {
+        couponRepository.save(coupon);
+    }
+
+    public Coupon getCoupon(long id) {
+        return couponRepository.findById(id)
+                .orElseThrow(() -> new CouponException("요청하신 쿠폰을 찾을 수 없어요."));
+    }
+}

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -22,7 +22,7 @@ public class CouponService {
     }
 
     @Transactional
-    public Coupon getCoupon(long id) {
+    public Coupon getCouponByAdmin(long id) {
         return couponRepository.findById(id)
                 .orElseThrow(() -> new CouponException("요청하신 쿠폰을 찾을 수 없어요."));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
         hbm2ddl.auto: validate
         check_nullability: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     hibernate:
       naming:
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,30 @@
+create database if not exists coupon;
+use coupon;
+
+create table if not exists member
+(
+    id BIGINT AUTO_INCREMENT PRIMARY KEY
+);
+
+create table if not exists coupon
+(
+    id                   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name                 VARCHAR(30)                                              NOT NULL,
+    discount_amount      DECIMAL(10, 2)                                           NOT NULL,
+    minimum_order_amount DECIMAL(10, 2)                                           NOT NULL,
+    category             ENUM ('FASHION', 'HOME_APPLIANCES', 'FURNITURE', 'FOOD') NOT NULL,
+    start_at             TIMESTAMP                                                NOT NULL,
+    end_at               TIMESTAMP                                                NOT NULL
+);
+
+create table if not exists member_coupon
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    coupon_id  BIGINT    NOT NULL,
+    member_id  BIGINT    NOT NULL,
+    used       BOOLEAN   NOT NULL,
+    issued_at  TIMESTAMP NOT NULL,
+    expired_at TIMESTAMP NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE,
+    FOREIGN KEY (coupon_id) REFERENCES coupon (id) ON DELETE CASCADE
+);

--- a/src/test/java/coupon/CouponApplicationTests.java
+++ b/src/test/java/coupon/CouponApplicationTests.java
@@ -9,5 +9,4 @@ class CouponApplicationTests {
     @Test
     void contextLoads() {
     }
-
 }

--- a/src/test/java/coupon/coupon/domain/CouponNameTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponNameTest.java
@@ -1,27 +1,17 @@
 package coupon.coupon.domain;
 
-import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import coupon.coupon.CouponException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 
 class CouponNameTest {
 
     @DisplayName("이름이 없으면 예외가 발생한다.")
     @Test
     void cannotCreateIfNoName() {
-        // given
-        int discountAmount = 1000;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when
-        assertThatThrownBy(() -> new Coupon(null, discountAmount, minimumOrderAmount, category, startAt, endAt))
+        assertThatThrownBy(() -> new CouponName(null))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("쿠폰 이름이 누락되었습니다.");
     }
@@ -31,14 +21,9 @@ class CouponNameTest {
     void cannotCreateIfExceedLength() {
         // given
         String name = "가".repeat(31);
-        int discountAmount = 1000;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
 
         // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+        assertThatThrownBy(() -> new CouponName(name))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("쿠폰은 30자 이하의 이름을 설정해주세요.");
     }

--- a/src/test/java/coupon/coupon/domain/CouponNameTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponNameTest.java
@@ -2,6 +2,8 @@ package coupon.coupon.domain;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import coupon.coupon.CouponException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -14,6 +16,15 @@ class CouponNameTest {
         assertThatThrownBy(() -> new CouponName(null))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("쿠폰 이름이 누락되었습니다.");
+    }
+
+    @DisplayName("이름이 1자 미만이거나 공백으로만 이루어져 있으면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " "})
+    void cannotCreateIfBlank(String name) {
+        assertThatThrownBy(() -> new CouponName(name))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("쿠폰은 30자 이하의 이름을 설정해주세요.");
     }
 
     @DisplayName("이름이 30자를 초과하면 예외가 발생한다.")

--- a/src/test/java/coupon/coupon/domain/CouponNameTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponNameTest.java
@@ -1,0 +1,45 @@
+package coupon.coupon.domain;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import coupon.coupon.CouponException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CouponNameTest {
+
+    @DisplayName("이름이 없으면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfNoName() {
+        // given
+        int discountAmount = 1000;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when
+        assertThatThrownBy(() -> new Coupon(null, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("쿠폰 이름이 누락되었습니다.");
+    }
+
+    @DisplayName("이름이 30자를 초과하면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfExceedLength() {
+        // given
+        String name = "가".repeat(31);
+        int discountAmount = 1000;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("쿠폰은 30자 이하의 이름을 설정해주세요.");
+    }
+}

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -25,39 +25,6 @@ class CouponTest {
         assertThatNoException().isThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt));
     }
 
-    @DisplayName("이름이 없으면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfNoName() {
-        // given
-        int discountAmount = 1000;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when
-        assertThatThrownBy(() -> new Coupon(null, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("쿠폰 이름이 누락되었습니다.");
-    }
-
-    @DisplayName("이름이 30자를 초과하면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfExceedLength() {
-        // given
-        String name = "가".repeat(31);
-        int discountAmount = 1000;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("쿠폰은 30자 이하의 이름을 설정해주세요.");
-    }
-
     @DisplayName("할인 금액이 500원 단위가 아니면 예외가 발생한다.")
     @Test
     void cannotCreateIfWrongDiscountAmountUnit() {

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -25,40 +25,6 @@ class CouponTest {
         assertThatNoException().isThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt));
     }
 
-    @DisplayName("최소 주문 금액이 5000원 미만이면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfMinimumOrderAmountUnder() {
-        // given
-        String name = "coupon";
-        int discountAmount = 1000;
-        int minimumOrderAmount = 4500;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
-    }
-
-    @DisplayName("최소 주문 금액이 100000원 초과이면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfMinimumOrderAmountOver() {
-        // given
-        String name = "coupon";
-        int discountAmount = 1000;
-        int minimumOrderAmount = 100500;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
-    }
-
     @DisplayName("할인율이 3% 미만이면 예외가 발생한다.")
     @Test
     void cannotCreateIfDiscountRateUnder() {

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -58,4 +58,21 @@ class CouponTest {
                 .isInstanceOf(CouponException.class)
                 .hasMessage("할인율은 3% 이상, 20% 이하이어야 합니다.");
     }
+
+    @DisplayName("카테고리는 null일 수 없다.")
+    @Test
+    void cannotCreateIfCategoryNull() {
+        // given
+        String name = "coupon";
+        int discountAmount = 2500;
+        int minimumOrderAmount = 10000;
+        Category category = null;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("카테고리를 선택해주세요.");
+    }
 }

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -1,0 +1,196 @@
+package coupon.coupon.domain;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import coupon.coupon.CouponException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class CouponTest {
+
+    @DisplayName("쿠폰을 생성한다.")
+    @Test
+    void createCoupon() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 30000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatNoException().isThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt));
+    }
+
+    @DisplayName("이름이 없으면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfNoName() {
+        // given
+        int discountAmount = 1000;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when
+        assertThatThrownBy(() -> new Coupon(null, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("쿠폰 이름이 누락되었습니다.");
+    }
+
+    @DisplayName("이름이 30자를 초과하면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfExceedLength() {
+        // given
+        String name = "가".repeat(31);
+        int discountAmount = 1000;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("쿠폰은 30자 이하의 이름을 설정해주세요.");
+    }
+
+    @DisplayName("할인 금액이 500원 단위가 아니면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfWrongDiscountAmountUnit() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1100;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인 금액은 500원 단위로 설정할 수 있습니다.");
+    }
+
+    @DisplayName("할인 금액이 1000원 미만이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfDiscountAmountUnder() {
+        // given
+        String name = "coupon";
+        int discountAmount = 500;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+    }
+
+    @DisplayName("할인 금액이 10000원 초과이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfDiscountAmountOver() {
+        // given
+        String name = "coupon";
+        int discountAmount = 10500;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+    }
+
+    @DisplayName("최소 주문 금액이 5000원 미만이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfMinimumOrderAmountUnder() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 4500;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
+    }
+
+    @DisplayName("최소 주문 금액이 100000원 초과이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfMinimumOrderAmountOver() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 100500;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
+    }
+
+    @DisplayName("할인율이 3% 미만이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfDiscountRateUnder() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 50000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인율은 3% 이상, 20% 이하이어야 합니다.");
+    }
+
+    @DisplayName("할인율이 20% 초과이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfDiscountRateOver() {
+        // given
+        String name = "coupon";
+        int discountAmount = 2500;
+        int minimumOrderAmount = 10000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인율은 3% 이상, 20% 이하이어야 합니다.");
+    }
+
+    @DisplayName("종료일이 시작일보다 이전이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfEndIsBeforeStart() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 30000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().minusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("종료일이 시작일보다 앞설 수 없습니다.");
+    }
+}

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -64,7 +64,7 @@ class CouponTest {
     void cannotCreateIfCategoryNull() {
         // given
         String name = "coupon";
-        int discountAmount = 2500;
+        int discountAmount = 2000;
         int minimumOrderAmount = 10000;
         Category category = null;
         LocalDate startAt = LocalDate.now();

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -25,57 +25,6 @@ class CouponTest {
         assertThatNoException().isThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt));
     }
 
-    @DisplayName("할인 금액이 500원 단위가 아니면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfWrongDiscountAmountUnit() {
-        // given
-        String name = "coupon";
-        int discountAmount = 1100;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("할인 금액은 500원 단위로 설정할 수 있습니다.");
-    }
-
-    @DisplayName("할인 금액이 1000원 미만이면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfDiscountAmountUnder() {
-        // given
-        String name = "coupon";
-        int discountAmount = 500;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
-    }
-
-    @DisplayName("할인 금액이 10000원 초과이면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfDiscountAmountOver() {
-        // given
-        String name = "coupon";
-        int discountAmount = 10500;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
-    }
-
     @DisplayName("최소 주문 금액이 5000원 미만이면 예외가 발생한다.")
     @Test
     void cannotCreateIfMinimumOrderAmountUnder() {

--- a/src/test/java/coupon/coupon/domain/CouponTest.java
+++ b/src/test/java/coupon/coupon/domain/CouponTest.java
@@ -58,21 +58,4 @@ class CouponTest {
                 .isInstanceOf(CouponException.class)
                 .hasMessage("할인율은 3% 이상, 20% 이하이어야 합니다.");
     }
-
-    @DisplayName("종료일이 시작일보다 이전이면 예외가 발생한다.")
-    @Test
-    void cannotCreateIfEndIsBeforeStart() {
-        // given
-        String name = "coupon";
-        int discountAmount = 1000;
-        int minimumOrderAmount = 30000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().minusDays(1);
-
-        // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
-                .isInstanceOf(CouponException.class)
-                .hasMessage("종료일이 시작일보다 앞설 수 없습니다.");
-    }
 }

--- a/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
@@ -1,9 +1,11 @@
 package coupon.coupon.domain;
 
+import java.math.BigDecimal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import coupon.coupon.CouponException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class DiscountAmountTest {
@@ -42,5 +44,19 @@ class DiscountAmountTest {
         assertThatThrownBy(() -> new DiscountAmount(discountAmount))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+    }
+
+    @DisplayName("주어진 금액에 대한 할인 금액의 비율을 계산한다.")
+    @Test
+    void getDiscountRate(){
+        // given
+        DiscountAmount discountAmount = new DiscountAmount(2500);
+        MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount(10000);
+
+        // when
+        BigDecimal discountRate = discountAmount.getDiscountRate(minimumOrderAmount);
+
+        //then
+        assertThat(discountRate.intValue()).isEqualTo(25);
     }
 }

--- a/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
@@ -1,0 +1,62 @@
+package coupon.coupon.domain;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import coupon.coupon.CouponException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class DiscountAmountTest {
+
+    @DisplayName("할인 금액이 500원 단위가 아니면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfWrongDiscountAmountUnit() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1100;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인 금액은 500원 단위로 설정할 수 있습니다.");
+    }
+
+    @DisplayName("할인 금액이 1000원 미만이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfDiscountAmountUnder() {
+        // given
+        String name = "coupon";
+        int discountAmount = 500;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+    }
+
+    @DisplayName("할인 금액이 10000원 초과이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfDiscountAmountOver() {
+        // given
+        String name = "coupon";
+        int discountAmount = 10500;
+        int minimumOrderAmount = 5000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
+    }
+}

--- a/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
@@ -48,7 +48,7 @@ class DiscountAmountTest {
 
     @DisplayName("주어진 금액에 대한 할인 금액의 비율을 계산한다.")
     @Test
-    void getDiscountRate(){
+    void getDiscountRate() {
         // given
         DiscountAmount discountAmount = new DiscountAmount(2500);
         MinimumOrderAmount minimumOrderAmount = new MinimumOrderAmount(10000);

--- a/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/DiscountAmountTest.java
@@ -1,6 +1,5 @@
 package coupon.coupon.domain;
 
-import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import coupon.coupon.CouponException;
@@ -13,15 +12,10 @@ class DiscountAmountTest {
     @Test
     void cannotCreateIfWrongDiscountAmountUnit() {
         // given
-        String name = "coupon";
         int discountAmount = 1100;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
 
         // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+        assertThatThrownBy(() -> new DiscountAmount(discountAmount))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("할인 금액은 500원 단위로 설정할 수 있습니다.");
     }
@@ -30,15 +24,10 @@ class DiscountAmountTest {
     @Test
     void cannotCreateIfDiscountAmountUnder() {
         // given
-        String name = "coupon";
         int discountAmount = 500;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
 
         // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+        assertThatThrownBy(() -> new DiscountAmount(discountAmount))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
     }
@@ -47,15 +36,10 @@ class DiscountAmountTest {
     @Test
     void cannotCreateIfDiscountAmountOver() {
         // given
-        String name = "coupon";
         int discountAmount = 10500;
-        int minimumOrderAmount = 5000;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
 
         // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+        assertThatThrownBy(() -> new DiscountAmount(discountAmount))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("할인 금액은 1000원 이상, 10000원 이하이어야 합니다.");
     }

--- a/src/test/java/coupon/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/coupon/domain/MemberCouponTest.java
@@ -1,0 +1,25 @@
+package coupon.coupon.domain;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class MemberCouponTest {
+
+    @DisplayName("쿠폰 발급 일시로 만료 일시를 구한다.")
+    @Test
+    void calculateExpiredAt() {
+        // given
+        Coupon coupon = new Coupon("name", 1000, 30000, Category.FASHION, LocalDate.now(), LocalDate.now()
+                .plusDays(10));
+        Member member = new Member();
+
+        // when
+        MemberCoupon memberCoupon = new MemberCoupon(coupon, member);
+
+        //then
+        assertThat(memberCoupon.getIssuedAt().plusDays(7)).isBeforeOrEqualTo(memberCoupon.getExpiredAt());
+    }
+}

--- a/src/test/java/coupon/coupon/domain/MinimumOrderAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/MinimumOrderAmountTest.java
@@ -1,0 +1,45 @@
+package coupon.coupon.domain;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import coupon.coupon.CouponException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class MinimumOrderAmountTest {
+
+    @DisplayName("최소 주문 금액이 5000원 미만이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfMinimumOrderAmountUnder() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 4500;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
+    }
+
+    @DisplayName("최소 주문 금액이 100000원 초과이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfMinimumOrderAmountOver() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 100500;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
+    }
+}

--- a/src/test/java/coupon/coupon/domain/MinimumOrderAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/MinimumOrderAmountTest.java
@@ -12,7 +12,7 @@ class MinimumOrderAmountTest {
     @Test
     void cannotCreateIfMinimumOrderAmountUnder() {
         // given
-        int minimumOrderAmount = 4500;
+        int minimumOrderAmount = 4990;
 
         // when & then
         assertThatThrownBy(() -> new MinimumOrderAmount(minimumOrderAmount))
@@ -24,7 +24,7 @@ class MinimumOrderAmountTest {
     @Test
     void cannotCreateIfMinimumOrderAmountOver() {
         // given
-        int minimumOrderAmount = 100500;
+        int minimumOrderAmount = 100010;
 
         // when & then
         assertThatThrownBy(() -> new MinimumOrderAmount(minimumOrderAmount))

--- a/src/test/java/coupon/coupon/domain/MinimumOrderAmountTest.java
+++ b/src/test/java/coupon/coupon/domain/MinimumOrderAmountTest.java
@@ -1,6 +1,5 @@
 package coupon.coupon.domain;
 
-import java.time.LocalDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import coupon.coupon.CouponException;
@@ -13,15 +12,10 @@ class MinimumOrderAmountTest {
     @Test
     void cannotCreateIfMinimumOrderAmountUnder() {
         // given
-        String name = "coupon";
-        int discountAmount = 1000;
         int minimumOrderAmount = 4500;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
 
         // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+        assertThatThrownBy(() -> new MinimumOrderAmount(minimumOrderAmount))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
     }
@@ -30,15 +24,10 @@ class MinimumOrderAmountTest {
     @Test
     void cannotCreateIfMinimumOrderAmountOver() {
         // given
-        String name = "coupon";
-        int discountAmount = 1000;
         int minimumOrderAmount = 100500;
-        Category category = Category.FASHION;
-        LocalDate startAt = LocalDate.now();
-        LocalDate endAt = LocalDate.now().plusDays(1);
 
         // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt))
+        assertThatThrownBy(() -> new MinimumOrderAmount(minimumOrderAmount))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("최소 주문 금액은 5000원 이상, 100000원 이하이어야 합니다.");
     }

--- a/src/test/java/coupon/coupon/domain/TermTest.java
+++ b/src/test/java/coupon/coupon/domain/TermTest.java
@@ -1,11 +1,13 @@
 package coupon.coupon.domain;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import coupon.coupon.CouponException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 class TermTest {
 
@@ -20,5 +22,20 @@ class TermTest {
         assertThatThrownBy(() -> new Term(startAt, endAt))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("종료일이 시작일보다 앞설 수 없습니다.");
+    }
+
+    @DisplayName("시작일과 종료일의 시간은 각각 00:00:00.000 및 23:59:59.999로 설정된다.")
+    @Test
+    void termStartAndEndTimeAreSetProperly() {
+        // given
+        LocalDate startAt = LocalDate.of(2024, 10, 1);
+        LocalDate endAt = LocalDate.of(2024, 10, 2);
+
+        // when
+        Term term = new Term(startAt, endAt);
+
+        // then
+        assertThat(term).extracting("startAt").isEqualTo(LocalDateTime.of(2024, 10, 1, 0, 0, 0, 0));
+        assertThat(term).extracting("endAt").isEqualTo(LocalDateTime.of(2024, 10, 2, 23, 59, 59, 999_999_000));
     }
 }

--- a/src/test/java/coupon/coupon/domain/TermTest.java
+++ b/src/test/java/coupon/coupon/domain/TermTest.java
@@ -1,0 +1,27 @@
+package coupon.coupon.domain;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import coupon.coupon.CouponException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class TermTest {
+
+    @DisplayName("종료일이 시작일보다 이전이면 예외가 발생한다.")
+    @Test
+    void cannotCreateIfEndIsBeforeStart() {
+        // given
+        String name = "coupon";
+        int discountAmount = 1000;
+        int minimumOrderAmount = 30000;
+        Category category = Category.FASHION;
+        LocalDate startAt = LocalDate.now();
+        LocalDate endAt = LocalDate.now().minusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt)).isInstanceOf(CouponException.class)
+                .hasMessage("종료일이 시작일보다 앞설 수 없습니다.");
+    }
+}

--- a/src/test/java/coupon/coupon/domain/TermTest.java
+++ b/src/test/java/coupon/coupon/domain/TermTest.java
@@ -38,4 +38,30 @@ class TermTest {
         assertThat(term).extracting("startAt").isEqualTo(LocalDateTime.of(2024, 10, 1, 0, 0, 0, 0));
         assertThat(term).extracting("endAt").isEqualTo(LocalDateTime.of(2024, 10, 2, 23, 59, 59, 999_999_000));
     }
+
+    @DisplayName("시작일이 null일 경우 예외가 발생한다.")
+    @Test
+    void cannotCreateIfStartIsNull() {
+        // given
+        LocalDate startAt = null;
+        LocalDate endAt = LocalDate.of(2024, 10, 2);
+
+        // when & then
+        assertThatThrownBy(() -> new Term(startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("시작 날짜와 끝 날짜를 설정해주세요");
+    }
+
+    @DisplayName("종료일이 null일 경우 예외가 발생한다.")
+    @Test
+    void cannotCreateIfEndIsNull() {
+        // given
+        LocalDate startAt = null;
+        LocalDate endAt = LocalDate.of(2024, 10, 1);
+
+        // when & then
+        assertThatThrownBy(() -> new Term(startAt, endAt))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("시작 날짜와 끝 날짜를 설정해주세요");
+    }
 }

--- a/src/test/java/coupon/coupon/domain/TermTest.java
+++ b/src/test/java/coupon/coupon/domain/TermTest.java
@@ -13,15 +13,12 @@ class TermTest {
     @Test
     void cannotCreateIfEndIsBeforeStart() {
         // given
-        String name = "coupon";
-        int discountAmount = 1000;
-        int minimumOrderAmount = 30000;
-        Category category = Category.FASHION;
         LocalDate startAt = LocalDate.now();
         LocalDate endAt = LocalDate.now().minusDays(1);
 
         // when & then
-        assertThatThrownBy(() -> new Coupon(name, discountAmount, minimumOrderAmount, category, startAt, endAt)).isInstanceOf(CouponException.class)
+        assertThatThrownBy(() -> new Term(startAt, endAt))
+                .isInstanceOf(CouponException.class)
                 .hasMessage("종료일이 시작일보다 앞설 수 없습니다.");
     }
 }

--- a/src/test/java/coupon/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/coupon/service/CouponServiceTest.java
@@ -38,7 +38,7 @@ public class CouponServiceTest {
         couponService.create(coupon);
 
         // then
-        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+        Coupon savedCoupon = couponService.getCouponByAdmin(coupon.getId());
         assertThat(savedCoupon).isNotNull();
     }
 
@@ -49,7 +49,7 @@ public class CouponServiceTest {
         long notExistCouponId = 0;
 
         // when & then
-        assertThatThrownBy(() -> couponService.getCoupon(notExistCouponId))
+        assertThatThrownBy(() -> couponService.getCouponByAdmin(notExistCouponId))
                 .isInstanceOf(CouponException.class)
                 .hasMessage("요청하신 쿠폰을 찾을 수 없어요.");
     }

--- a/src/test/java/coupon/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/coupon/service/CouponServiceTest.java
@@ -1,0 +1,78 @@
+package coupon.coupon.service;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import coupon.coupon.CouponException;
+import coupon.coupon.domain.Category;
+import coupon.coupon.domain.Coupon;
+import coupon.coupon.repository.CouponRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+public class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Disabled
+    @DisplayName("요청한 쿠폰을 조회한다.")
+    @Test
+    void getCoupon() {
+        // given
+        Coupon coupon = new Coupon(
+                "linirini",
+                1000,
+                10000,
+                Category.FASHION,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7));
+
+        // when
+        couponService.create(coupon);
+
+        // then
+        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+        assertThat(savedCoupon).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 쿠폰을 조회하면 예외가 발생한다.")
+    void cannotGetCoupon() {
+        // given
+        long notExistCouponId = 0;
+
+        // when & then
+        assertThatThrownBy(() -> couponService.getCoupon(notExistCouponId))
+                .isInstanceOf(CouponException.class)
+                .hasMessage("요청하신 쿠폰을 찾을 수 없어요.");
+    }
+
+    @Test
+    @DisplayName("쿠폰을 생성한다.")
+    void createCoupon() {
+        // given
+        Coupon coupon = new Coupon(
+                "linirini",
+                1000,
+                10000,
+                Category.FASHION,
+                LocalDate.now(),
+                LocalDate.now().plusDays(7));
+
+        // when
+        couponService.create(coupon);
+
+        // then
+        assertThat(couponRepository.findById(coupon.getId())).isNotNull();
+    }
+}
+

--- a/src/test/java/coupon/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/coupon/service/CouponServiceTest.java
@@ -1,7 +1,6 @@
 package coupon.coupon.service;
 
 import java.time.LocalDate;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +22,6 @@ public class CouponServiceTest {
     @Autowired
     private CouponRepository couponRepository;
 
-    @Disabled
     @DisplayName("요청한 쿠폰을 조회한다.")
     @Test
     void getCoupon() {


### PR DESCRIPTION
안녕하세요, 프린! 
저는 토미의 강의가 없었으면 복제 지연 해결 방안을 고민하는 흐름을 잡는 것도 어려웠을 것 같은데요, 프린은 어떠셨나요? 🥲

저는 Writer DB로 바로 쿠폰을 조회하는 방법으로 복제 지연을 해결해보려고 했는데요, 아래는 제가 고민했던 방안들과 선택의 이유를 정리해보았어요!
물론 실제 사용자의 데이터를 기반으로 판단해야할 부분이지만, 우선은 (감히) 개인적인 생각으로 다음을 기준으로 여러가지 방법을 따져봤습니다.

1. 반동기 복제 방식
    반동기 복제를 사용하여 적어도 하나의 Reader DB로부터 데이터를 성공적으로 수신했을 때에만 응답을 반환하도록 하여 복제 지연을 줄일 수 있습니다. 하지만 이로 인해 쓰기 성능이 떨어질 수 있습니다. 또한, Reader DB가 많다면 적어도 하나의 서버로부터 데이터를 성공적으로 수신한 것을 기준으로 판단한다는 부분에서 확장성을 고려한다면 좋은 해결 방법은 아닙니다.
    
2. 읽기 지연    
    조회 시점에 데이터가 즉시 확인되지 않으면, 일정 시간 후에 다시 조회합니다.     
    관리자가 쿠폰을 생성하고 replica 지연 시간 내에 쿠폰을 확인하지 못하는 불편함은 관리자에게 적절한 안내 메세지만 주어진다면 감수할 수 있는 부분이라고 생각했습니다.    
    하지만, 지연 시간을 고려할 때 우리가 통제할 수 없는 외부 요인도 있기 때문에 정확한 지연시간을 구할 수 없어서 좋은 해결책은 아니라고 생각했습니다.
    
3. read DB에서 못 찾으면 write DB에서 조회    
    복제 지연으로 인해 read DB에서 데이터를 찾을 수 없는 경우, write DB로 직접 조회합니다. 이 방식이 가장 정확한 데이터를 가져올 수 있는 방법이라고 생각합니다. 하지만, 복제 지연이 빈번하게 발생할 경우 write DB에 부하가 집중될 수 있습니다. 하지만, 관리자를 사용하는 사람은 일반적인 사용자보다 적으므로, 조회 빈도가 역시 상대적 적을 것이라고 생각했을 때 다른 방법들 중 가장 나은 차선책이라고 생각했습니다. 
    
4. 바로 write DB에서 조회   
    어드민은 일반 사용자보다 적어 조회 빈도가 적을 뿐만 아니라, 쿠폰을 생성하고 바로 조회하는 경우 상대적으로 적을 것이라고 생각합니다. 따라서, 3번 방법에서 더 나아가 Read를 거칠 필요 없이 Write를 바로 조회하여 데이터베이스 접근 횟수를 줄여볼 수 있다고 생각합니다.
    
5. 레디스를 통한 캐싱 후 조회    
    Disk 까지 접근하지 않아도 Memory 기반 데이터들에서 빠르게 데이터를 조회할 수 있습니다. 하지만 비용적인 측면을 감수할 정도로 빠르게 데이터를 읽거나 트래픽이 몰려 부분은 아니라고 생각했습다.

위와 같은 근거로 고민해보았을 때, 저는 4번 방법으로 구현했습니다.

(마지막 커밋 메세지를 잘못 올렸어요 ㅜㅜ 마지막 커밋이 `복제 지연 해결` 관련 커밋입니다! 죄송합니다..ㅜ)
리뷰 잘 부탁드립니다🙇‍♀️