### PR TITLE
[2단계 - DB 복제와 캐시] 새양(양경호) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package coupon.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+@EnableCaching
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer(objectMapper)));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
+    }
+}

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package coupon.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.cache.CacheManager;
@@ -10,12 +12,28 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @EnableCaching
 @Configuration
 public class RedisConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        return objectMapper;
+    }
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
@@ -29,10 +47,15 @@ public class RedisConfig {
                 .build();
     }
 
+
     @Bean
-    public ObjectMapper objectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        return objectMapper;
+    public RedisTemplate<String, Long> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return template;
     }
 }

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -2,6 +2,7 @@ package coupon.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -20,7 +21,8 @@ public class RedisConfig {
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer(objectMapper)));
+                        new GenericJackson2JsonRedisSerializer(objectMapper)))
+                .entryTtl(Duration.ofMinutes(10));
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .cacheDefaults(cacheConfig)

--- a/src/main/java/coupon/config/RoutingDataSource.java
+++ b/src/main/java/coupon/config/RoutingDataSource.java
@@ -13,11 +13,11 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
     @Override
     protected Object determineCurrentLookupKey() {
         if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
-            log.debug("Using Reader DataSource");
+            log.debug("Reader dataSource used");
             return READER_SERVER;
         }
 
-        log.debug("Using Writer DataSource");
+        log.debug("Writer dataSource used");
         return WRITER_SERVER;
     }
 }

