### PR TITLE
[1단계 - DB 복제와 캐시] 카피(김상혁) 미션 제출합니다.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         ipv4_address: 172.20.0.10
     volumes:
       - ./data/writer:/var/lib/mysql
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_writer
     restart: always
     environment:
@@ -30,6 +31,7 @@ services:
         ipv4_address: 172.20.0.11
     volumes:
       - ./data/reader:/var/lib/mysql
+      - ./init/init.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_reader
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -9,7 +9,7 @@ CREATE TABLE Coupon
     minimumOrderAmount INT         NOT NULL,
     discountAmount     INT         NOT NULL,
     discountRate       INT         NOT NULL,
-    category           VARCHAR(255),
+    category           VARCHAR(30),
     issueStartDate     DATETIME,
     issueEndDate       DATETIME
 );

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,0 +1,16 @@
+create DATABASE IF NOT EXISTS coupon;
+
+use coupon;
+
+CREATE TABLE Coupon
+(
+    id                 BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name               VARCHAR(30) NOT NULL,
+    minimumOrderAmount INT         NOT NULL,
+    discountAmount     INT         NOT NULL,
+    discountRate       INT         NOT NULL,
+    category           VARCHAR(255),
+    issueStartDate     DATETIME,
+    issueEndDate       DATETIME
+);
+

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -34,13 +34,18 @@ public class DataSourceConfig {
         DataSource writeDataSource = writerDataSource();
         DataSource readDataSource = readerDataSource();
 
-        Map<Object, Object> dataSourceMap = new HashMap<>();
-        dataSourceMap.put(DataSourceType.WRITER, writeDataSource);
-        dataSourceMap.put(DataSourceType.READER, readDataSource);
+        Map<Object, Object> dataSourceMap = initializeDataSource(writeDataSource, readDataSource);
         dataSourceRouter.setTargetDataSources(dataSourceMap);
         dataSourceRouter.setDefaultTargetDataSource(writeDataSource);
 
         return dataSourceRouter;
+    }
+
+    private Map<Object, Object> initializeDataSource(DataSource writeDataSource, DataSource readDataSource) {
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(DataSourceType.WRITER, writeDataSource);
+        dataSourceMap.put(DataSourceType.READER, readDataSource);
+        return dataSourceMap;
     }
 
     @Bean

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -1,0 +1,52 @@
+package coupon.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @DependsOn({"writerDataSource", "readerDataSource"})
+    public DataSource routeDataSource() {
+        ReadOnlyDataSourceRouter dataSourceRouter = new ReadOnlyDataSourceRouter();
+        DataSource writeDataSource = writerDataSource();
+        DataSource readDataSource = readerDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put(DataSourceType.WRITER, writeDataSource);
+        dataSourceMap.put(DataSourceType.READER, readDataSource);
+        dataSourceRouter.setTargetDataSources(dataSourceMap);
+        dataSourceRouter.setDefaultTargetDataSource(writeDataSource);
+
+        return dataSourceRouter;
+    }
+
+    @Bean
+    @Primary
+    @DependsOn({"routeDataSource"})
+    public DataSource dataSource() {
+        return new LazyConnectionDataSourceProxy(routeDataSource());
+    }
+}

--- a/src/main/java/coupon/config/DataSourceType.java
+++ b/src/main/java/coupon/config/DataSourceType.java
@@ -1,0 +1,6 @@
+package coupon.config;
+
+public enum DataSourceType {
+    READER,
+    WRITER
+}

--- a/src/main/java/coupon/config/ReadOnlyDataSourceRouter.java
+++ b/src/main/java/coupon/config/ReadOnlyDataSourceRouter.java
@@ -1,0 +1,15 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReadOnlyDataSourceRouter extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return DataSourceType.READER;
+        }
+        return DataSourceType.WRITER;
+    }
+}

