### PR TITLE
[1단계 - DB 복제와 캐시] 산초(나영서) 미션 제출합니다.

### DIFF
--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -26,13 +26,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 )
 public class DataSourceConfig {
 
-    @Primary
-    @Bean(name = "dataSource")
-    public DataSource dataSource(
-            @Qualifier("routingDataSource") DataSourceRouter routingDataSource) {
-        return new LazyConnectionDataSourceProxy(routingDataSource);
-    }
-
     @Bean(name = "writerDataSource")
     @ConfigurationProperties(prefix = "coupon.datasource.writer")
     public DataSource writerDataSource() {
@@ -58,6 +51,13 @@ public class DataSourceConfig {
         return router;
     }
 
+    @Primary
+    @Bean(name = "dataSource")
+    public DataSource dataSource(
+            @Qualifier("routingDataSource") DataSourceRouter routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
     @Bean(name = "couponEntityManagerFactory")
     public LocalContainerEntityManagerFactoryBean couponEntityManagerFactory(
             @Qualifier("dataSource") DataSource dataSource) {
@@ -67,15 +67,15 @@ public class DataSourceConfig {
 
         HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
         vendorAdapter.setDatabase(Database.MYSQL);
-        vendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQL8Dialect");
         em.setJpaVendorAdapter(vendorAdapter);
 
         Map<String, Object> properties = new HashMap<>();
-        properties.put("hibernate.hbm2ddl.auto", "create-drop");
         properties.put("hibernate.physical_naming_strategy",
-                "org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl");
+                "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+        properties.put("hibernate.implicit_naming_strategy",
+                "org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl");
+        properties.put("hibernate.show_sql", "true");
         em.setJpaPropertyMap(properties);
-
         return em;
     }
 

--- a/src/main/java/coupon/config/DataSourceConfig.java
+++ b/src/main/java/coupon/config/DataSourceConfig.java
@@ -1,0 +1,87 @@
+package coupon.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@EnableJpaRepositories(
+        basePackages = "coupon.repository",
+        entityManagerFactoryRef = "couponEntityManagerFactory",
+        transactionManagerRef = "couponTransactionManager"
+)
+public class DataSourceConfig {
+
+    @Primary
+    @Bean(name = "dataSource")
+    public DataSource dataSource(
+            @Qualifier("routingDataSource") DataSourceRouter routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+    @Bean(name = "writerDataSource")
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "readerDataSource")
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readerDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "routingDataSource")
+    public DataSourceRouter routingDataSource(
+            @Qualifier("writerDataSource") DataSource writerDataSource,
+            @Qualifier("readerDataSource") DataSource readerDataSource) {
+        DataSourceRouter router = new DataSourceRouter();
+        Map<Object, Object> dataSources = new HashMap<>();
+        dataSources.put(DataSourceType.WRITER, writerDataSource);
+        dataSources.put(DataSourceType.READER, readerDataSource);
+        router.setTargetDataSources(dataSources);
+        router.setDefaultTargetDataSource(writerDataSource);
+        return router;
+    }
+
+    @Bean(name = "couponEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean couponEntityManagerFactory(
+            @Qualifier("dataSource") DataSource dataSource) {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(dataSource);
+        em.setPackagesToScan("coupon.entity");
+
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setDatabase(Database.MYSQL);
+        vendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQL8Dialect");
+        em.setJpaVendorAdapter(vendorAdapter);
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("hibernate.hbm2ddl.auto", "create-drop");
+        properties.put("hibernate.physical_naming_strategy",
+                "org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl");
+        em.setJpaPropertyMap(properties);
+
+        return em;
+    }
+
+    @Bean
+    public PlatformTransactionManager couponTransactionManager(
+            @Qualifier("couponEntityManagerFactory") LocalContainerEntityManagerFactoryBean couponEntityManagerFactory) {
+        return new JpaTransactionManager(Objects.requireNonNull(couponEntityManagerFactory.getObject()));
+    }
+}

--- a/src/main/java/coupon/config/DataSourceRouter.java
+++ b/src/main/java/coupon/config/DataSourceRouter.java
@@ -5,24 +5,11 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 public class DataSourceRouter extends AbstractRoutingDataSource {
 
-    private static final ThreadLocal<DataSourceType> currentDataSource = new ThreadLocal<>();
-
     @Override
     protected Object determineCurrentLookupKey() {
-        if (currentDataSource.get() != null) {
-            return currentDataSource.get();
-        }
         if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
             return DataSourceType.READER;
         }
         return DataSourceType.WRITER;
-    }
-
-    public static void setDataSourceType(DataSourceType dataSourceType) {
-        currentDataSource.set(dataSourceType);
-    }
-
-    public static void clearDataSourceType() {
-        currentDataSource.remove();
     }
 }

--- a/src/main/java/coupon/config/DataSourceRouter.java
+++ b/src/main/java/coupon/config/DataSourceRouter.java
@@ -1,0 +1,28 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class DataSourceRouter extends AbstractRoutingDataSource {
+
+    private static final ThreadLocal<DataSourceType> currentDataSource = new ThreadLocal<>();
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (currentDataSource.get() != null) {
+            return currentDataSource.get();
+        }
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return DataSourceType.READER;
+        }
+        return DataSourceType.WRITER;
+    }
+
+    public static void setDataSourceType(DataSourceType dataSourceType) {
+        currentDataSource.set(dataSourceType);
+    }
+
+    public static void clearDataSourceType() {
+        currentDataSource.remove();
+    }
+}