--- a/src/main/java/coupon/dao/MemberCouponCacheDao.java
+++ b/src/main/java/coupon/dao/MemberCouponCacheDao.java
@@ -1,0 +1,33 @@
+package coupon.dao;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberCouponCacheDao {
+
+    private static final String CACHE_KEY_MEMBER_COUPON_COUNT = "member-coupon:count";
+
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    public Long incrementCount(long memberId, long couponId) {
+        String key = generateKey(memberId, couponId);
+        return redisTemplate.opsForValue().increment(key);
+    }
+
+    public boolean existKey(long memberId, long couponId) {
+        String key = generateKey(memberId, couponId);
+        return redisTemplate.opsForValue().get(key) != null;
+    }
+
+    public void setCount(long memberId, long couponId, long count) {
+        String key = generateKey(memberId, couponId);
+        redisTemplate.opsForValue().set(key, count);
+    }
+
+    private String generateKey(long memberId, long couponId) {
+        return CACHE_KEY_MEMBER_COUPON_COUNT + ":" + memberId + ":" + couponId;
+    }
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,5 +1,6 @@
 package coupon.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -78,6 +79,7 @@ public class Coupon {
         validate();
     }
 
+    @JsonIgnore
     public boolean issueAvailable() {
         if (issuedStartDate == null || issuedEndDate == null) {
             return false;
@@ -98,17 +100,20 @@ public class Coupon {
         }
     }
 
+    @JsonIgnore
     @AssertTrue(message = "할인 금액은 500원 단위여야 합니다.")
     public boolean isValidDiscountAmountUnit() {
         return discountAmount.remainder(BigDecimal.valueOf(500)).compareTo(BigDecimal.ZERO) == 0;
     }
 
+    @JsonIgnore
     @AssertTrue(message = "할인율은 3% 이상 20% 이하여야 합니다.")
     public boolean isValidDiscountRate() {
         BigDecimal ratio = discountAmount.divide(minimumOrderAmount, 2, RoundingMode.DOWN);
         return ratio.compareTo(BigDecimal.valueOf(0.03)) >= 0 && ratio.compareTo(BigDecimal.valueOf(0.2)) <= 0;
     }
 
+    @JsonIgnore
     @AssertTrue(message = "발급 기간 시작일은 종료일보다 이전이거나 같아야 합니다.")
     public boolean isValidIssuedStartDate() {
         return !issuedStartDate.isAfter(issuedEndDate);

--- a/src/main/java/coupon/domain/CouponCategory.java
+++ b/src/main/java/coupon/domain/CouponCategory.java
@@ -1,7 +1,9 @@
 package coupon.domain;
 
 import java.util.Arrays;
+import lombok.Getter;
 
+@Getter
 public enum CouponCategory {
     FASHION("패션"),
     ELECTRONICS("가전"),

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -20,9 +20,9 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private long couponId;
-
     private long memberId;
+
+    private long couponId;
 
     private boolean used = false;
 
@@ -30,9 +30,9 @@ public class MemberCoupon {
 
     private LocalDateTime expiresAt;
 
-    public MemberCoupon(long couponId, long memberId) {
-        this.couponId = couponId;
+    public MemberCoupon(long memberId, long couponId) {
         this.memberId = memberId;
+        this.couponId = couponId;
         this.issuedAt = LocalDateTime.now();
         this.expiresAt = calculateExpiresAt(this.issuedAt);
     }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Data;
@@ -22,13 +20,9 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    @ManyToOne
-    private Coupon coupon;
+    private long couponId;
 
-    @NotNull
-    @ManyToOne
-    private Member member;
+    private long memberId;
 
     private boolean used = false;
 
@@ -36,10 +30,9 @@ public class MemberCoupon {
 
     private LocalDateTime expiresAt;
 
-    public MemberCoupon(Coupon coupon, Member member) {
-        this.coupon = coupon;
-        this.member = member;
-        this.used = false;
+    public MemberCoupon(long couponId, long memberId) {
+        this.couponId = couponId;
+        this.memberId = memberId;
         this.issuedAt = LocalDateTime.now();
         this.expiresAt = calculateExpiresAt(this.issuedAt);
     }

--- a/src/main/java/coupon/dto/MemberCouponResponse.java
+++ b/src/main/java/coupon/dto/MemberCouponResponse.java
@@ -1,0 +1,33 @@
+package coupon.dto;
+
+import coupon.domain.Coupon;
+import coupon.domain.MemberCoupon;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record MemberCouponResponse(
+        long id,
+        String name,
+        BigDecimal discountAmount,
+        BigDecimal minimumOrderAmount,
+        String category,
+        boolean used,
+        LocalDateTime issuedAt,
+        LocalDateTime expiresAt
+) {
+    public static MemberCouponResponse from(
+            MemberCoupon memberCoupon,
+            Coupon coupon
+    ) {
+        return new MemberCouponResponse(
+                memberCoupon.getId(),
+                coupon.getName(),
+                coupon.getDiscountAmount(),
+                coupon.getMinimumOrderAmount(),
+                coupon.getCategory().getName(),
+                memberCoupon.isUsed(),
+                memberCoupon.getIssuedAt(),
+                memberCoupon.getExpiresAt()
+        );
+    }
+}

--- a/src/main/java/coupon/exception/BadRequestException.java
+++ b/src/main/java/coupon/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package coupon.exception;
+
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,9 @@
+package coupon.repository;
+
+import coupon.domain.MemberCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+    int countByMemberIdAndCouponId(long memberId, long couponId);
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
-    int countByMemberIdAndCouponId(long memberId, long couponId);
+    long countByMemberIdAndCouponId(long memberId, long couponId);
 }

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,9 +1,12 @@
 package coupon.repository;
 
 import coupon.domain.MemberCoupon;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
     long countByMemberIdAndCouponId(long memberId, long couponId);
+
+    List<MemberCoupon> findByMemberId(long memberId);
 }

--- a/src/main/java/coupon/repository/MemberRepository.java
+++ b/src/main/java/coupon/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+import coupon.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -4,6 +4,7 @@ import coupon.domain.Coupon;
 import coupon.exception.NotFoundException;
 import coupon.repository.CouponRepository;
 import coupon.util.TransactionExecutor;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,9 +19,10 @@ public class CouponService {
         this.transactionExecutor = transactionExecutor;
     }
 
+    @CachePut(value = "coupons", key = "#coupon.id")
     @Transactional
-    public void create(Coupon coupon) {
-        couponRepository.save(coupon);
+    public Coupon create(Coupon coupon) {
+        return couponRepository.save(coupon);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -5,11 +5,14 @@ import coupon.exception.NotFoundException;
 import coupon.repository.CouponRepository;
 import coupon.util.TransactionExecutor;
 import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CouponService {
+
+    private static final String CACHE_KEY_COUPON = "coupons";
 
     private final CouponRepository couponRepository;
     private final TransactionExecutor transactionExecutor;
@@ -19,12 +22,13 @@ public class CouponService {
         this.transactionExecutor = transactionExecutor;
     }
 
-    @CachePut(value = "coupons", key = "#coupon.id")
+    @CachePut(value = CACHE_KEY_COUPON, key = "#coupon.id")
     @Transactional
     public Coupon create(Coupon coupon) {
         return couponRepository.save(coupon);
     }
 
+    @Cacheable(value = CACHE_KEY_COUPON, key = "#id")
     @Transactional(readOnly = true)
     public Coupon getCoupon(long id) {
         return couponRepository.findById(id)

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -3,6 +3,7 @@ package coupon.service;
 import coupon.domain.Coupon;
 import coupon.repository.CouponRepository;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.repository.query.Param;
@@ -10,15 +11,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class CouponService {
 
-    private static final String CACHE_KEY_COUPON = "coupons";
+    private static final String CACHE_KEY_COUPON = "coupon";
 
     private final CouponRepository couponRepository;
-
-    public CouponService(CouponRepository couponRepository) {
-        this.couponRepository = couponRepository;
-    }
 
     @CachePut(value = CACHE_KEY_COUPON, key = "#result.id")
     @Transactional

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,11 +1,11 @@
 package coupon.service;
 
 import coupon.domain.Coupon;
-import coupon.exception.NotFoundException;
 import coupon.repository.CouponRepository;
-import coupon.util.TransactionExecutor;
+import java.util.Optional;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,14 +15,12 @@ public class CouponService {
     private static final String CACHE_KEY_COUPON = "coupons";
 
     private final CouponRepository couponRepository;
-    private final TransactionExecutor transactionExecutor;
 
-    public CouponService(CouponRepository couponRepository, TransactionExecutor transactionExecutor) {
+    public CouponService(CouponRepository couponRepository) {
         this.couponRepository = couponRepository;
-        this.transactionExecutor = transactionExecutor;
     }
 
-    @CachePut(value = CACHE_KEY_COUPON, key = "#coupon.id")
+    @CachePut(value = CACHE_KEY_COUPON, key = "#result.id")
     @Transactional
     public Coupon create(Coupon coupon) {
         return couponRepository.save(coupon);
@@ -30,15 +28,7 @@ public class CouponService {
 
     @Cacheable(value = CACHE_KEY_COUPON, key = "#id")
     @Transactional(readOnly = true)
-    public Coupon getCoupon(long id) {
-        return couponRepository.findById(id)
-                .orElseGet(() -> findCouponWithNonReadonlyTransaction(id));
-    }
-
-    private Coupon findCouponWithNonReadonlyTransaction(long id) {
-        return transactionExecutor.executeOnWriter(
-                () -> couponRepository.findById(id)
-                        .orElseThrow(() -> new NotFoundException("쿠폰이 존재하지 않습니다. id: " + id))
-        );
+    public Optional<Coupon> getCoupon(@Param("id") long id) {
+        return couponRepository.findById(id);
     }
 }

--- a/src/main/java/coupon/service/MemberService.java
+++ b/src/main/java/coupon/service/MemberService.java
@@ -1,0 +1,19 @@
+package coupon.service;
+
+import coupon.domain.Member;
+import coupon.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public Member create(String name) {
+        return memberRepository.save(new Member(name));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
     open-in-view: false
     show-sql: true
 
+  data:
+    redis:
+      port: 36379
+      repositories:
+        enabled: false
+
 coupon.datasource:
   writer:
     type: com.zaxxer.hikari.HikariDataSource

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,5 @@ coupon.datasource:
 
 logging:
   level:
-    coupon:
-      config:
-        RoutingDataSource: DEBUG
+    coupon.config.RoutingDataSource: DEBUG
+    org.springframework.cache: TRACE

--- a/src/test/java/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/MemberCouponTest.java
@@ -2,7 +2,6 @@ package coupon.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import coupon.util.CouponFixture;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,7 +12,7 @@ class MemberCouponTest {
     @DisplayName("발급 받은 쿠폰은 7일간 이용이 가능하다.")
     void canUseFor7Days() {
         // given
-        MemberCoupon memberCoupon = new MemberCoupon(CouponFixture.createCoupon(), new Member("Jake"));
+        MemberCoupon memberCoupon = new MemberCoupon(1L, 1L);
         LocalDateTime expectedAt = LocalDateTime.now()
                 .toLocalDate()
                 .plusDays(7)

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import coupon.domain.Coupon;
 import coupon.util.CouponFixture;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,16 +18,13 @@ public class CouponServiceTest {
     private CouponService couponService;
 
     @Test
-    @DisplayName("복제 지연 테스트")
-    void replicationDelay() {
-        // given
-        Coupon coupon = CouponFixture.createCoupon();
-
-        // when
-        couponService.create(coupon);
-        Coupon savedCoupon = couponService.getCoupon(coupon.getId());
+    @DisplayName("캐싱 테스트")
+    void getCouponFromCache() {
+        // given & when
+        Coupon savedCoupon = couponService.create(CouponFixture.createCoupon());
+        Optional<Coupon> cachedCoupon = couponService.getCoupon(savedCoupon.getId());
 
         // then
-        assertThat(savedCoupon).isNotNull();
+        assertThat(cachedCoupon).isPresent();
     }
 }

--- a/src/test/java/coupon/service/MemberServiceTest.java
+++ b/src/test/java/coupon/service/MemberServiceTest.java
@@ -1,0 +1,31 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("멤버를 생성하여 아이디를 부여한다.")
+    void create() {
+        // given
+        String name = "Seyang";
+
+        // when
+        Member member = memberService.create(name);
+
+        // then
+        assertThat(member.getId()).isNotNull();
+        assertThat(member.getName()).isEqualTo(name);
+    }
+}

--- a/src/test/java/coupon/service/MemberServiceTest.java
+++ b/src/test/java/coupon/service/MemberServiceTest.java
@@ -3,8 +3,18 @@ package coupon.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import coupon.domain.Member;
+import coupon.domain.MemberCoupon;
+import coupon.util.CouponFixture;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -12,14 +22,17 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class MemberServiceTest {
 
+    private static final Logger log = LoggerFactory.getLogger(MemberServiceTest.class);
     @Autowired
     private MemberService memberService;
+    @Autowired
+    private CouponService couponService;
 
     @Test
     @DisplayName("멤버를 생성하여 아이디를 부여한다.")
     void create() {
         // given
-        String name = "Seyang";
+        String name = "Jake";
 
         // when
         Member member = memberService.create(name);
@@ -27,5 +40,39 @@ class MemberServiceTest {
         // then
         assertThat(member.getId()).isNotNull();
         assertThat(member.getName()).isEqualTo(name);
+    }
+
+    @Test
+    @DisplayName("한 사용자가 쿠폰 발급을 9번 동시에 할 경우 5번만 발급된다.")
+    void issueMaxMemberCouponsConcurrent() throws InterruptedException {
+        // given
+        int nThreads = 9;
+        int expectedSuccessCount = 5;
+        ExecutorService pool = Executors.newFixedThreadPool(nThreads);
+        CountDownLatch latch = new CountDownLatch(nThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+        List<MemberCoupon> issuedCoupons = new CopyOnWriteArrayList<>();
+
+        // when
+        Long couponId = couponService.create(CouponFixture.createCoupon()).getId();
+        Long memberId = memberService.create("Jake").getId();
+        for (int i = 0; i < nThreads; i++) {
+            pool.submit(() -> {
+                try {
+                    MemberCoupon memberCoupon = memberService.issueCoupon(memberId, couponId);
+                    issuedCoupons.add(memberCoupon);
+                    successCount.incrementAndGet();
+                } catch (Exception ex) {
+                    log.error(ex.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        // then
+        System.out.println("issuedCoupons = " + issuedCoupons);
+        assertThat(successCount.get()).isEqualTo(expectedSuccessCount);
     }
 }

--- a/src/test/java/coupon/service/MemberServiceTest.java
+++ b/src/test/java/coupon/service/MemberServiceTest.java
@@ -2,15 +2,20 @@ package coupon.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import coupon.domain.Coupon;
 import coupon.domain.Member;
 import coupon.domain.MemberCoupon;
+import coupon.dto.MemberCouponResponse;
 import coupon.util.CouponFixture;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -23,23 +28,22 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 class MemberServiceTest {
 
     private static final Logger log = LoggerFactory.getLogger(MemberServiceTest.class);
+    Member member;
     @Autowired
     private MemberService memberService;
     @Autowired
     private CouponService couponService;
 
+    @BeforeEach
+    void setUp() {
+        member = memberService.create("Jake");
+    }
+
     @Test
     @DisplayName("멤버를 생성하여 아이디를 부여한다.")
     void create() {
-        // given
-        String name = "Jake";
-
-        // when
-        Member member = memberService.create(name);
-
-        // then
         assertThat(member.getId()).isNotNull();
-        assertThat(member.getName()).isEqualTo(name);
+        assertThat(member.getName()).isNotEmpty();
     }
 
     @Test
@@ -55,7 +59,7 @@ class MemberServiceTest {
 
         // when
         Long couponId = couponService.create(CouponFixture.createCoupon()).getId();
-        Long memberId = memberService.create("Jake").getId();
+        Long memberId = member.getId();
         for (int i = 0; i < nThreads; i++) {
             pool.submit(() -> {
                 try {
@@ -74,5 +78,33 @@ class MemberServiceTest {
         // then
         System.out.println("issuedCoupons = " + issuedCoupons);
         assertThat(successCount.get()).isEqualTo(expectedSuccessCount);
+    }
+
+    @Test
+    @DisplayName("자신이 발급받은 모든 쿠폰을 조회한다.")
+    void getIssuedCoupons() {
+        // given
+        List<Coupon> coupons = CouponFixture.createCoupons().stream()
+                .map(couponService::create)
+                .toList();
+        List<MemberCoupon> memberCoupons = new ArrayList<>();
+        Random random = new Random();
+        Long memberId = member.getId();
+
+        // when
+        for (Coupon coupon : coupons) {
+            for (int i = random.nextInt(1, 5); i > 0; i--) {
+                MemberCoupon memberCoupon = memberService.issueCoupon(memberId, coupon.getId());
+                memberCoupons.add(memberCoupon);
+            }
+        }
+        List<MemberCouponResponse> issuedCoupons = memberService.getIssuedCoupons(memberId);
+
+        List<Long> actualIds = issuedCoupons.stream().map(MemberCouponResponse::id).toList();
+        List<Long> expectedIds = memberCoupons.stream().map(MemberCoupon::getId).toList();
+
+        // then
+        System.out.println("issuedCoupons = " + issuedCoupons);
+        assertThat(actualIds).isEqualTo(expectedIds);
     }
 }

--- a/src/test/java/coupon/util/CouponFixture.java
+++ b/src/test/java/coupon/util/CouponFixture.java
@@ -4,6 +4,7 @@ import coupon.domain.Coupon;
 import coupon.domain.CouponCategory;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class CouponFixture {
 
@@ -15,6 +16,51 @@ public class CouponFixture {
                 CouponCategory.FOOD,
                 LocalDateTime.now().minusDays(2),
                 LocalDateTime.now().plusDays(2)
+        );
+    }
+
+    public static List<Coupon> createCoupons() {
+        return List.of(
+                new Coupon(
+                        "배민 10% 할인 쿠폰",
+                        BigDecimal.valueOf(1000),
+                        BigDecimal.valueOf(10000),
+                        CouponCategory.FOOD,
+                        LocalDateTime.now().minusDays(2),
+                        LocalDateTime.now().plusDays(2)
+                ),
+                new Coupon(
+                        "배민 20% 할인 쿠폰",
+                        BigDecimal.valueOf(4000),
+                        BigDecimal.valueOf(20000),
+                        CouponCategory.FOOD,
+                        LocalDateTime.now().minusDays(1),
+                        LocalDateTime.now().plusDays(1)
+                ),
+                new Coupon(
+                        "무신사 15% 할인 쿠폰",
+                        BigDecimal.valueOf(6000),
+                        BigDecimal.valueOf(40000),
+                        CouponCategory.FASHION,
+                        LocalDateTime.now().minusDays(3),
+                        LocalDateTime.now().plusDays(1)
+                ),
+                new Coupon(
+                        "애플 학생 5% 할인 쿠폰",
+                        BigDecimal.valueOf(5000),
+                        BigDecimal.valueOf(100000),
+                        CouponCategory.ELECTRONICS,
+                        LocalDateTime.now().minusDays(1),
+                        LocalDateTime.now().plusDays(3)
+                ),
+                new Coupon(
+                        "한샘 신혼 20% 할인 쿠폰",
+                        BigDecimal.valueOf(10000),
+                        BigDecimal.valueOf(50000),
+                        CouponCategory.FURNITURE,
+                        LocalDateTime.now().minusDays(5),
+                        LocalDateTime.now().plusDays(5)
+                )
         );
     }
 }

--- a/src/test/java/coupon/util/CouponFixture.java
+++ b/src/test/java/coupon/util/CouponFixture.java
@@ -13,8 +13,8 @@ public class CouponFixture {
                 BigDecimal.valueOf(1000),
                 BigDecimal.valueOf(10000),
                 CouponCategory.FOOD,
-                LocalDateTime.now(),
-                LocalDateTime.now().plusDays(7).minusNanos(1)
+                LocalDateTime.now().minusDays(2),
+                LocalDateTime.now().plusDays(2)
         );
     }
 }


### PR DESCRIPTION
안녕하세요 시소!

이번 단계에서는 `Redis` 를 사용하여 캐싱을 진행해보았고, 과정 중 겪었던 문제점이나 저의 생각 그리고 해결 방안 등을 아래에 정리해 보았어요!

### 1. 회원에게 쿠폰을 발급하는 기능 구현
> 한 명의 회원은 동일한 쿠폰을 사용한 쿠폰을 포함하여 최대 5장까지 발급할 수 있다.

- 먼저, DB 에서 특정 멤버에게 발급된 특정 쿠폰 개수를 반환하는 메서드를 JPA 네이밍 메서드 `MemberCouponRepository.countByMemberIdAndCouponId(long memberId, long couponId)` 로 두었습니다.
- 주어진 요구사항은 중요한 비지니스 로직이기 때문에 이전 단계에서 구현한 ` Writer DB` 를 조회하도록 `TransactionExecutor.executeOnWriter(Supplier<T> supplier)` 메서드를 사용하여 호출하도록 하였습니다.
- 하지만 **성능 향상** 또한 캐싱으로 해결하자는 이번 단계의 요구사항인 만큼, 현재 읽으려는 값(사용자에게 발급된 특정 쿠폰 개수) 는 캐싱을 사용하려고 했습니다.
- 캐싱으로 `ConcurrentHashMap<String, Long>` 을 사용하려다, 멀티 애플리케이션 환경도 고려하여 `Redis` 를 사용하겠다 생각하였습니다.
- 조회 캐싱 전략으로는 `cache miss` 일 때, `DB` 조회 후 캐시에 저장, 이후 반환 하는 `Look Aside` 방식을 채택하였습니다.

### 2. 회원의 쿠폰 목록 조회 기능 구현
> [미션 설명](https://techcourse.woowahan.com/s/Cjiz6fNL/lt/R6TAnPXF)에 있는 것처럼 쿠폰과 회원에게 발급된 쿠폰의 저장소가 분리될 예정이므로, 두 테이블을 조인할 수 없다.
회원의 쿠폰 목록 조회 시 쿠폰, 회원에게 발급된 쿠폰의 정보를 모두 보여줄 수 있어야 한다.

- 기존에 존재하던 `MemberCoupon` 도메인에 `@ManyToOne` 으로 연결해둔 `Member member` 필드와 `Coupon coupon` 필드를 제거하였습니다!
- `long memberId`과 `long couponId` 만 두어 서로 분리된 테이블로 만들었습니다!
  (화살표가 없어요!)
  ![image](https://github.com/user-attachments/assets/1bd909be-cc50-4723-86ca-173a97bf039b)


### 3. 쿠폰 캐싱
> 성능을 위해 쿠폰을 캐싱하고, 회원의 쿠폰 목록 조회 시 쿠폰 정보는 캐시를 통해 조회하도록 수정한다.
- `MemberServiceTest` 에서 `자신이 발급받은 모든 쿠폰을 조회한다` 테스트를 실행하여 로그를 조회하면 DB 엑세스와 캐시 엑세스 모두 볼 수 있습니다!
- ![image](https://github.com/user-attachments/assets/3766b737-9b09-4c3a-8aeb-bb1c9398a324)

<br>

데모데이가 얼마 남지않아 많이 바쁘실텐데 시간나실 때 리뷰 부탁드릴게요!
미션과 데모데이 모두 파이팅입니다! 시소!! 🤗