### PR TITLE
[1단계 - DB 복제와 캐시] 폴라(장유진) 미션 제출합니다.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         ipv4_address: 172.20.0.10
     volumes:
       - ./data/writer:/var/lib/mysql
+      - ./init/init.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_writer
     restart: always
     environment:
@@ -30,6 +31,7 @@ services:
         ipv4_address: 172.20.0.11
     volumes:
       - ./data/reader:/var/lib/mysql
+      - ./init/init.sql:/docker-entrypoint-initdb.d/init.sql
     container_name: mysql_reader
     environment:
       MYSQL_ROOT_PASSWORD: root

--- a/docker/init/init.sql
+++ b/docker/init/init.sql
@@ -1,0 +1,33 @@
+CREATE DATABASE IF NOT EXISTS coupon;
+USE coupon;
+
+create table coupon (
+                        discount_price integer not null,
+                        issue_date date not null,
+                        issue_end_date date not null,
+                        minimum_order_price integer not null,
+                        createdAt datetime(6),
+                        id bigint not null auto_increment,
+                        name varchar(30) not null,
+                        category enum ('FASHION','HOME_APPLIANCES','FURNITURE','FOOD') not null,
+                        primary key (id)
+);
+
+create table member (
+                        createdAt datetime(6),
+                        id bigint not null auto_increment,
+                        name varchar(255) not null,
+                        primary key (id)
+);
+
+create table member_coupon (
+                               is_used bit not null,
+                               coupon_id bigint not null,
+                               createdAt datetime(6),
+                               expired_at datetime(6) not null,
+                               id bigint not null auto_increment,
+                               issued_at datetime(6) not null,
+                               member_id bigint not null,
+                               primary key (id),
+                               foreign key (member_id) references member(id) on delete cascade
+);

--- a/src/main/java/coupon/CouponApplication.java
+++ b/src/main/java/coupon/CouponApplication.java
@@ -2,7 +2,9 @@ package coupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CouponApplication {
 

--- a/src/main/java/coupon/api/repository/CouponRepository.java
+++ b/src/main/java/coupon/api/repository/CouponRepository.java
@@ -1,0 +1,18 @@
+package coupon.api.repository;
+
+import coupon.entity.Coupon;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CouponRepository extends Repository<Coupon, Long> {
+
+    List<Coupon> findAll();
+
+    void save(Coupon coupon);
+
+    Optional<Coupon> findCouponById(Long couponId);
+
+    void deleteAll();
+}

--- a/src/main/java/coupon/api/service/CouponService.java
+++ b/src/main/java/coupon/api/service/CouponService.java
@@ -1,0 +1,35 @@
+package coupon.api.service;
+
+import coupon.api.repository.CouponRepository;
+import coupon.common.exception.CouponNotFoundException;
+import coupon.common.manager.TransactionManager;
+import coupon.domain.coupon.CouponDomain;
+import coupon.entity.Coupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public void create(CouponDomain coupon) {
+        couponRepository.save(new Coupon(coupon));
+    }
+
+    @Transactional(readOnly = true)
+    public Coupon searchCoupon(Long couponId) {
+        return couponRepository.findCouponById(couponId)
+                .orElse(searchFromReader(couponId));
+    }
+
+    private Coupon searchFromReader(Long couponId) {
+        return new TransactionManager().newTransaction(
+                () -> couponRepository.findCouponById(couponId)
+                        .orElseThrow(CouponNotFoundException::new)
+        );
+    }
+}