--- a/src/main/java/coupon/config/DataSourceType.java
+++ b/src/main/java/coupon/config/DataSourceType.java
@@ -1,0 +1,8 @@
+package coupon.config;
+
+public enum DataSourceType {
+
+    WRITER,
+    READER,
+    ;
+}

--- a/src/main/java/coupon/config/DatabaseInitializer.java
+++ b/src/main/java/coupon/config/DatabaseInitializer.java
@@ -1,0 +1,30 @@
+package coupon.config;
+
+import jakarta.annotation.PostConstruct;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseInitializer {
+
+    private final DataSource writerDataSource;
+    private final DataSource readerDataSource;
+
+    protected DatabaseInitializer(
+            @Qualifier("writerDataSource") DataSource writerDataSource,
+            @Qualifier("readerDataSource") DataSource readerDataSource) {
+        this.writerDataSource = writerDataSource;
+        this.readerDataSource = readerDataSource;
+    }
+
+    @PostConstruct
+    public void init() {
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+        populator.addScript(new ClassPathResource("schema.sql"));
+        populator.execute(writerDataSource);
+        populator.execute(readerDataSource);
+    }
+}

--- a/src/main/java/coupon/domain/coupon/Category.java
+++ b/src/main/java/coupon/domain/coupon/Category.java
@@ -1,0 +1,10 @@
+package coupon.domain.coupon;
+
+public enum Category {
+
+    FASHION,
+    ELECTRONICS,
+    FURNITURE,
+    FOOD,
+    ;
+}

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -1,0 +1,27 @@
+package coupon.domain.coupon;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class Coupon {
+
+    private final Long id;
+    private final Name name;
+    private final DiscountAmount discountAmount;
+    private final MinOrderAmount minOrderAmount;
+    private final DiscountRange discountRange;
+    private final Category category;
+    private final IssueDuration issueDuration;
+
+    public Coupon(Long id, String name, long discountAmount, long minOrderAmount,
+                  Category category, LocalDate issueStartDate, LocalDate issueEndDate) {
+        this.id = id;
+        this.name = new Name(name);
+        this.discountAmount = new DiscountAmount(discountAmount);
+        this.minOrderAmount = new MinOrderAmount(minOrderAmount);
+        this.discountRange = new DiscountRange(discountAmount, minOrderAmount);
+        this.category = category;
+        this.issueDuration = new IssueDuration(issueStartDate, issueEndDate);
+    }
+}