--- a/src/main/java/coupon/domain/Category.java
+++ b/src/main/java/coupon/domain/Category.java
@@ -1,0 +1,8 @@
+package coupon.domain;
+
+public enum Category {
+    FASHION,
+    ELECTRONICS,
+    FURNITURE,
+    FOOD
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -18,6 +18,16 @@ import java.util.Objects;
 @Entity
 public class Coupon {
 
+    private static final int MAX_COUPON_NAME = 30;
+    private static final int MIN_ORDER_AMOUNT = 5000;
+    private static final int MAX_ORDER_AMOUNT = 100000;
+    private static final int MIN_DISCOUNT_AMOUNT = 1000;
+    private static final int MAX_DISCOUNT_AMOUNT = 10000;
+    private static final int DISCOUNT_AMOUNT_UNIT = 500;
+    private static final int MIN_DISCOUNT_RATE = 3;
+    private static final int MAX_DISCOUNT_RATE = 20;
+    private static final int PERCENT_FACTOR = 100;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -59,22 +69,22 @@ public class Coupon {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("쿠폰 이름은 필수입니다.");
         }
-        if (name.length() > 30) {
+        if (name.length() > MAX_COUPON_NAME) {
             throw new IllegalArgumentException("쿠폰 이름은 30자 이하여야 합니다.");
         }
     }
 
     private void validateMinimumOrderAmount(int minimumOrderAmount) {
-        if (minimumOrderAmount < 5000 || minimumOrderAmount > 100000) {
+        if (minimumOrderAmount < MIN_ORDER_AMOUNT || minimumOrderAmount > MAX_ORDER_AMOUNT) {
             throw new IllegalArgumentException("최소 주문 금액은 5,000원 이상, 100,000원 이하여야 합니다.");
         }
     }
 
     private void validateDiscountAmount(int discountAmount) {
-        if (discountAmount < 1000 || discountAmount > 10000) {
+        if (discountAmount < MIN_DISCOUNT_AMOUNT || discountAmount > MAX_DISCOUNT_AMOUNT) {
             throw new IllegalArgumentException("할인 금액은 1,000원 이상, 10,000원 이하여야 합니다.");
         }
-        if (discountAmount % 500 != 0) {
+        if (discountAmount % DISCOUNT_AMOUNT_UNIT != 0) {
             throw new IllegalArgumentException("할인 금액은 500원 단위로 설정해야 합니다.");
         }
     }
@@ -82,13 +92,13 @@ public class Coupon {
 
     private void validateDiscountRate(int discountAmount, int minimumOrderAmount) {
         int discountRate = calculateDiscountRate(discountAmount, minimumOrderAmount);
-        if (discountRate < 3 || discountRate > 20) {
+        if (discountRate < MIN_DISCOUNT_RATE || discountRate > MAX_DISCOUNT_RATE) {
             throw new IllegalArgumentException("할인율은 3% 이상, 20% 이하여야 합니다.");
         }
     }
 
     private int calculateDiscountRate(int discountAmount, int minimumOrderAmount) {
-        return (discountAmount * 100) / minimumOrderAmount;
+        return (discountAmount * PERCENT_FACTOR) / minimumOrderAmount;
     }
 
     private void validateIssuePeriod(LocalDateTime issueStartDate, LocalDateTime issueEndDate) {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,0 +1,119 @@
+package coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 30)
+    private String name;
+
+    private int minimumOrderAmount;
+
+    private int discountAmount;
+
+    private int discountRate;
+
+    @Enumerated(value = EnumType.STRING)
+    private Category category;
+
+    private LocalDateTime issueStartDate;
+
+    private LocalDateTime issueEndDate;
+
+    public Coupon(String name, int minimumOrderAmount, int discountAmount, Category category,
+                  LocalDateTime issueStartDate, LocalDateTime issueEndDate) {
+        validateName(name);
+        validateMinimumOrderAmount(minimumOrderAmount);
+        validateDiscountAmount(discountAmount);
+        validateDiscountRate(discountAmount, minimumOrderAmount);
+        validateIssuePeriod(issueStartDate, issueEndDate);
+
+        this.name = name;
+        this.minimumOrderAmount = minimumOrderAmount;
+        this.discountAmount = discountAmount;
+        this.discountRate = calculateDiscountRate(discountAmount, minimumOrderAmount);
+        this.category = category;
+        this.issueStartDate = issueStartDate;
+        this.issueEndDate = issueEndDate;
+    }
+
+    private void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("쿠폰 이름은 필수입니다.");
+        }
+        if (name.length() > 30) {
+            throw new IllegalArgumentException("쿠폰 이름은 30자 이하여야 합니다.");
+        }
+    }
+
+    private void validateMinimumOrderAmount(int minimumOrderAmount) {
+        if (minimumOrderAmount < 5000 || minimumOrderAmount > 100000) {
+            throw new IllegalArgumentException("최소 주문 금액은 5,000원 이상, 100,000원 이하여야 합니다.");
+        }
+    }
+
+    private void validateDiscountAmount(int discountAmount) {
+        if (discountAmount < 1000 || discountAmount > 10000) {
+            throw new IllegalArgumentException("할인 금액은 1,000원 이상, 10,000원 이하여야 합니다.");
+        }
+        if (discountAmount % 500 != 0) {
+            throw new IllegalArgumentException("할인 금액은 500원 단위로 설정해야 합니다.");
+        }
+    }
+
+
+    private void validateDiscountRate(int discountAmount, int minimumOrderAmount) {
+        int discountRate = calculateDiscountRate(discountAmount, minimumOrderAmount);
+        if (discountRate < 3 || discountRate > 20) {
+            throw new IllegalArgumentException("할인율은 3% 이상, 20% 이하여야 합니다.");
+        }
+    }
+
+    private int calculateDiscountRate(int discountAmount, int minimumOrderAmount) {
+        return (discountAmount * 100) / minimumOrderAmount;
+    }
+
+    private void validateIssuePeriod(LocalDateTime issueStartDate, LocalDateTime issueEndDate) {
+        if (issueStartDate == null || issueEndDate == null) {
+            throw new IllegalArgumentException("발급 기간의 시작일과 종료일은 필수입니다.");
+        }
+        if (!issueStartDate.isBefore(issueEndDate) && !issueStartDate.isEqual(issueEndDate)) {
+            throw new IllegalArgumentException("발급 시작일은 종료일보다 이전이어야 합니다.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Coupon coupon = (Coupon) o;
+        return Objects.equals(id, coupon.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/coupon/dto/CouponRequest.java
+++ b/src/main/java/coupon/dto/CouponRequest.java
@@ -1,0 +1,7 @@
+package coupon.dto;
+
+import java.time.LocalDateTime;
+
+public record CouponRequest(String name, int minimumOrderAmount, int discountAmount,
+                            String category, LocalDateTime issueStartDate, LocalDateTime issueEndDate) {
+}

--- a/src/main/java/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+import coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/coupon/service/CouponCommandService.java
+++ b/src/main/java/coupon/service/CouponCommandService.java
@@ -1,0 +1,29 @@
+package coupon.service;
+
+import coupon.domain.Category;
+import coupon.domain.Coupon;
+import coupon.dto.CouponRequest;
+import coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class CouponCommandService {
+
+    private final CouponRepository couponRepository;
+
+    public Long create(CouponRequest request) {
+        Coupon coupon = new Coupon(request.name(), request.minimumOrderAmount(), request.discountAmount(),
+                Category.valueOf(request.category()),
+                request.issueStartDate(), request.issueEndDate());
+        return couponRepository.save(coupon).getId();
+    }
+
+    public Coupon getCoupon(Long id) {
+        return couponRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID(" + id + ")의 쿠폰을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/coupon/service/CouponQueryService.java
+++ b/src/main/java/coupon/service/CouponQueryService.java
@@ -1,0 +1,20 @@
+package coupon.service;
+
+import coupon.domain.Coupon;
+import coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class CouponQueryService {
+
+    private final CouponRepository couponRepository;
+
+    public Coupon getCoupon(Long id) {
+        return couponRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID(" + id + ")의 쿠폰을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,30 @@
+package coupon.service;
+
+import coupon.domain.Category;
+import coupon.domain.Coupon;
+import coupon.dto.CouponRequest;
+import coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public Long create(CouponRequest request) {
+        Coupon coupon = new Coupon(request.name(), request.minimumOrderAmount(), request.discountAmount(),
+                Category.valueOf(request.category()),
+                request.issueStartDate(), request.issueEndDate());
+        return couponRepository.save(coupon).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(Long id) {
+        return couponRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID(" + id + ")의 쿠폰을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,30 +1,26 @@
 package coupon.service;
 
-import coupon.domain.Category;
 import coupon.domain.Coupon;
 import coupon.dto.CouponRequest;
-import coupon.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class CouponService {
 
-    private final CouponRepository couponRepository;
+    private final CouponCommandService couponCommandService;
+    private final CouponQueryService couponQueryService;
 
-    @Transactional
     public Long create(CouponRequest request) {
-        Coupon coupon = new Coupon(request.name(), request.minimumOrderAmount(), request.discountAmount(),
-                Category.valueOf(request.category()),
-                request.issueStartDate(), request.issueEndDate());
-        return couponRepository.save(coupon).getId();
+        return couponCommandService.create(request);
     }
 
-    @Transactional(readOnly = true)
     public Coupon getCoupon(Long id) {
-        return couponRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 ID(" + id + ")의 쿠폰을 찾을 수 없습니다."));
+        try {
+            return couponQueryService.getCoupon(id);
+        } catch (IllegalArgumentException e) {
+            return couponCommandService.getCoupon(id);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,6 @@ spring:
     hibernate:
       naming:
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
@@ -12,7 +11,7 @@ spring:
         format_sql: true
         show_sql: false
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/test/java/coupon/service/CouponCommandServiceTest.java
+++ b/src/test/java/coupon/service/CouponCommandServiceTest.java
@@ -1,0 +1,50 @@
+package coupon.service;
+
+import coupon.domain.Category;
+import coupon.domain.Coupon;
+import coupon.dto.CouponRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CouponCommandServiceTest {
+
+    @Autowired
+    private CouponCommandService couponCommandService;
+
+    @DisplayName("쿠폰 생성 성공")
+    @Test
+    void coupon_create() {
+        //given
+        CouponRequest request = new CouponRequest("쿠폰", 5000, 1000,
+                Category.FOOD.name(), LocalDateTime.now(), LocalDateTime.now().plusWeeks(1));
+
+        //when
+        Long couponId = couponCommandService.create(request);
+
+        //then
+        assertThat(couponId).isNotNull();
+    }
+
+    @DisplayName("쿠폰 조회 성공")
+    @Test
+    void coupon_select() {
+        //given
+        CouponRequest request = new CouponRequest("쿠폰", 5000, 1000,
+                Category.FOOD.name(), LocalDateTime.now(), LocalDateTime.now().plusWeeks(1));
+        Long couponId = couponCommandService.create(request);
+
+        //when
+        Long findCouponId = couponCommandService.getCoupon(couponId).getId();
+
+        //then
+        assertThat(couponId).isEqualTo(findCouponId);
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -3,6 +3,7 @@ package coupon.service;
 import coupon.domain.Category;
 import coupon.domain.Coupon;
 import coupon.dto.CouponRequest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +18,7 @@ public class CouponServiceTest {
     @Autowired
     private CouponService couponService;
 
+    @DisplayName("쿠폰 조회 시 복제 지연 발생을 방지")
     @Test
     void coupon_replica_delay() {
         //given

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,33 @@
+package coupon.service;
+
+import coupon.domain.Category;
+import coupon.domain.Coupon;
+import coupon.dto.CouponRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Test
+    void coupon_replica_delay() {
+        //given
+        CouponRequest request = new CouponRequest("쿠폰", 5000, 1000,
+                Category.FOOD.name(), LocalDateTime.now(), LocalDateTime.now().plusWeeks(1));
+
+        //when
+        Long couponId = couponService.create(request);
+        Coupon savedCoupon = couponService.getCoupon(couponId);
+
+        //then
+        assertThat(savedCoupon).isNotNull();
+    }
+}


### PR DESCRIPTION
안녕하세요 초코칩!
잘 부탁드립니다~

복제 지연 해결방법에 대해 고민하면서 생각했던 것들에 대해 적어봤어요.
리뷰하실 때 참고 부탁드립니다!

### 1. 비동기를 동기방식으로 바꾼다
- 항상 소스 서버와 리플리카 서버의 데이터가 같다는 것이 보장되기 때문에 복제 지연을 방지할 수 있다.
- 소스 서버에 기록하는 것과 리플리카 서버로 복제하는 것이 하나의 작업으로 처리된다면 성능저하가 발생한다.
- 모든 작업이 데이터의 일관성이 중요한 것은 아니기 때문에 해당 방법은 단점이 클 것이라 판단했다.

### 2. 비동기를 반동기방식으로 바꾼다.
- 리플리카 서버의 릴레이 로그까지 적는 작업까지 하나의 트랜잭션으로 처리한다.
- 리플리카 서버로 데이터가 적혔다는 것은 보장할 수 있지만, 복제 지연을 완벽하게 방지하는 것은 아니다.
- 결국 비동기에 비해 처리 속도가 느리고, 복제 지연을 완벽히 막지 않기 때문에 적용하지 않았다.

### 3. 코드 상에서 리플리카 서버에 데이터가 없는 경우 소스 서버에 다시 조회하도록 한다.
- 복제 지연 발생 시 트랜잭션을 한번 더 시작하여 쿼리를 보내야한다는 단점이 있지만 복제 지연 발생을 완벽히 막을 수 있다는 장점이 있고 원하는 곳에 적용할 수 있어 선택하였다.