### PR TITLE
[1단계 - DB 복제와 캐시] 알파카(최휘용) 미션 제출합니다.

### DIFF
--- a/src/main/java/coupon/DataSourceConfig.java
+++ b/src/main/java/coupon/DataSourceConfig.java
@@ -1,7 +1,6 @@
 package coupon;
 
 import com.zaxxer.hikari.HikariDataSource;
-import jakarta.persistence.EntityManagerFactory;
 import java.util.HashMap;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -13,8 +12,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
-import org.springframework.orm.jpa.JpaTransactionManager;
-import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
 public class DataSourceConfig {
@@ -57,12 +54,5 @@ public class DataSourceConfig {
     @Bean
     public DataSource dataSource(DataSource routingDataSource) {
         return new LazyConnectionDataSourceProxy(routingDataSource);
-    }
-
-    @Bean
-    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
-        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
-        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory);
-        return jpaTransactionManager;
     }
 }

--- a/src/main/java/coupon/DataSourceConfig.java
+++ b/src/main/java/coupon/DataSourceConfig.java
@@ -1,0 +1,68 @@
+package coupon;
+
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class DataSourceConfig {
+
+    public static final String READER = "reader";
+    public static final String WRITER = "writer";
+
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    @Bean
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    @Bean
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @DependsOn({"writerDataSource", "readerDataSource"})
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier("writerDataSource") DataSource writer,
+            @Qualifier("readerDataSource") DataSource reader) {
+        ReadOnlyDataSourceRouter routingDataSource = new ReadOnlyDataSourceRouter();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+
+        dataSourceMap.put(WRITER, writer);
+        dataSourceMap.put(READER, reader);
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(writer);
+
+        return routingDataSource;
+    }
+
+    @DependsOn({"routingDataSource"})
+    @Primary
+    @Bean
+    public DataSource dataSource(DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory);
+        return jpaTransactionManager;
+    }
+}

--- a/src/main/java/coupon/ReadOnlyDataSourceRouter.java
+++ b/src/main/java/coupon/ReadOnlyDataSourceRouter.java
@@ -1,0 +1,15 @@
+package coupon;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class ReadOnlyDataSourceRouter extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return DataSourceConfig.READER;
+        }
+        return DataSourceConfig.WRITER;
+    }
+}