--- a/src/main/java/coupon/domain/coupon/DiscountAmount.java
+++ b/src/main/java/coupon/domain/coupon/DiscountAmount.java
@@ -1,0 +1,32 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class DiscountAmount {
+
+    private static final int MIN_LIMIT = 1000;
+    private static final int MAX_LIMIT = 10000;
+    private static final int UNIT = 500;
+
+    private final long discountAmount;
+
+    public DiscountAmount(long discountAmount) {
+        validateDiscountAmountRange(discountAmount);
+        validateDiscountAmountUnit(discountAmount);
+        this.discountAmount = discountAmount;
+    }
+
+    private void validateDiscountAmountRange(long discountAmount) {
+        if (discountAmount < MIN_LIMIT || discountAmount > MAX_LIMIT) {
+            throw new IllegalArgumentException(
+                    String.format("정해진 할인 금액 범위를 벗어났습니다. - 범위 : %d원 ~ %d원", MIN_LIMIT, MAX_LIMIT));
+        }
+    }
+
+    private void validateDiscountAmountUnit(long discountAmount) {
+        if (discountAmount % UNIT != 0) {
+            throw new IllegalArgumentException(String.format("할인 금액은 정해진 단위로 입력해주세요. - 단위 : %d원", UNIT));
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/DiscountRange.java
+++ b/src/main/java/coupon/domain/coupon/DiscountRange.java
@@ -1,0 +1,28 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class DiscountRange {
+
+    private static final int MIN_LIMIT = 3;
+    private static final int MAX_LIMIT = 20;
+
+    private final int discountRange;
+
+    public DiscountRange(long discountAmount, long minOrderAmount) {
+        int discountRange = calculateDiscountRange(discountAmount, minOrderAmount);
+        validateDiscountRange(discountRange);
+        this.discountRange = discountRange;
+    }
+
+    private static int calculateDiscountRange(long discountAmount, long minOrderAmount) {
+        return (int) ((discountAmount / (double) minOrderAmount) * 100);
+    }
+
+    private static void validateDiscountRange(int discountRange) {
+        if (discountRange < MIN_LIMIT || discountRange > MAX_LIMIT) {
+            throw new IllegalArgumentException(String.format("정해진 할인율 범위를 벗어났습니다. - 범위: %d%% ~%d%%", MIN_LIMIT, MAX_LIMIT));
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/IssueDuration.java
+++ b/src/main/java/coupon/domain/coupon/IssueDuration.java
@@ -1,0 +1,24 @@
+package coupon.domain.coupon;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class IssueDuration {
+
+    private final LocalDate startDateTime;
+    private final LocalDate endDateTime;
+
+    public IssueDuration(LocalDate startDateTime, LocalDate endDateTime) {
+        validateIssueDuration(startDateTime, endDateTime);
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+    }
+
+    private void validateIssueDuration(LocalDate startDateTime, LocalDate endDateTime) {
+        if (startDateTime.isAfter(endDateTime)) {
+            throw new IllegalArgumentException("발급 시작일이 종료일보다 늦을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/MinOrderAmount.java
+++ b/src/main/java/coupon/domain/coupon/MinOrderAmount.java
@@ -1,0 +1,24 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class MinOrderAmount {
+
+    private static final int MIN_LIMIT = 5000;
+    private static final int MAX_LIMIT = 100000;
+
+    private final long minOrderAmount;
+
+    public MinOrderAmount(long minOrderAmount) {
+        validateMinOrderAmountRange(minOrderAmount);
+        this.minOrderAmount = minOrderAmount;
+    }
+
+    private void validateMinOrderAmountRange(long minOrderAmount) {
+        if (minOrderAmount < MIN_LIMIT || minOrderAmount > MAX_LIMIT) {
+            throw new IllegalArgumentException(
+                    String.format("정해진 최소 주문 금액 범위를 벗어났습니다. - 범위 : %d원 ~ %d원", MIN_LIMIT, MAX_LIMIT));
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/Name.java
+++ b/src/main/java/coupon/domain/coupon/Name.java
@@ -1,0 +1,20 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+@Getter
+public class Name {
+
+    private final String name;
+
+    public Name(String name) {
+        validateNameExists(name);
+        this.name = name;
+    }
+
+    private void validateNameExists(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("이름은 필수 값입니다.");
+        }
+    }
+}

--- a/src/main/java/coupon/domain/user/User.java
+++ b/src/main/java/coupon/domain/user/User.java
@@ -1,0 +1,14 @@
+package coupon.domain.user;
+
+import lombok.Getter;
+
+@Getter
+public class User {
+
+    private Long id;
+    private final String name;
+
+    public User(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/coupon/domain/usercoupon/UserCoupon.java
+++ b/src/main/java/coupon/domain/usercoupon/UserCoupon.java
@@ -1,0 +1,22 @@
+package coupon.domain.usercoupon;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class UserCoupon {
+
+    private final Long id;
+    private final Long userId;
+    private final Long couponId;
+    private final boolean isUsed;
+    private final UsingDuration usingDuration;
+
+    public UserCoupon(Long id, Long userId, Long couponId, boolean isUsed, LocalDateTime issuedDateTime) {
+        this.id = id;
+        this.userId = userId;
+        this.couponId = couponId;
+        this.isUsed = isUsed;
+        this.usingDuration = new UsingDuration(issuedDateTime);
+    }
+}

--- a/src/main/java/coupon/domain/usercoupon/UsingDuration.java
+++ b/src/main/java/coupon/domain/usercoupon/UsingDuration.java
@@ -1,0 +1,19 @@
+package coupon.domain.usercoupon;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.Getter;
+
+@Getter
+public class UsingDuration {
+
+    private static final int DAYS = 7;
+
+    private final LocalDateTime startDateTime;
+    private final LocalDateTime endDateTime;
+
+    public UsingDuration(LocalDateTime issuedDateTime) {
+        this.startDateTime = issuedDateTime;
+        this.endDateTime = issuedDateTime.plusDays(DAYS).with(LocalTime.MAX);
+    }
+}

--- a/src/main/java/coupon/entity/CouponEntity.java
+++ b/src/main/java/coupon/entity/CouponEntity.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/coupon/entity/CouponEntity.java
+++ b/src/main/java/coupon/entity/CouponEntity.java
@@ -1,0 +1,41 @@
+package coupon.entity;
+
+import coupon.domain.coupon.Category;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class CouponEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private long discountAmount;
+
+    private long minOrderAmount;
+
+    private int discountRange;
+
+    @Enumerated(value = EnumType.STRING)
+    private Category category;
+
+    private LocalDate issueStartDate;
+
+    private LocalDate issueEndDate;
+}

--- a/src/main/java/coupon/entity/UserCouponEntity.java
+++ b/src/main/java/coupon/entity/UserCouponEntity.java
@@ -1,0 +1,35 @@
+package coupon.entity;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class UserCouponEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private long userId;
+
+    private long couponId;
+
+    private boolean used;
+
+    private LocalDateTime usedDateTime;
+
+    private LocalDateTime expiredDateTime;
+}

--- a/src/main/java/coupon/entity/UserCouponEntity.java
+++ b/src/main/java/coupon/entity/UserCouponEntity.java
@@ -1,12 +1,10 @@
 package coupon.entity;
 
-import static jakarta.persistence.GenerationType.*;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/coupon/entity/UserEntity.java
+++ b/src/main/java/coupon/entity/UserEntity.java
@@ -1,6 +1,6 @@
 package coupon.entity;
 
-import static jakarta.persistence.GenerationType.*;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/coupon/entity/UserEntity.java
+++ b/src/main/java/coupon/entity/UserEntity.java
@@ -1,0 +1,24 @@
+package coupon.entity;
+
+import static jakarta.persistence.GenerationType.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String name;
+}

--- a/src/main/java/coupon/mapper/DomainEntityMapper.java
+++ b/src/main/java/coupon/mapper/DomainEntityMapper.java
@@ -1,0 +1,23 @@
+package coupon.mapper;
+
+import coupon.domain.coupon.Coupon;
+import coupon.domain.user.User;
+import coupon.domain.usercoupon.UserCoupon;
+import coupon.entity.CouponEntity;
+import coupon.entity.UserCouponEntity;
+import coupon.entity.UserEntity;
+
+public class DomainEntityMapper {
+
+    public static CouponEntity mapToCouponEntity(Coupon coupon) {
+        return new CouponEntity(
+                coupon.getId(),
+                coupon.getName().getName(),
+                coupon.getDiscountAmount().getDiscountAmount(),
+                coupon.getMinOrderAmount().getMinOrderAmount(),
+                coupon.getDiscountRange().getDiscountRange(),
+                coupon.getCategory(),
+                coupon.getIssueDuration().getStartDateTime(),
+                coupon.getIssueDuration().getEndDateTime());
+    }
+}

--- a/src/main/java/coupon/mapper/EntityDomainMapper.java
+++ b/src/main/java/coupon/mapper/EntityDomainMapper.java
@@ -1,0 +1,18 @@
+package coupon.mapper;
+
+import coupon.domain.coupon.Coupon;
+import coupon.entity.CouponEntity;
+
+public class EntityDomainMapper {
+
+    public static Coupon mapToCoupon(CouponEntity couponEntity) {
+        return new Coupon(
+                couponEntity.getId(),
+                couponEntity.getName(),
+                couponEntity.getDiscountAmount(),
+                couponEntity.getMinOrderAmount(),
+                couponEntity.getCategory(),
+                couponEntity.getIssueEndDate(),
+                couponEntity.getIssueEndDate());
+    }
+}

--- a/src/main/java/coupon/repository/CouponReaderRepository.java
+++ b/src/main/java/coupon/repository/CouponReaderRepository.java
@@ -1,0 +1,24 @@
+package coupon.repository;
+
+import coupon.entity.CouponEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponReaderRepository {
+
+    private final CouponRepository couponRepository;
+    private final CouponWriterRepository couponWriterRepository;
+
+    @Transactional(readOnly = true)
+    public Optional<CouponEntity> findById(long id) {
+        Optional<CouponEntity> fromReader = couponRepository.findById(id);
+        if (fromReader.isPresent()) {
+            return fromReader;
+        }
+        return couponWriterRepository.readFromWriter(id);
+    }
+}

--- a/src/main/java/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/repository/CouponRepository.java
@@ -1,0 +1,9 @@
+package coupon.repository;
+
+import coupon.entity.CouponEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CouponRepository extends JpaRepository<CouponEntity, Long> {
+}

--- a/src/main/java/coupon/repository/CouponWriterRepository.java
+++ b/src/main/java/coupon/repository/CouponWriterRepository.java
@@ -1,0 +1,20 @@
+package coupon.repository;
+
+import coupon.entity.CouponEntity;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CouponWriterRepository {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Optional<CouponEntity> readFromWriter(long id) {
+        return couponRepository.findById(id);
+    }
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,16 +1,13 @@
 package coupon.service;
 
-import coupon.config.DataSourceRouter;
-import coupon.config.DataSourceType;
 import coupon.domain.coupon.Coupon;
 import coupon.entity.CouponEntity;
 import coupon.mapper.DomainEntityMapper;
 import coupon.mapper.EntityDomainMapper;
+import coupon.repository.CouponReaderRepository;
 import coupon.repository.CouponRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.exception.SQLGrammarException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final CouponReaderRepository couponReaderRepository;
 
     @Transactional
     public CouponEntity create(Coupon coupon) {
@@ -28,27 +26,8 @@ public class CouponService {
 
     @Transactional(readOnly = true)
     public Coupon getCoupon(Long id) {
-        try {
-            Optional<CouponEntity> couponEntity = getCouponById(id);
-            if (couponEntity.isEmpty()) {
-                DataSourceRouter.setDataSourceType(DataSourceType.WRITER);
-                couponEntity = couponRepository.findById(id);
-            }
-            if(couponEntity.isEmpty()) {
-                throw new IllegalArgumentException("존재하지 않는 쿠폰입니다.");
-            }
-            return EntityDomainMapper.mapToCoupon(couponEntity.get());
-        } finally {
-            DataSourceRouter.clearDataSourceType();
-        }
-    }
-
-    private Optional<CouponEntity> getCouponById(Long id) {
-        try {
-            return couponRepository.findById(id);
-        } catch (SQLGrammarException ex) {
-            log.info("쿠폰이 조회되지 않습니다. - id: {}", id);
-            return Optional.empty();
-        }
+        CouponEntity couponEntity = couponReaderRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+        return EntityDomainMapper.mapToCoupon(couponEntity);
     }
 }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,0 +1,54 @@
+package coupon.service;
+
+import coupon.config.DataSourceRouter;
+import coupon.config.DataSourceType;
+import coupon.domain.coupon.Coupon;
+import coupon.entity.CouponEntity;
+import coupon.mapper.DomainEntityMapper;
+import coupon.mapper.EntityDomainMapper;
+import coupon.repository.CouponRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.SQLGrammarException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public CouponEntity create(Coupon coupon) {
+        return couponRepository.save(DomainEntityMapper.mapToCouponEntity(coupon));
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon getCoupon(Long id) {
+        try {
+            Optional<CouponEntity> couponEntity = getCouponById(id);
+            if (couponEntity.isEmpty()) {
+                DataSourceRouter.setDataSourceType(DataSourceType.WRITER);
+                couponEntity = couponRepository.findById(id);
+            }
+            if(couponEntity.isEmpty()) {
+                throw new IllegalArgumentException("존재하지 않는 쿠폰입니다.");
+            }
+            return EntityDomainMapper.mapToCoupon(couponEntity.get());
+        } finally {
+            DataSourceRouter.clearDataSourceType();
+        }
+    }
+
+    private Optional<CouponEntity> getCouponById(Long id) {
+        try {
+            return couponRepository.findById(id);
+        } catch (SQLGrammarException ex) {
+            log.info("쿠폰이 조회되지 않습니다. - id: {}", id);
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: none
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
         hbm2ddl.auto: validate
         check_nullability: true
@@ -21,14 +21,14 @@ coupon.datasource:
   writer:
     type: com.zaxxer.hikari.HikariDataSource
     driverClassName: com.mysql.cj.jdbc.Driver
-    jdbcUrl: jdbc:mysql://localhost:33306/coupon?characterEncoding=UTF-8&serverTimezone=UTC
+    jdbcUrl: jdbc:mysql://localhost:33306/coupon?createDatabaseIfNotExist=true&characterEncoding=UTF-8&serverTimezone=UTC
     username: root
     password: root
     maximumPoolSize: 10
   reader:
     type: com.zaxxer.hikari.HikariDataSource
     driverClassName: com.mysql.cj.jdbc.Driver
-    jdbcUrl: jdbc:mysql://localhost:33307/coupon?characterEncoding=UTF-8&serverTimezone=UTC
+    jdbcUrl: jdbc:mysql://localhost:33307/coupon?createDatabaseIfNotExist=true&characterEncoding=UTF-8&serverTimezone=UTC
     username: root
     password: root
     maximumPoolSize: 10

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS coupon_entity
+(
+    id               bigint  NOT NULL AUTO_INCREMENT,
+    discount_range   integer NOT NULL,
+    issue_end_date   date,
+    issue_start_date date,
+    discount_amount  bigint  NOT NULL,
+    min_order_amount bigint  NOT NULL,
+    name             varchar(255),
+    category         ENUM ('FASHION', 'ELECTRONICS', 'FURNITURE', 'FOOD'),
+    PRIMARY KEY (id)
+    ) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS user_entity
+(
+    id   bigint NOT NULL AUTO_INCREMENT,
+    name varchar(255),
+    PRIMARY KEY (id)
+    ) ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS user_coupon_entity
+(
+    id                bigint NOT NULL AUTO_INCREMENT,
+    used              bit    NOT NULL,
+    coupon_id         bigint NOT NULL,
+    expired_date_time datetime(6),
+    used_date_time    datetime(6),
+    user_id           bigint NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_user_coupon_user FOREIGN KEY (user_id) REFERENCES user_entity (id),
+    CONSTRAINT fk_user_coupon_coupon FOREIGN KEY (coupon_id) REFERENCES coupon_entity (id)
+    ) ENGINE = InnoDB;

--- a/src/test/java/coupon/domain/DiscountAmountTest.java
+++ b/src/test/java/coupon/domain/DiscountAmountTest.java
@@ -1,0 +1,29 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.domain.coupon.DiscountAmount;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiscountAmountTest {
+
+    @ParameterizedTest
+    @ValueSource(longs = {999, 10001})
+    @DisplayName("정해진 할인 금액 범위를 벗어나면 예외 발생")
+    void givenDiscountAmountIsExceedRange(long discountAmount) {
+        assertThatCode(() -> new DiscountAmount(discountAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정해진 할인 금액 범위를 벗어났습니다.");
+    }
+
+    @Test
+    @DisplayName("할인 금액이 500원 단위가 아니면 예외 발생")
+    void givenDiscountAmountIsNotMultipleOf500() {
+        assertThatCode(() -> new DiscountAmount(5001))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("할인 금액은 정해진 단위로 입력해주세요.");
+    }
+}

--- a/src/test/java/coupon/domain/DiscountRangeTest.java
+++ b/src/test/java/coupon/domain/DiscountRangeTest.java
@@ -1,0 +1,28 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.domain.coupon.DiscountRange;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DiscountRangeTest {
+
+    @ParameterizedTest
+    @MethodSource("getDiscountAmountAndMinOrderAmount")
+    @DisplayName("정해진 할인율 범위를 넘어가면 예외 발생")
+    void givenDiscountRateIsExceedRange(long discountAmount, long minOrderAmount) {
+        assertThatCode(() -> new DiscountRange(discountAmount, minOrderAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정해진 할인율 범위를 벗어났습니다.");
+    }
+
+    private static Stream<Arguments> getDiscountAmountAndMinOrderAmount() {
+        return Stream.of(
+                Arguments.of(1000, 50000),
+                Arguments.of(21000, 100000));
+    }
+}

--- a/src/test/java/coupon/domain/IssueDurationTest.java
+++ b/src/test/java/coupon/domain/IssueDurationTest.java
@@ -1,0 +1,22 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.domain.coupon.IssueDuration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class IssueDurationTest {
+
+    @Test
+    @DisplayName("시작일이 종료일보다 늦으면 예외 발생")
+    void givenStartDateIsAfterEndDate() {
+        assertThatCode(() -> new IssueDuration(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2024, 12, 31)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("발급 시작일이 종료일보다 늦을 수 없습니다.");
+    }
+}

--- a/src/test/java/coupon/domain/MinOrderAmountTest.java
+++ b/src/test/java/coupon/domain/MinOrderAmountTest.java
@@ -1,0 +1,20 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.domain.coupon.MinOrderAmount;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MinOrderAmountTest {
+
+    @ParameterizedTest
+    @ValueSource(longs = {4999, 100001})
+    @DisplayName("정해진 최소 주문 금액 범위를 벗어나면 예외 발생")
+    void givenMinOrderAmountIsExceedRange(long minOrderAmount) {
+        assertThatCode(() -> new MinOrderAmount(minOrderAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정해진 최소 주문 금액 범위를 벗어났습니다.");
+    }
+}

--- a/src/test/java/coupon/domain/NameTest.java
+++ b/src/test/java/coupon/domain/NameTest.java
@@ -1,0 +1,22 @@
+package coupon.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.domain.coupon.Name;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NameTest {
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "  "})
+    @DisplayName("이름이 존재하지 않으면 예외 발생")
+    void givenNameIsNotExists(String name) {
+        assertThatCode(() -> new Name(name))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이름은 필수 값입니다.");
+    }
+}

--- a/src/test/java/coupon/domain/usercoupon/UsingDurationTest.java
+++ b/src/test/java/coupon/domain/usercoupon/UsingDurationTest.java
@@ -1,0 +1,22 @@
+package coupon.domain.usercoupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UsingDurationTest {
+
+    @Test
+    @DisplayName("발급된 쿠폰은 사용 만료일의 자정 전까지 사용 가능하다")
+    void test() {
+        LocalDateTime startDateTime = LocalDateTime.of(2024, 10, 18, 0, 0, 0);
+        UsingDuration usingDuration = new UsingDuration(startDateTime);
+
+        assertThat(usingDuration.getEndDateTime())
+                .isEqualTo(startDateTime.plusDays(7).with(LocalTime.MAX));
+    }
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,7 +1,6 @@
 package coupon.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import coupon.domain.coupon.Category;
 import coupon.domain.coupon.Coupon;

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,0 +1,38 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import coupon.domain.coupon.Category;
+import coupon.domain.coupon.Coupon;
+import coupon.entity.CouponEntity;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Test
+    @DisplayName("쿠폰 생성 테스트")
+    void createCoupon() {
+        Coupon coupon = new Coupon(null, "hello, coupon!", 1000,
+                10000, Category.FOOD, LocalDate.now(), LocalDate.now().plusDays(7));
+        couponService.create(coupon);
+    }
+
+    @Test
+    @DisplayName("복제지연 테스트")
+    void duplicationDelay() {
+        Coupon coupon = new Coupon(null, "coupon!!", 1000,
+                10000, Category.FOOD, LocalDate.now(), LocalDate.now().plusDays(7));
+        CouponEntity couponEntity = couponService.create(coupon);
+        Coupon savedCoupon = couponService.getCoupon(couponEntity.getId());
+        assertThat(savedCoupon).isNotNull();
+    }
+}


### PR DESCRIPTION
안녕하세요 무빈😊
우테코의 마지막 미션에서 만나게 되어 정말 반갑습니다.
제가 고민한 내용들을 간단히 적어봤어요~
(고민한 내용들을 그대로 드러내고자 '~다' 체를 사용했습니다 ㅎㅎ)

---

### 문제 상황 분석
쿠폰을 생성하고 나서 바로 그 쿠폰을 조회하려 할 때 발생하는 문제이다.
즉, writer 에 저장이 완료되었더라도, 읽어올 때 reader에서 읽어오기 때문에 아직 복제가 안되면 문제가 발생한다.
만약 이 서비스가 내부 직원들을 대상으로 하는 것이라면, 성능이 크게 중요하지 않을 수도 있다.
하지만 대상이 사용자들이라면? 성능이 중요하다.
그리고 쿠폰이라는 도메인은 돈과 관련되어있으므로 정합성도 못지 않게 중요하다.
굳이 우위를 가리자면, '정합성 > 성능'일 것이다.

따라서 가장 반드시 지켜야 하는 조건은
❗️저장된 쿠폰이 조회가 되는 것 & 저장되지 않은 쿠폰은 조회되지 않는 것❗️
이다. 

---

### 복제 지연 해결 방법

**1/ 클라이언트에서 or 서버에서 일정 시간 대기 후 읽어오는 방법**
- 구현은 가장 쉽겠지만, 성능이 좋지 않을 것이다.

**2/ writer 에 저장 후 값을 캐싱해고, read 시 캐시를 읽는 방법**
- writer 에 저장이 정상적으로 된게 보장이 된다면, 정합성의 문제는 없을 것 같다.
- 하지만 '캐시'라는 새로운 장치가 들어온다는 점에서 성능 측면에서 고려할게 많아진다.
- 만약 이 캐시가 remote 캐시라면, 네트워크 오버해드가 발생한다.
- local 캐시라면, 각 서버간 공유가 되지 않는 문제가 발생할 수 있다.
- 예를 들어서, 5대의 ec2 에 로드 밸런싱을 하고 있다면 local 캐시는 의미가 없어진다.
- session 을 사용하고 sticky session 기능을 사용한다면 문제가 되지 않을 수 있지만, 이 경우 캐싱이 스티키 세션에 의존하게 되어버린다.
- 따라서 이 방법을 사용한다면 remote cache 를 사용해야 할 것이다.

**3/ reader 에 없다면 writer 에서 읽어오는 방법**
- 데이터베이스가 다르다면, 데이서 소스가 다를 것이고, 서로 다른 커넥션이 생기게 된다.
- 하나의 트랜잭션에서 두개의 커넥션이 생긴다면, 트랜잭션의 시간이 더 길어지고, lock 하고 있는 리소스들도 많아진다.
- 이 과정에서 일반적인 트랜잭션보다 오버헤드가 발생한다.

---

### 결론

완벽한 방법은 없다🙀
그나마 고르자면 2번 또는 3번일 것인데, 그 빈도를 생각해보자면..

2번은 모든 조회 요청에 대해 remote 캐시를 조회한다.
3번은 'reader 에 없는 경우'에만 write 에 접근힌다.
따라서 발생 빈도가 적은 3번의 방법이 적절해보인다👍

하지만 복제 지연 시간이 유의미하게 길어진다면, 2번이 더 적절한 방법일 수도 있다.