--- a/src/main/java/coupon/common/ErrorConstant.java
+++ b/src/main/java/coupon/common/ErrorConstant.java
@@ -1,0 +1,23 @@
+package coupon.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorConstant {
+
+    COUPON_NAME_IS_NULL_OR_EMPTY(HttpStatus.BAD_REQUEST, "쿠폰의 이름은 비어있을 수 없습니다."),
+    COUPON_NAME_IS_NOT_IN_RANGE(HttpStatus.BAD_REQUEST, "너무 긴 쿠폰 이름입니다."),
+    DISCOUNT_PRICE_NOT_IN_RANGE(HttpStatus.BAD_REQUEST, "가능한 할인 금액이 아닙니다."),
+    COUPON_PRICE_RATE_NOT_IN_RANGE(HttpStatus.BAD_REQUEST, "쿠폰의 할인율이 너무 높거나 낮습니다."),
+    NOT_AVAILABLE_UNIT_PRICE(HttpStatus.BAD_REQUEST, "가능한 금액 단위가 아닙니다."),
+    COUPON_ISSUE_DATE_IS_NULL(HttpStatus.BAD_REQUEST, "쿠폰의 날짜는 비어있을 수 없습니다."),
+    NOT_AVAILABLE_COUPON_DATE(HttpStatus.BAD_REQUEST, "쿠폰의 시작일이 끝나는 날보다 늦을 수 없습니다."),
+    MEMBER_NAME_IS_NULL_OR_EMPTY(HttpStatus.BAD_REQUEST, "이름은 비어있을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/coupon/common/ErrorConstant.java
+++ b/src/main/java/coupon/common/ErrorConstant.java
@@ -16,7 +16,7 @@ public enum ErrorConstant {
     NOT_AVAILABLE_UNIT_PRICE(HttpStatus.BAD_REQUEST, "가능한 금액 단위가 아닙니다."),
     COUPON_ISSUE_DATE_IS_NULL(HttpStatus.BAD_REQUEST, "쿠폰의 날짜는 비어있을 수 없습니다."),
     NOT_AVAILABLE_COUPON_DATE(HttpStatus.BAD_REQUEST, "쿠폰의 시작일이 끝나는 날보다 늦을 수 없습니다."),
-    MEMBER_NAME_IS_NULL_OR_EMPTY(HttpStatus.BAD_REQUEST, "이름은 비어있을 수 없습니다.");
+    MEMBER_NAME_IS_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "이름은 비어있을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/coupon/common/exception/CouponException.java
+++ b/src/main/java/coupon/common/exception/CouponException.java
@@ -1,0 +1,24 @@
+package coupon.common.exception;
+
+import coupon.common.ErrorConstant;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CouponException extends RuntimeException {
+
+    private final ErrorConstant errorConstant;
+
+    public CouponException(ErrorConstant error) {
+        super(error.getMessage());
+        this.errorConstant = error;
+    }
+
+    public String getMessage() {
+        return errorConstant.getMessage();
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorConstant.getHttpStatus();
+    }
+}

--- a/src/main/java/coupon/common/exception/CouponNotFoundException.java
+++ b/src/main/java/coupon/common/exception/CouponNotFoundException.java
@@ -1,0 +1,16 @@
+package coupon.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CouponNotFoundException extends RuntimeException {
+
+    private static final String MESSAGE = "해당하는 쿠폰을 찾을 수 없습니다.";
+
+    private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+    public CouponNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/coupon/common/manager/TransactionManager.java
+++ b/src/main/java/coupon/common/manager/TransactionManager.java
@@ -1,0 +1,16 @@
+package coupon.common.manager;
+
+import lombok.NoArgsConstructor;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Supplier;
+
+@NoArgsConstructor
+public class TransactionManager {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public <T> T newTransaction(Supplier<T> supplier) {
+        return supplier.get();
+    }
+}

--- a/src/main/java/coupon/common/response/ExceptionResponse.java
+++ b/src/main/java/coupon/common/response/ExceptionResponse.java
@@ -1,0 +1,18 @@
+package coupon.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ExceptionResponse {
+
+    private String message;
+
+    public static ExceptionResponse from(String message) {
+        return new ExceptionResponse(message);
+    }
+}

--- a/src/main/java/coupon/config/DatabaseType.java
+++ b/src/main/java/coupon/config/DatabaseType.java
@@ -1,0 +1,7 @@
+package coupon.config;
+
+public enum DatabaseType {
+
+    READ,
+    WRITE
+}

--- a/src/main/java/coupon/config/ReplicationDatasourceConfig.java
+++ b/src/main/java/coupon/config/ReplicationDatasourceConfig.java
@@ -31,7 +31,7 @@ public class ReplicationDatasourceConfig {
     }
 
     @Bean
-    public DataSource dynamicDataSource(
+    public DataSource routingDataSource(
             @Qualifier(read) DataSource writerDataSource,
             @Qualifier(write) DataSource readerDataSource
     ) {
@@ -49,7 +49,7 @@ public class ReplicationDatasourceConfig {
     @Bean
     @Primary
     public DataSource dataSource() {
-        DataSource dataSource = dynamicDataSource(writeDataSource(), readDataSource());
+        DataSource dataSource = routingDataSource(writeDataSource(), readDataSource());
         return new LazyConnectionDataSourceProxy(dataSource);
     }
 }

--- a/src/main/java/coupon/config/ReplicationDatasourceConfig.java
+++ b/src/main/java/coupon/config/ReplicationDatasourceConfig.java
@@ -1,0 +1,55 @@
+package coupon.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+@Configuration
+public class ReplicationDatasourceConfig {
+
+    private static final String read = "read";
+    private static final String write = "writer";
+
+    @Bean(read)
+    @ConfigurationProperties(prefix = "coupon.datasource.writer")
+    public DataSource writeDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean(write)
+    @ConfigurationProperties(prefix = "coupon.datasource.reader")
+    public DataSource readDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    public DataSource dynamicDataSource(
+            @Qualifier(read) DataSource writerDataSource,
+            @Qualifier(write) DataSource readerDataSource
+    ) {
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+        Map<Object, Object> dataSourceMap = Map.of(
+                DatabaseType.READ, readerDataSource,
+                DatabaseType.WRITE, writerDataSource
+        );
+
+        routingDataSource.setTargetDataSources(dataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(writerDataSource);
+        return readerDataSource;
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        DataSource dataSource = dynamicDataSource(writeDataSource(), readDataSource());
+        return new LazyConnectionDataSourceProxy(dataSource);
+    }
+}

--- a/src/main/java/coupon/config/RoutingDataSource.java
+++ b/src/main/java/coupon/config/RoutingDataSource.java
@@ -1,0 +1,15 @@
+package coupon.config;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+    
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return DatabaseType.READ;
+        }
+        return DatabaseType.WRITE;
+    }
+}

--- a/src/main/java/coupon/domain/coupon/Category.java
+++ b/src/main/java/coupon/domain/coupon/Category.java
@@ -1,0 +1,15 @@
+package coupon.domain.coupon;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Category {
+
+    FASHION("패션"),
+    HOME_APPLIANCES("가전"),
+    FURNITURE("가구"),
+    FOOD("식품");
+
+    private final String name;
+}

--- a/src/main/java/coupon/domain/coupon/CouponDomain.java
+++ b/src/main/java/coupon/domain/coupon/CouponDomain.java
@@ -1,0 +1,50 @@
+package coupon.domain.coupon;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class CouponDomain {
+
+    private final CouponName couponName;
+
+    private final PriceInformation priceInformation;
+
+    private final Category category;
+
+    private final IssuePeriod issuePeriod;
+
+    public CouponDomain(String couponName,
+                        int discountPrice,
+                        int minimumPrice,
+                        Category category,
+                        LocalDate issueDate,
+                        LocalDate endDate
+    ) {
+        this.couponName = new CouponName(couponName);
+        this.priceInformation = new PriceInformation(discountPrice, minimumPrice);
+        this.category = category;
+        this.issuePeriod = new IssuePeriod(issueDate, endDate);
+    }
+
+    public String getCouponName() {
+        return couponName.getName();
+    }
+
+    public int getDiscountPrice() {
+        return priceInformation.getDiscountPrice();
+    }
+
+    public int getMinimumPrice() {
+        return priceInformation.getMinimumPrice();
+    }
+
+    public LocalDate getStartDate() {
+        return issuePeriod.getStartDate();
+    }
+
+    public LocalDate getEndDate() {
+        return issuePeriod.getEndDate();
+    }
+}

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class CouponName {
 
-    private static final int MAX_COUPON_NAME_LENGTH = 30;
+    public static final int MAX_COUPON_NAME_LENGTH = 30;
 
     private final String name;
 
@@ -17,7 +17,7 @@ public class CouponName {
     }
 
     private void validate(String name) {
-        if (name == null || name.isEmpty()) {
+        if (name == null || name.isBlank()) {
             throw new CouponException(ErrorConstant.COUPON_NAME_IS_NULL_OR_EMPTY);
         }
 

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -1,0 +1,29 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import lombok.Getter;
+
+@Getter
+public class CouponName {
+
+    private static final int MAX_COUPON_NAME_LENGTH = 30;
+
+    private final String name;
+
+    public CouponName(String name) {
+        validate(name);
+        this.name = name;
+    }
+
+    private void validate(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new CouponException(ErrorConstant.COUPON_NAME_IS_NULL_OR_EMPTY);
+        }
+
+        int nameLength = name.length();
+        if (MAX_COUPON_NAME_LENGTH < nameLength) {
+            throw new CouponException(ErrorConstant.COUPON_NAME_IS_NOT_IN_RANGE);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/DiscountPrice.java
+++ b/src/main/java/coupon/domain/coupon/DiscountPrice.java
@@ -1,0 +1,29 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import lombok.Getter;
+
+@Getter
+public class DiscountPrice {
+
+    public static final int MINIMUM_PRICE = 1000;
+    public static final int MAXIMUM_PRICE = 10000;
+    public static final int PRICE_UNIT = 500;
+
+    private final int price;
+
+    public DiscountPrice(int price) {
+        validate(price);
+        this.price = price;
+    }
+
+    private void validate(int price) {
+        if (price < MINIMUM_PRICE || MAXIMUM_PRICE < price) {
+            throw new CouponException(ErrorConstant.DISCOUNT_PRICE_NOT_IN_RANGE);
+        }
+        if (price % PRICE_UNIT != 0) {
+            throw new CouponException(ErrorConstant.NOT_AVAILABLE_UNIT_PRICE);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/IssuePeriod.java
+++ b/src/main/java/coupon/domain/coupon/IssuePeriod.java
@@ -1,0 +1,30 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class IssuePeriod {
+
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+
+    public IssuePeriod(LocalDate startDate, LocalDate endDate) {
+        validate(startDate, endDate);
+
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    private void validate(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            throw new CouponException(ErrorConstant.COUPON_ISSUE_DATE_IS_NULL);
+        }
+        if (startDate.isAfter(endDate)) {
+            throw new CouponException(ErrorConstant.NOT_AVAILABLE_COUPON_DATE);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/MinimumPrice.java
+++ b/src/main/java/coupon/domain/coupon/MinimumPrice.java
@@ -1,0 +1,25 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import lombok.Getter;
+
+@Getter
+public class MinimumPrice {
+
+    public static final int MINIMUM_PRICE = 5000;
+    public static final int MAXIMUM_PRICE = 100000;
+
+    private final int price;
+
+    public MinimumPrice(int price) {
+        validate(price);
+        this.price = price;
+    }
+
+    private void validate(int price) {
+        if (price < MINIMUM_PRICE || MAXIMUM_PRICE < price) {
+            throw new CouponException(ErrorConstant.DISCOUNT_PRICE_NOT_IN_RANGE);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/coupon/PriceInformation.java
+++ b/src/main/java/coupon/domain/coupon/PriceInformation.java
@@ -1,0 +1,36 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+
+public class PriceInformation {
+
+    private static final int MAXIMUM_DISCOUNT_RATE = 20;
+    private static final int MINIMUM_DISCOUNT_RATE = 3;
+
+    private final DiscountPrice discountPrice;
+    private final MinimumPrice minimumPrice;
+
+    public PriceInformation(int discountPrice, int minimumPrice) {
+        validateDiscountRate(discountPrice, minimumPrice);
+
+        this.discountPrice = new DiscountPrice(discountPrice);
+        this.minimumPrice = new MinimumPrice(minimumPrice);
+    }
+
+    private void validateDiscountRate(int discountPrice, int minimumPrice) {
+        int rate = minimumPrice / discountPrice;
+
+        if (rate < MINIMUM_DISCOUNT_RATE || MAXIMUM_DISCOUNT_RATE < rate) {
+            throw new CouponException(ErrorConstant.COUPON_PRICE_RATE_NOT_IN_RANGE);
+        }
+    }
+
+    public int getDiscountPrice() {
+        return discountPrice.getPrice();
+    }
+
+    public int getMinimumPrice() {
+        return minimumPrice.getPrice();
+    }
+}

--- a/src/main/java/coupon/domain/member/MemberDomain.java
+++ b/src/main/java/coupon/domain/member/MemberDomain.java
@@ -1,0 +1,14 @@
+package coupon.domain.member;
+
+public class MemberDomain {
+
+    private final MemberName memberName;
+    
+    public MemberDomain(String name) {
+        this.memberName = new MemberName(name);
+    }
+
+    public String getMemberName() {
+        return memberName.getName();
+    }
+}

--- a/src/main/java/coupon/domain/member/MemberName.java
+++ b/src/main/java/coupon/domain/member/MemberName.java
@@ -1,0 +1,22 @@
+package coupon.domain.member;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import lombok.Getter;
+
+@Getter
+public class MemberName {
+
+    private final String name;
+
+    public MemberName(String name) {
+        validate(name);
+        this.name = name;
+    }
+
+    private void validate(String name) {
+        if (name == null || name.isBlank()) {
+            throw new CouponException(ErrorConstant.MEMBER_NAME_IS_NULL_OR_EMPTY);
+        }
+    }
+}

--- a/src/main/java/coupon/domain/member/MemberName.java
+++ b/src/main/java/coupon/domain/member/MemberName.java
@@ -16,7 +16,7 @@ public class MemberName {
 
     private void validate(String name) {
         if (name == null || name.isBlank()) {
-            throw new CouponException(ErrorConstant.MEMBER_NAME_IS_NULL_OR_EMPTY);
+            throw new CouponException(ErrorConstant.MEMBER_NAME_IS_NULL_OR_BLANK);
         }
     }
 }

--- a/src/main/java/coupon/entity/Coupon.java
+++ b/src/main/java/coupon/entity/Coupon.java
@@ -1,0 +1,54 @@
+package coupon.entity;
+
+import coupon.domain.coupon.Category;
+import coupon.domain.coupon.CouponDomain;
+import coupon.entity.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Table(name = "coupon")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "discount_price", nullable = false)
+    private int discountPrice;
+
+    @Column(name = "minimum_order_price", nullable = false)
+    private int minimumOrderPrice;
+
+    @Column(name = "category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    @Column(name = "issue_date", nullable = false)
+    private LocalDate issueDate;
+
+    @Column(name = "issue_end_date", nullable = false)
+    private LocalDate issueEndDate;
+
+    public Coupon(CouponDomain coupon) {
+        this(null,
+                coupon.getCouponName(),
+                coupon.getDiscountPrice(),
+                coupon.getMinimumPrice(),
+                coupon.getCategory(),
+                coupon.getStartDate(),
+                coupon.getEndDate()
+        );
+    }
+}

--- a/src/main/java/coupon/entity/Member.java
+++ b/src/main/java/coupon/entity/Member.java
@@ -1,0 +1,35 @@
+package coupon.entity;
+
+import coupon.domain.member.MemberDomain;
+import coupon.entity.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "member")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    public Member(MemberDomain memberDomain) {
+        this(null,
+                memberDomain.getMemberName());
+    }
+
+    public MemberCoupon issueCoupon(Long couponId, LocalDateTime issuedAt) {
+        return MemberCoupon.issueOf(this, couponId, issuedAt);
+    }
+}

--- a/src/main/java/coupon/entity/MemberCoupon.java
+++ b/src/main/java/coupon/entity/MemberCoupon.java
@@ -1,0 +1,42 @@
+package coupon.entity;
+
+import coupon.entity.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "member_coupon")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCoupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "coupon_id", nullable = false)
+    private Long couponId;
+
+    @OneToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "is_used", nullable = false)
+    private Boolean isUsed;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    public static MemberCoupon issueOf(Member member, Long couponId, LocalDateTime issuedAt) {
+        return new MemberCoupon(null, couponId, member, false, issuedAt, issuedAt.plusDays(7));
+    }
+}

--- a/src/main/java/coupon/entity/base/BaseEntity.java
+++ b/src/main/java/coupon/entity/base/BaseEntity.java
@@ -1,0 +1,20 @@
+package coupon.entity.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/coupon/handler/GlobalExceptionHandler.java
+++ b/src/main/java/coupon/handler/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package coupon.handler;
+
+import coupon.common.exception.CouponException;
+import coupon.common.exception.CouponNotFoundException;
+import coupon.common.response.ExceptionResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(CouponException.class)
+    private ResponseEntity<ExceptionResponse> couponException(
+            HttpServletRequest request,
+            CouponException e
+    ) {
+        logHandlerError(request, e.getMessage());
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ExceptionResponse.from(e.getErrorConstant().getMessage()));
+    }
+
+    @ExceptionHandler(CouponNotFoundException.class)
+    private ResponseEntity<ExceptionResponse> couponNotFoundException(
+            HttpServletRequest request,
+            CouponNotFoundException e
+    ) {
+        logHandlerError(request, e.getMessage());
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ExceptionResponse.from(e.getMessage()));
+    }
+
+    private void logHandlerError(HttpServletRequest request, String message) {
+        log.error("message : {} URL : {} method : {} query : {} ",
+                message,
+                request.getRequestURL(),
+                request.getMethod(),
+                request.getQueryString()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
         hbm2ddl.auto: validate
         check_nullability: true
@@ -21,14 +21,14 @@ coupon.datasource:
   writer:
     type: com.zaxxer.hikari.HikariDataSource
     driverClassName: com.mysql.cj.jdbc.Driver
-    jdbcUrl: jdbc:mysql://localhost:33306/coupon?characterEncoding=UTF-8&serverTimezone=UTC
+    jdbcUrl: jdbc:mysql://localhost:33306/coupon?createDatabaseIfNotExist=true&characterEncoding=UTF-8&serverTimezone=UTC
     username: root
     password: root
     maximumPoolSize: 10
   reader:
     type: com.zaxxer.hikari.HikariDataSource
     driverClassName: com.mysql.cj.jdbc.Driver
-    jdbcUrl: jdbc:mysql://localhost:33307/coupon?characterEncoding=UTF-8&serverTimezone=UTC
+    jdbcUrl: jdbc:mysql://localhost:33307/coupon?createDatabaseIfNotExist=true&characterEncoding=UTF-8&serverTimezone=UTC
     username: root
     password: root
     maximumPoolSize: 10

--- a/src/test/java/coupon/api/service/CouponServiceTest.java
+++ b/src/test/java/coupon/api/service/CouponServiceTest.java
@@ -1,0 +1,50 @@
+package coupon.api.service;
+
+import coupon.api.repository.CouponRepository;
+import coupon.common.exception.CouponNotFoundException;
+import coupon.domain.coupon.Category;
+import coupon.domain.coupon.CouponDomain;
+import coupon.entity.Coupon;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Test
+    @DisplayName("Replication이 딜레이 되더라도 쿠폰 조회에 영향이 가지 않는다.")
+    void replicationDelay() {
+        int couponSize = couponRepository.findAll().size();
+
+        CouponDomain coupon = new CouponDomain("coupon",
+                1000,
+                10000,
+                Category.FASHION,
+                LocalDate.now(),
+                LocalDate.now().plusDays(3)
+        );
+        couponService.create(coupon);
+
+        Coupon savedCoupon = couponService.searchCoupon((long) (couponSize + 1));
+        assertThat(savedCoupon).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 쿠폰인 경우 에러를 발생한다.")
+    void searchCoupon_whenNotExist() {
+        assertThatThrownBy(() -> couponService.searchCoupon(Long.MAX_VALUE))
+                .isInstanceOf(CouponNotFoundException.class);
+    }
+}

--- a/src/test/java/coupon/domain/coupon/CouponNameTest.java
+++ b/src/test/java/coupon/domain/coupon/CouponNameTest.java
@@ -1,0 +1,27 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CouponNameTest {
+
+    @Test
+    @DisplayName("이름이 없을 경우 에러를 발생한다.")
+    void getName_WhenNameIsEmpty() {
+        assertThatThrownBy(() -> new CouponName(null))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.COUPON_NAME_IS_NULL_OR_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("이름의 길이가 기준보다 길경우 에러를 발생한다.")
+    void getName_WhenNameIsLong() {
+        assertThatThrownBy(() -> new CouponName("1111111111111111111111111111111111"))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.COUPON_NAME_IS_NOT_IN_RANGE.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/coupon/CouponNameTest.java
+++ b/src/test/java/coupon/domain/coupon/CouponNameTest.java
@@ -11,8 +11,16 @@ class CouponNameTest {
 
     @Test
     @DisplayName("이름이 없을 경우 에러를 발생한다.")
-    void getName_WhenNameIsEmpty() {
+    void getName_WhenNameIsNull() {
         assertThatThrownBy(() -> new CouponName(null))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.COUPON_NAME_IS_NULL_OR_EMPTY.getMessage());
+    }
+
+    @Test
+    @DisplayName("이름이 공백인 경우 에러를 발생한다.")
+    void getName_WhenNameIsBlank() {
+        assertThatThrownBy(() -> new CouponName("     "))
                 .isInstanceOf(CouponException.class)
                 .hasMessage(ErrorConstant.COUPON_NAME_IS_NULL_OR_EMPTY.getMessage());
     }
@@ -20,7 +28,7 @@ class CouponNameTest {
     @Test
     @DisplayName("이름의 길이가 기준보다 길경우 에러를 발생한다.")
     void getName_WhenNameIsLong() {
-        assertThatThrownBy(() -> new CouponName("1111111111111111111111111111111111"))
+        assertThatThrownBy(() -> new CouponName("1".repeat(CouponName.MAX_COUPON_NAME_LENGTH + 1)))
                 .isInstanceOf(CouponException.class)
                 .hasMessage(ErrorConstant.COUPON_NAME_IS_NOT_IN_RANGE.getMessage());
     }

--- a/src/test/java/coupon/domain/coupon/DiscountPriceTest.java
+++ b/src/test/java/coupon/domain/coupon/DiscountPriceTest.java
@@ -1,0 +1,35 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DiscountPriceTest {
+
+    @Test
+    @DisplayName("쿠폰의 할인 가격이 범위보다 작을 경우 에러를 발생한다.")
+    void discountPrice_NotInRange_Small() {
+        assertThatThrownBy(() -> new DiscountPrice(DiscountPrice.MINIMUM_PRICE - 1))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.DISCOUNT_PRICE_NOT_IN_RANGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("쿠폰의 할인 가격이 범위보다 클 경우 에러를 발생한다.")
+    void discountPrice_NotInRange_Big() {
+        assertThatThrownBy(() -> new DiscountPrice(DiscountPrice.MAXIMUM_PRICE + 1))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.DISCOUNT_PRICE_NOT_IN_RANGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("쿠폰의 가격 단위에 맞지 않는 경우 에러를 발생한다.")
+    void discountPrice_NotAvailableUnit() {
+        assertThatThrownBy(() -> new DiscountPrice(DiscountPrice.MINIMUM_PRICE + 1))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.NOT_AVAILABLE_UNIT_PRICE.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/coupon/IssuePeriodTest.java
+++ b/src/test/java/coupon/domain/coupon/IssuePeriodTest.java
@@ -26,4 +26,12 @@ class IssuePeriodTest {
                 .isInstanceOf(CouponException.class)
                 .hasMessage(ErrorConstant.COUPON_ISSUE_DATE_IS_NULL.getMessage());
     }
+
+    @Test
+    @DisplayName("종료 일자가 시작일자보다 앞설 경우 에러를 발생한다.")
+    void issuePeriod_WhenStartDateIsAfterEndDate() {
+        assertThatThrownBy(() -> new IssuePeriod(LocalDate.now().plusDays(1), LocalDate.now()))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.NOT_AVAILABLE_COUPON_DATE.getMessage());
+    }
 }

--- a/src/test/java/coupon/domain/coupon/IssuePeriodTest.java
+++ b/src/test/java/coupon/domain/coupon/IssuePeriodTest.java
@@ -1,0 +1,29 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IssuePeriodTest {
+
+    @Test
+    @DisplayName("발행 일자가 null 일 경우 에러를 발생한다.")
+    void issuePeriod_WhenDateIsNull() {
+        assertThatThrownBy(() -> new IssuePeriod(null, LocalDate.now()))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.COUPON_ISSUE_DATE_IS_NULL.getMessage());
+    }
+
+    @Test
+    @DisplayName("종료 일자가 null 일 경우 에러를 발생한다.")
+    void issuePeriod_WhenEndDateIsNull() {
+        assertThatThrownBy(() -> new IssuePeriod(LocalDate.now(), null))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.COUPON_ISSUE_DATE_IS_NULL.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/coupon/MinimumPriceTest.java
+++ b/src/test/java/coupon/domain/coupon/MinimumPriceTest.java
@@ -1,0 +1,27 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MinimumPriceTest {
+
+    @Test
+    @DisplayName("가능한 범위의 최소값이 아닌 최소금액인 경우 에러를 발생한다.")
+    void minimumPrice_WhenSmall() {
+        assertThatThrownBy(() -> new MinimumPrice(MinimumPrice.MINIMUM_PRICE - 1))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.DISCOUNT_PRICE_NOT_IN_RANGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("가능한 범위의 최대값이 아닌 최소금액인 경우 에러를 발생한다.")
+    void minimumPrice_WhenBig() {
+        assertThatThrownBy(() -> new MinimumPrice(MinimumPrice.MAXIMUM_PRICE + 1))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.DISCOUNT_PRICE_NOT_IN_RANGE.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/coupon/PriceInformationTest.java
+++ b/src/test/java/coupon/domain/coupon/PriceInformationTest.java
@@ -5,14 +5,18 @@ import coupon.common.exception.CouponException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-class PriceInformationTest {
+class
+
+PriceInformationTest {
 
     @Test
     @DisplayName("총 할인율이 가능한 범위가 아닌 1% 인 경우 에러를 발생한다.")
     void priceInformation_WhenNoRate() {
-        assertThatThrownBy(() -> new PriceInformation(1000, 100000))
+        assertThatThrownBy(() -> new PriceInformation(DiscountPrice.MINIMUM_PRICE, MinimumPrice.MAXIMUM_PRICE))
                 .isInstanceOf(CouponException.class)
                 .hasMessage(ErrorConstant.COUPON_PRICE_RATE_NOT_IN_RANGE.getMessage());
     }
@@ -20,8 +24,19 @@ class PriceInformationTest {
     @Test
     @DisplayName("총 할인율이 가능한 범위가 아닌 100% 인 경우 에러를 발생한다.")
     void priceInformation_When100Rate() {
-        assertThatThrownBy(() -> new PriceInformation(10000, 10000))
+        assertThatThrownBy(() -> new PriceInformation(DiscountPrice.MAXIMUM_PRICE, DiscountPrice.MAXIMUM_PRICE))
                 .isInstanceOf(CouponException.class)
                 .hasMessage(ErrorConstant.COUPON_PRICE_RATE_NOT_IN_RANGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("총 할인율이 가능한 범위인 경우 에러를 발생하지 않는다.")
+    void priceInformation_WhenAvailableRate() {
+        PriceInformation priceInformation = new PriceInformation(DiscountPrice.MINIMUM_PRICE, MinimumPrice.MINIMUM_PRICE);
+
+        assertAll(
+                () -> assertThat(priceInformation.getMinimumPrice()).isEqualTo(MinimumPrice.MINIMUM_PRICE),
+                () -> assertThat(priceInformation.getDiscountPrice()).isEqualTo(DiscountPrice.MINIMUM_PRICE)
+        );
     }
 }

--- a/src/test/java/coupon/domain/coupon/PriceInformationTest.java
+++ b/src/test/java/coupon/domain/coupon/PriceInformationTest.java
@@ -1,0 +1,27 @@
+package coupon.domain.coupon;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PriceInformationTest {
+
+    @Test
+    @DisplayName("총 할인율이 가능한 범위가 아닌 1% 인 경우 에러를 발생한다.")
+    void priceInformation_WhenNoRate() {
+        assertThatThrownBy(() -> new PriceInformation(1000, 100000))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.COUPON_PRICE_RATE_NOT_IN_RANGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("총 할인율이 가능한 범위가 아닌 100% 인 경우 에러를 발생한다.")
+    void priceInformation_When100Rate() {
+        assertThatThrownBy(() -> new PriceInformation(10000, 10000))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.COUPON_PRICE_RATE_NOT_IN_RANGE.getMessage());
+    }
+}

--- a/src/test/java/coupon/domain/member/MemberNameTest.java
+++ b/src/test/java/coupon/domain/member/MemberNameTest.java
@@ -14,6 +14,6 @@ class MemberNameTest {
     void memberName_WhenEmpty() {
         assertThatThrownBy(() -> new MemberName(" "))
                 .isInstanceOf(CouponException.class)
-                .hasMessage(ErrorConstant.MEMBER_NAME_IS_NULL_OR_EMPTY.getMessage());
+                .hasMessage(ErrorConstant.MEMBER_NAME_IS_NULL_OR_BLANK.getMessage());
     }
 }

--- a/src/test/java/coupon/domain/member/MemberNameTest.java
+++ b/src/test/java/coupon/domain/member/MemberNameTest.java
@@ -1,0 +1,19 @@
+package coupon.domain.member;
+
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MemberNameTest {
+
+    @Test
+    @DisplayName("이름이 비어있는 경우 에러를 발생한다.")
+    void memberName_WhenEmpty() {
+        assertThatThrownBy(() -> new MemberName(" "))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.MEMBER_NAME_IS_NULL_OR_EMPTY.getMessage());
+    }
+}


### PR DESCRIPTION
안녕하세요 리니! 폴라입니다! 😊

일단 제 가정이 어떤 상황이었는지 말씀드려야 할 것 같아요!

## 제가 생각한 상황

요구사항에 나와있는 것처럼 쿠폰과 유저쿠폰은 나뉘어져있는 것으로 보아 **쿠폰 발급**이라는 로직은,
어드민 페이지에서 쓰일 것이라고 생각했습니다.

즉, 예를 들어 크리스마스에 쿠폰을 발급한다고 가정했을 때 이 행위는 **당장 발급 1초전, 하루 전날에 이루어지지 않을 것**이라고 생각했습니다. 🤔

## 생각의 흐름

### 🔥 쿠폰 등록 이후의 복제 지연이 문제인가?

솔직히 문제라고 느껴지지 않았습니다.

보통 쿠폰을 등록한 이후 쿠폰을 다시 본다고 하더라도 1초 이상은 걸릴 것 같았던 것이 첫번째 이유이고
만약 1초라는 수치가 2초가 되더라도 **쿠폰 등록** 에서 만큼은 문제가 없다고 느꼈습니다.

등록하고 바로 수정을 한다고 하더라도 그 과정이 그만큼 짧은 시간안에 이루어질까요?
쿠폰을 다운받도록 열려있는 상태가 아닌 **쿠폰을 만드는 과정**이니 사실 1초 아니 2초가 걸려도 문제가 없다고 생각해요.

그래서 **_솔직히 그냥 둘까_** 라는 것도 고민에 들어가있었어요.

### 📑 굳이 다시 읽어야 하는가?

그래도 지연은 지연이니깐요. 정말 정말 만약에 중요한 이벤트여서 모두가 보고있는 시점이라면 다같이 1초를 기다리게 되겠지요.
그래서 두번째로 생각한 것은 **그냥 되돌려주기**였어요.

저 였다면 쿠폰을 등록했을 때 등록한 쿠폰 정보를 보여주고 뒤로갔을 때 쿠폰 리스트를 조회하게 할 것 같거든요. 🤔
그렇다면 뒤로가기에 **쿠폰을 등록하고 뒤로가서 리스트를 불러오는 것은 적어도 1초 이상이 아닐까요?**

쿠폰 정보를 보여주는 탭이 없더라도 반환된 쿠폰 정보를 현재 있는 리스트 맨 상단에 붙여주세요 라는 
소통만 되어도 문제가 없다고 생각했습니다.

### 💧 아무도 믿지 말자

그렇지만 이런 경우에는 **"소통"이 되어야 한다**는게 문제가 될 수 있습니다. 💨
결국 둘 중 한쪽만 삐끗해도 문제가 발생한다는 것이니깐요. 

저도 간혹 이렇게 싱크가 안맞았던..그러니까 누군가에겐 당연했지만 당연하지 않았던 상황들이 많아서 이왕이면 소통을 하지 않고도 쓸 수 있게 하는 것이 맞겠다 생각했어요.

또 서버 상에서 이제는 **_"복제지연 해결했습니다~ 이제 반환 안할거예요~ "_** 라고 한다면 프론트도 그에 맞는 조치를 취해야겠죠.
이게 굉장히 불편한 것 같아요.

### 🌟 캐시..?

그 다음으로 생각한 것이 캐싱이였습니다. 왜냐면 이미 `Redis` 가 `Docker-compose` 안에 넣어주신 상태였더라구요 ㅋㅋㅋㅋㅋ

그렇지만 결국 선택하지 않았습니다.
일단 `Redis`가 제공되긴 했으나 여기서 사용한다고 하더라도 
굳이 **`Redis` 를 사용해야만 했던 이유**에 대해서는 제가 답할 수 없을 것 같았어요.

데이터 구조가 유연하고 읽기,저장이 빠르다 는 것이 제가 생각하는 `Redis`의 장점인데 이게 지금 상황에 어울리는가?
로 생각하면 아니라고 생각했습니다.

그래서 일단은 단순히 캐싱만 하기 좋은 데이터베이스나 구조가 뭐가 있을까 좀 더 고민해보는 것으로 결정했습니다.

### 쿠폰 등록 이후의 복제 지연이 문제인가? 라는 생각을 한 이유

그렇지만 일단 지연 안되게 해주세요 라는 요청이 들어왔다고 가정한다면 기간안에(미션 기간) 지연은 안되게 해야겠죠

다시 처음으로 돌아가서 제가 "쿠폰 등록 이후의 복제 지연이 문제인가?" 라는 생각을 한 이유는 결국
1. 그만큼 잦은 요청이 들어올 만하지 않은 기능이기 때문에
2. 1초 단위가 시급한 기능이 아니기 때문에

이 두가지로 좁혀진다고 봤을때 한가지 들어온 생각이 지금의 방식인 `Write` 에서 읽는 것이였습니다.


## 🤔 이유

일단 `Write` 로 읽음으로써 생겼던 걱정은 이랬습니다.

```
1. 잦다면 `Write` 에 부하가 커질것이라는 점
2. 존재하지 않는 `id` 일때도 `Read` 와 `Write` DB를 모두 거쳐야 한다는 점
3. 만들어진 이후에 바로 수정을 하는 경우 누군가는 다른 정보를 바라보고 있을 것이라는 점
```

`1`초라는 전제가 쥐어졌기 때문에 일단 3번은 이뤄지기 힘들다고 보는게 맞을 것 같습니다.
어드민 "페이지" 니까 결국 누군가 등록하고 그게 누군가에게 보여지고, 그것을 누군가가 수정하고, 수정한 것이 등록되고 의 흐름이니깐요.

그리고 1번은 "어드민 페이지" 라는 가정을 했을때 
갑자기 저희 회사가 미쳐서 연속적으로 새로운 이벤트용 쿠폰을 생산하자 하는게 아니고서야 "잦지 않다"는 것이 자명하기 때문에 똑같이 힘들다고 볼 수 있을 것 같습니다.

나머지 2번이 제일 마음에 걸렸습니다.
존재하지 않는 `id`를 호출할일이 얼마나 잦겠냐만은 그럼에도 앞으로 생기는 모든 `API` 에 없는경우~에서 찾아~ 를 가정하고 코드를 짜야 한다는게 참 불편하고 슬프더라고요. (이건 캐싱도 마찬가지긴 하겠네요)

그래서 2단계에서는 이 부분을 해소하는 것을 목표로 잡고
아직은 잦지 않기 때문에 요구사항이었던 복제 지연 문제는 이렇게 해결하고 2단계 넘어가면서 좀 더 고민해보려고 합니다! 😀

리니의 생각은 어떨지 궁금하네요! 😊