--- a/src/main/java/coupon/domain/Category.java
+++ b/src/main/java/coupon/domain/Category.java
@@ -1,0 +1,6 @@
+package coupon.domain;
+
+public enum Category {
+
+    FASHION, HOME_APPLIANCE, FURNITURE, FOOD
+}

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,0 +1,24 @@
+package coupon.domain;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class MemberCoupon {
+
+    private final Long id;
+    private final Long couponId;
+    private final Long memberId;
+    private final boolean used;
+    private final LocalDate issueDate;
+    private final LocalDate expirationDate;
+
+    public MemberCoupon(Long id, Long couponId, Long memberId, boolean used, LocalDate issueDate) {
+        this.id = id;
+        this.couponId = couponId;
+        this.memberId = memberId;
+        this.used = used;
+        this.issueDate = issueDate;
+        this.expirationDate = issueDate.plusDays(6);
+    }
+}

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,22 +1,41 @@
 package coupon.domain;
 
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberCoupon {
 
-    private final Long id;
-    private final Long couponId;
-    private final Long memberId;
-    private final boolean used;
-    private final LocalDate issueDate;
-    private final LocalDate expirationDate;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+    private boolean used;
+    private LocalDate issueDate;
+    private LocalDate expirationDate;
 
-    public MemberCoupon(Long id, Long couponId, Long memberId, boolean used, LocalDate issueDate) {
+    public MemberCoupon(Long id, Coupon coupon, Member member, boolean used, LocalDate issueDate) {
         this.id = id;
-        this.couponId = couponId;
-        this.memberId = memberId;
+        this.coupon = coupon;
+        this.member = member;
         this.used = used;
         this.issueDate = issueDate;
         this.expirationDate = issueDate.plusDays(6);

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -15,6 +15,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coupon {
 
+    private static final int MINIMUM_DISCOUNT_RATE = 3;
+    private static final int MAXIMUM_DISCOUNT_RATE = 20;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,10 +33,19 @@ public class Coupon {
 
     public Coupon(CouponName couponName, DiscountMount discountMount, MinimumMount minimumMount, Category category,
                   Period period) {
+        validateDiscountRate(discountMount, minimumMount);
         this.couponName = couponName;
         this.discountMount = discountMount;
         this.minimumMount = minimumMount;
         this.category = category;
         this.period = period;
+    }
+
+    private void validateDiscountRate(DiscountMount discountMount, MinimumMount minimumMount) {
+        float discountRate = (float) discountMount.getDiscountMount() / minimumMount.getMinimumMount() * 100;
+        int truncatedDiscountRate = (int) discountRate;
+        if (truncatedDiscountRate < MINIMUM_DISCOUNT_RATE || truncatedDiscountRate > MAXIMUM_DISCOUNT_RATE) {
+            throw new IllegalArgumentException("쿠폰 할인율은 3% 이상, 20% 이하여야 합니다.");
+        }
     }
 }

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -1,0 +1,23 @@
+package coupon.domain.coupon;
+
+import coupon.domain.Category;
+import lombok.Getter;
+
+@Getter
+public class Coupon {
+
+    private final CouponName couponName;
+    private final DiscountMount discountMount;
+    private final MinimumMount minimumMount;
+    private final Category category;
+    private final Period period;
+
+    public Coupon(CouponName couponName, DiscountMount discountMount, MinimumMount minimumMount, Category category,
+                  Period period) {
+        this.couponName = couponName;
+        this.discountMount = discountMount;
+        this.minimumMount = minimumMount;
+        this.category = category;
+        this.period = period;
+    }
+}

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -1,16 +1,32 @@
 package coupon.domain.coupon;
 
 import coupon.domain.Category;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coupon {
 
-    private final CouponName couponName;
-    private final DiscountMount discountMount;
-    private final MinimumMount minimumMount;
-    private final Category category;
-    private final Period period;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Embedded
+    private CouponName couponName;
+    @Embedded
+    private DiscountMount discountMount;
+    @Embedded
+    private MinimumMount minimumMount;
+    private Category category;
+    @Embedded
+    private Period period;
 
     public Coupon(CouponName couponName, DiscountMount discountMount, MinimumMount minimumMount, Category category,
                   Period period) {

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -1,0 +1,25 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class CouponName {
+
+    private static final int MAX_LENGTH = 30;
+
+    private final String name;
+
+    public CouponName(String name) {
+        validate(name);
+        this.name = name;
+    }
+
+    private void validate(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("이름은 비어있을 수 없습니다.");
+        }
+        if (name.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("이름은 최대 " + MAX_LENGTH + "자 입니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -1,17 +1,19 @@
 package coupon.domain.coupon;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class CouponName {
 
     private static final int MAX_LENGTH = 30;
 
-    private final String name;
+    private String couponName;
 
-    public CouponName(String name) {
-        validate(name);
-        this.name = name;
+    public CouponName(String couponName) {
+        validate(couponName);
+        this.couponName = couponName;
     }
 
     private void validate(String name) {

--- a/src/main/java/coupon/domain/coupon/DiscountMount.java
+++ b/src/main/java/coupon/domain/coupon/DiscountMount.java
@@ -1,19 +1,21 @@
 package coupon.domain.coupon;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class DiscountMount {
 
     private static final int MINIMUM_MOUNT = 1_000;
     private static final int MAXIMUM_MOUNT = 10_000;
     private static final int UNIT = 500;
 
-    private final int mount;
+    private int discountMount;
 
-    public DiscountMount(int mount) {
-        validate(mount);
-        this.mount = mount;
+    public DiscountMount(int discountMount) {
+        validate(discountMount);
+        this.discountMount = discountMount;
     }
 
     private void validate(int mount) {

--- a/src/main/java/coupon/domain/coupon/DiscountMount.java
+++ b/src/main/java/coupon/domain/coupon/DiscountMount.java
@@ -1,0 +1,30 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class DiscountMount {
+
+    private static final int MINIMUM_MOUNT = 1_000;
+    private static final int MAXIMUM_MOUNT = 10_000;
+    private static final int UNIT = 500;
+
+    private final int mount;
+
+    public DiscountMount(int mount) {
+        validate(mount);
+        this.mount = mount;
+    }
+
+    private void validate(int mount) {
+        if (mount < MINIMUM_MOUNT) {
+            throw new IllegalArgumentException("할인 금액은 " + MINIMUM_MOUNT + "원 이상이어야 합니다.");
+        }
+        if (mount > MAXIMUM_MOUNT) {
+            throw new IllegalArgumentException("할인 금액은 " + MAXIMUM_MOUNT + "원 이하여야 합니다.");
+        }
+        if (mount % UNIT != 0) {
+            throw new IllegalArgumentException("할인 금액은 " + UNIT + "원 단위여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/MinimumMount.java
+++ b/src/main/java/coupon/domain/coupon/MinimumMount.java
@@ -1,0 +1,26 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class MinimumMount {
+
+    private static final int MINIMUM_MOUNT = 5_000;
+    private static final int MAXIMUM_MOUNT = 100_000;
+
+    private final int mount;
+
+    public MinimumMount(int mount) {
+        validate(mount);
+        this.mount = mount;
+    }
+
+    private void validate(int mount) {
+        if (mount < MINIMUM_MOUNT) {
+            throw new IllegalArgumentException("최소 주문 금액은 " + MINIMUM_MOUNT + "원 이상이어야 합니다.");
+        }
+        if (mount > MAXIMUM_MOUNT) {
+            throw new IllegalArgumentException("최소 주문 금액은 " + MAXIMUM_MOUNT + "원 이하여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/MinimumMount.java
+++ b/src/main/java/coupon/domain/coupon/MinimumMount.java
@@ -1,18 +1,20 @@
 package coupon.domain.coupon;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class MinimumMount {
 
     private static final int MINIMUM_MOUNT = 5_000;
     private static final int MAXIMUM_MOUNT = 100_000;
 
-    private final int mount;
+    private int minimumMount;
 
-    public MinimumMount(int mount) {
-        validate(mount);
-        this.mount = mount;
+    public MinimumMount(int minimumMount) {
+        validate(minimumMount);
+        this.minimumMount = minimumMount;
     }
 
     private void validate(int mount) {

--- a/src/main/java/coupon/domain/coupon/Period.java
+++ b/src/main/java/coupon/domain/coupon/Period.java
@@ -1,0 +1,23 @@
+package coupon.domain.coupon;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class Period {
+
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    public Period(LocalDate startDate, LocalDate endDate) {
+        validate(startDate, endDate);
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    private void validate(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("시작일은 종료일보다 이전이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/Period.java
+++ b/src/main/java/coupon/domain/coupon/Period.java
@@ -2,12 +2,14 @@ package coupon.domain.coupon;
 
 import java.time.LocalDate;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class Period {
 
-    private final LocalDate startDate;
-    private final LocalDate endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
     public Period(LocalDate startDate, LocalDate endDate) {
         validate(startDate, endDate);

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -1,0 +1,15 @@
+package coupon.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public class Member {
+
+    private final Long id;
+    private final MemberName memberName;
+
+    public Member(Long id, MemberName memberName) {
+        this.id = id;
+        this.memberName = memberName;
+    }
+}

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -1,12 +1,24 @@
 package coupon.domain.member;
 
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    private final Long id;
-    private final MemberName memberName;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Embedded
+    private MemberName memberName;
 
     public Member(Long id, MemberName memberName) {
         this.id = id;

--- a/src/main/java/coupon/domain/member/MemberName.java
+++ b/src/main/java/coupon/domain/member/MemberName.java
@@ -1,0 +1,25 @@
+package coupon.domain.member;
+
+import lombok.Getter;
+
+@Getter
+public class MemberName {
+
+    private static final int MAX_LENGTH = 30;
+
+    private final String name;
+
+    public MemberName(String name) {
+        validate(name);
+        this.name = name;
+    }
+
+    private void validate(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("이름은 비어있을 수 없습니다.");
+        }
+        if (name.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("이름은 최대 " + MAX_LENGTH + "자 입니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/repository/CouponRepository.java
@@ -1,0 +1,9 @@
+package coupon.repository;
+
+import coupon.domain.coupon.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -2,21 +2,25 @@ package coupon.service;
 
 import coupon.domain.coupon.Coupon;
 import coupon.repository.CouponRepository;
-import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 public class CouponService {
 
     private final CouponRepository couponRepository;
 
+    public CouponService(CouponRepository couponRepository, ApplicationContext context) {
+        this.couponRepository = couponRepository;
+    }
+
+    @Transactional
     public Coupon create(Coupon coupon) {
         return couponRepository.save(coupon);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Coupon getCoupon(Long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 쿠폰 id입니다."));

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,24 @@
+package coupon.service;
+
+import coupon.domain.coupon.Coupon;
+import coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public void create(Coupon coupon) {
+        couponRepository.save(coupon);
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(Long couponId) {
+        return couponRepository.findById(couponId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 쿠폰 id입니다."));
+    }
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -12,8 +12,8 @@ public class CouponService {
 
     private final CouponRepository couponRepository;
 
-    public void create(Coupon coupon) {
-        couponRepository.save(coupon);
+    public Coupon create(Coupon coupon) {
+        return couponRepository.save(coupon);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/coupon/service/support/DataSourceSupport.java
+++ b/src/main/java/coupon/service/support/DataSourceSupport.java
@@ -1,0 +1,15 @@
+package coupon.service.support;
+
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DataSourceSupport {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public <T> T executeOnWriter(Supplier<T> supplier) {
+        return supplier.get();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: false
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/test/java/coupon/domain/coupon/CouponNameTest.java
+++ b/src/test/java/coupon/domain/coupon/CouponNameTest.java
@@ -1,0 +1,36 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CouponNameTest {
+
+    @Test
+    @DisplayName("null 값으로 이름을 생성할 경우 예외로 처리한다.")
+    void nullName() {
+        String nullSource = null;
+        assertThatThrownBy(() -> new CouponName(nullSource))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 비어있을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("이름이 0자인 경우 예외로 처리한다.")
+    void zeroLength() {
+        String emptyName = "";
+        assertThatThrownBy(() -> new CouponName(emptyName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 비어있을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("이름이 30자를 초과하면 예외로 처리한다.")
+    void mountAboveMaximum() {
+        String tooLongName = "0123456789012345678901234567890";
+        assertThatThrownBy(() -> new CouponName(tooLongName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 최대 30자 입니다.");
+    }
+}

--- a/src/test/java/coupon/domain/coupon/CouponTest.java
+++ b/src/test/java/coupon/domain/coupon/CouponTest.java
@@ -1,0 +1,52 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import coupon.domain.Category;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CouponTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {1000, 6000})
+    @DisplayName("범위 내의 할인율로 생성할 수 있다.")
+    void discountRate(int discountMount) {
+        assertDoesNotThrow(() -> new Coupon(
+                new CouponName("총대마켓쿠폰"),
+                new DiscountMount(discountMount),
+                new MinimumMount(30000),
+                Category.FASHION,
+                new Period(LocalDate.now(), LocalDate.now().plusDays(1))));
+    }
+
+    @Test
+    @DisplayName("할인율 최소 할인율 미만일 경우 예외로 처리한다.")
+    void underMinimum() {
+        assertThatThrownBy(() -> new Coupon(
+                new CouponName("총대마켓쿠폰"),
+                new DiscountMount(1000),
+                new MinimumMount(50000),
+                Category.FASHION,
+                new Period(LocalDate.now(), LocalDate.now().plusDays(1))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 할인율은 3% 이상, 20% 이하여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("할인율 최대 할인율 초과일 경우 예외로 처리한다.")
+    void overMaximum() {
+        assertThatThrownBy(() -> new Coupon(
+                new CouponName("총대마켓쿠폰"),
+                new DiscountMount(7000),
+                new MinimumMount(30000),
+                Category.FASHION,
+                new Period(LocalDate.now(), LocalDate.now().plusDays(1))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 할인율은 3% 이상, 20% 이하여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/coupon/DiscountMountTest.java
+++ b/src/test/java/coupon/domain/coupon/DiscountMountTest.java
@@ -1,0 +1,46 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiscountMountTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {1000, 1500, 2000, 5000, 10000})
+    @DisplayName("유효한 할인 금액을 통해 생성할 수 있다.")
+    void validMountCreation(int mount) {
+        assertDoesNotThrow(() -> new DiscountMount(mount));
+    }
+
+    @Test
+    @DisplayName("최소 할인 금액 미만이면 예외로 처리한다.")
+    void mountBelowMinimum() {
+        int invalidMount = 500;
+        assertThatThrownBy(() -> new DiscountMount(invalidMount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 1000원 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("최대 할인 금액을 초과하면 예외로 처리한다")
+    void mountAboveMaximum() {
+        int invalidMount = 15000;
+        assertThatThrownBy(() -> new DiscountMount(invalidMount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 10000원 이하여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("할인 금액이 500원 단위가 아닐 경우 예외로 처리한다")
+    void mountNotMultipleOfUnit() {
+        int invalidMount = 1250;
+        assertThatThrownBy(() -> new DiscountMount(invalidMount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("할인 금액은 500원 단위여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/coupon/MinimumMountTest.java
+++ b/src/test/java/coupon/domain/coupon/MinimumMountTest.java
@@ -1,0 +1,37 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MinimumMountTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {5000, 5555, 6000, 50000, 100000})
+    @DisplayName("유효한 할인 금액을 통해 생성할 수 있다.")
+    void validMountCreation(int mount) {
+        assertDoesNotThrow(() -> new MinimumMount(mount));
+    }
+
+    @Test
+    @DisplayName("최소 할인 금액 미만이면 예외로 처리한다.")
+    void mountBelowMinimum() {
+        int invalidMount = 4000;
+        assertThatThrownBy(() -> new MinimumMount(invalidMount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 주문 금액은 5000원 이상이어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("최대 할인 금액을 초과하면 예외로 처리한다")
+    void mountAboveMaximum() {
+        int invalidMount = 110000;
+        assertThatThrownBy(() -> new MinimumMount(invalidMount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최소 주문 금액은 100000원 이하여야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/coupon/PeriodTest.java
+++ b/src/test/java/coupon/domain/coupon/PeriodTest.java
@@ -1,0 +1,21 @@
+package coupon.domain.coupon;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PeriodTest {
+
+    @Test
+    @DisplayName("시작일이 종료일보다 이후일 때 예외 발생")
+    void invalidPeriodCreation() {
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = startDate.minusDays(1);
+
+        assertThatThrownBy(() -> new Period(startDate, endDate))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("시작일은 종료일보다 이전이어야 합니다.");
+    }
+}

--- a/src/test/java/coupon/domain/member/MemberNameTest.java
+++ b/src/test/java/coupon/domain/member/MemberNameTest.java
@@ -1,0 +1,37 @@
+package coupon.domain.member;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberNameTest {
+
+
+    @Test
+    @DisplayName("null 값으로 이름을 생성할 경우 예외로 처리한다.")
+    void nullName() {
+        String nullSource = null;
+        assertThatThrownBy(() -> new MemberName(nullSource))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 비어있을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("이름이 0자인 경우 예외로 처리한다.")
+    void zeroLength() {
+        String emptyName = "";
+        assertThatThrownBy(() -> new MemberName(emptyName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 비어있을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("이름이 30자를 초과하면 예외로 처리한다.")
+    void mountAboveMaximum() {
+        String tooLongName = "이무송은포케이무송은포케이무송은포케이무송은포케이무송은포케이무송은포케이무송은포케이무송은포케이무송은포케";
+        assertThatThrownBy(() -> new MemberName(tooLongName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 최대 30자 입니다.");
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,31 @@
+package coupon.service;
+
+import coupon.domain.Category;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.CouponName;
+import coupon.domain.coupon.DiscountMount;
+import coupon.domain.coupon.MinimumMount;
+import coupon.domain.coupon.Period;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Test
+    void create() {
+        Coupon coupon = new Coupon(
+                new CouponName("쿠폰"),
+                new DiscountMount(1000),
+                new MinimumMount(5000),
+                Category.FASHION,
+                new Period(LocalDate.now().minusDays(1), LocalDate.now().plusDays(1))
+        );
+        couponService.create(coupon);
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,5 +1,7 @@
 package coupon.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import coupon.domain.Category;
 import coupon.domain.coupon.Coupon;
 import coupon.domain.coupon.CouponName;
@@ -18,14 +20,15 @@ class CouponServiceTest {
     private CouponService couponService;
 
     @Test
-    void create() {
-        Coupon coupon = new Coupon(
+    void 복제지연테스트() {
+        Coupon coupon = couponService.create(new Coupon(
                 new CouponName("쿠폰"),
                 new DiscountMount(1000),
                 new MinimumMount(5000),
                 Category.FASHION,
                 new Period(LocalDate.now().minusDays(1), LocalDate.now().plusDays(1))
-        );
-        couponService.create(coupon);
+        ));
+        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+        assertThat(savedCoupon).isNotNull();
     }
 }


### PR DESCRIPTION
안녕하세요 포케! 리뷰로 만나는 건 처음이네요 ㅎㅎ
잘 부탁드립니다!

## 복제 지연 해결 방법
일단 제가 사용한 방법은 실패 시 writer DB 재시도입니다.
고려한 방법들은 아래와 같습니다.
1. 사용자가 수정한 내용을 읽을 때는 writer db에서 읽음
2. 마지막 갱신 시간 후 1 분 동안은 writer db에서 읽음
3. 캐시 사용
4. 실패할 시 Writer로 재시도
5. Writer에서 읽는다

이 중 아래의 요소들을 고려해서 4번인 재시도를 결정하게 되었습니다.
- getCoupon의 **성능**
- getCoupon의 **실패 가능성**
- **효율성**
- **구현**의 쉬운 정도

### getCoupon의 사용
쿠폰을 조회하는 `getCoupon`을 사용하는 경우는 언제인가 생각해봤는데요.
크게 `createCoupon`을 통해 생성한 쿠폰을 확인하는 경우, 쿠폰을 사용자에게 발행하는 경우(`MemberCoupon`), 사용자가 쿠폰을 사용하는 경우 등을 생각했습니다. 이 중 발행과 쿠폰 사용은 빈번하게 일어난다고 생각합니다. 저희가 실제로 온라인 쇼핑몰을 사용할 때를 생각해 봐도 매 구매마다 쿠폰을 사용할 정도이기 때문에 성능은 최대한 신경 써야 한다고 생각했습니다.
이에 따라 5번을 고려하지 않았습니다. 읽기 요청을 매번 writer에서 할 경우 reader DB 복제로 인한 이득을 볼 수 없습니다. reader DB는 scale out이 쉽기 때문에 요청이 많아질 경우 이에 대한 성능 개선이 비교적 용이하기 때문에 이를 활용하기 위해선 최대한 많은 요청을 reader DB로 처리해야 합니다. 따라서 reader DB를 사용하지 않는 5번은 제외했습니다.

### 실패 가능성과 효율성
`getCoupon`을 했는데 실제 값이 없는 경우가 언제 있을지 생각해봤습니다.
그런데 쿠폰을 사용자에게 발행하는 경우나 쿠폰을 사용할 때 없는 쿠폰을 통해 `getCoupon`을 요청할 일은 없다고 봐도 될 것 같습니다. 즉, `getCoupon`이 실패하는 경우 중 생각나는 경우는 LMS에서의 시나리오처럼 발급 직후 다시 확인하는 경우입니다. 따라서 저희가 복제 지연을 해결하더라도 이를 사용할 일은 거의 없다고 봐도 될 것 같습니다. 이에 따라 이 복제 지연을 해결하기 위해 추가적인 캐시를 두는 것은 합리적인 방법이 아니라고 생각했습니다. 인메모리 캐시를 두기 위해 추가적인 메모리를 사용해야 하는 것에 비해 실제로 이를 사용할 일은 거의 없기 때문입니다. 또한 분산 서버를 고려할 경우 레디스 같은 캐시를 사용해야 할텐데 이 비용조차도 해결하는 문제를 고려해 보면 너무 지나치다는 생각이 들었습니다. 따라서 3번을 제외했습니다.

### 구현의 쉬운 정도
1, 2, 4번 모두 합리적인 방법이라고 생각했습니다. 따라서 미션 마감일을 고려해 이 중 가장 구현 난이도가 낮다고 판단되는 4번의 방식을 채택했습니다.

---
여기까지입니다. 이에 대한 포케의 생각과 해결 방법이 궁금하네요. 잘 부탁드립니다 ㅎㅎ~