### PR TITLE
[2단계 - DB 복제와 캐시] 망쵸(김주환) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.projectlombok:lombok'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -30,8 +30,6 @@ create table if not exists `member_coupon`
     `used`       boolean default false,
     `issued_at`  datetime(6),
     `expired_at` datetime(6),
-    primary key (`id`),
-    constraint `fk_member_coupon_coupon_id` foreign key (`coupon_id`) references coupon (`id`),
-    constraint `fk_member_coupon_member_id` foreign key (`member_id`) references member (`id`)
+    primary key (`id`)
 ) engine = innodb
   default charset = utf8mb4;

--- a/docker/init/schema.sql
+++ b/docker/init/schema.sql
@@ -16,8 +16,8 @@ create table if not exists `coupon`
     `discount_amount`      int,
     `minimum_order_amount` int,
     `category`             varchar(20),
-    `issue_started_at`     datetime,
-    `issue_ended_at`       datetime,
+    `issue_started_at`     datetime(6),
+    `issue_ended_at`       datetime(6),
     primary key (`id`)
 ) engine = innodb
   default charset = utf8mb4;

--- a/src/main/java/coupon/config/CacheConfig.java
+++ b/src/main/java/coupon/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package coupon.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/src/main/java/coupon/config/CacheConfig.java
+++ b/src/main/java/coupon/config/CacheConfig.java
@@ -1,9 +1,32 @@
 package coupon.config;
 
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
+
+    @Value("${spring.data.redis.ttl}")
+    private long TTL;
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory,
+                                     RedisCacheConfiguration redisCacheConfiguration) {
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(setTtl(redisCacheConfiguration))
+                .build();
+    }
+
+    private RedisCacheConfiguration setTtl(RedisCacheConfiguration redisCacheConfiguration) {
+        return redisCacheConfiguration.entryTtl(Duration.ofMinutes(TTL));
+    }
 }

--- a/src/main/java/coupon/config/CacheConfig.java
+++ b/src/main/java/coupon/config/CacheConfig.java
@@ -1,7 +1,5 @@
 package coupon.config;
 
-import java.time.Duration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -14,19 +12,12 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 @EnableCaching
 public class CacheConfig {
 
-    @Value("${spring.data.redis.ttl}")
-    private long TTL;
-
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory,
                                      RedisCacheConfiguration redisCacheConfiguration) {
         return RedisCacheManager.RedisCacheManagerBuilder
                 .fromConnectionFactory(redisConnectionFactory)
-                .cacheDefaults(setTtl(redisCacheConfiguration))
+                .cacheDefaults(redisCacheConfiguration)
                 .build();
-    }
-
-    private RedisCacheConfiguration setTtl(RedisCacheConfiguration redisCacheConfiguration) {
-        return redisCacheConfiguration.entryTtl(Duration.ofMinutes(TTL));
     }
 }

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +29,9 @@ public class RedisConfig {
 
     @Value("${spring.data.redis.password}")
     private String password;
+
+    @Value("${spring.data.redis.ttl}")
+    private long TTL;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -58,6 +62,7 @@ public class RedisConfig {
 
         return RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(keySerializationPair)
-                .serializeValuesWith(valueSerializationPair);
+                .serializeValuesWith(valueSerializationPair)
+                .entryTtl(Duration.ofMinutes(TTL));
     }
 }

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -1,0 +1,73 @@
+package coupon.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Value("${spring.data.redis.ttl}")
+    private long TTL;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(port);
+        redisConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
+                ObjectMapper.DefaultTyping.EVERYTHING,
+                JsonTypeInfo.As.PROPERTY
+        );
+        return mapper;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer(objectMapper())))
+                .entryTtl(Duration.ofMinutes(TTL));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -5,10 +5,12 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@EqualsAndHashCode(of = "id")
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coupon {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -79,7 +80,8 @@ public class Coupon {
         this.discountAmount = discountAmount;
         this.minimumOrderAmount = minimumOrderAmount;
         this.issueStartedAt = LocalDateTime.now().with(LocalTime.MIN);
-        this.issueEndedAt = LocalDateTime.now().plusMonths(EXPIRATION_MONTH - 1).with(LocalTime.MAX);
+        this.issueEndedAt = LocalDateTime.now().plusMonths(EXPIRATION_MONTH).minusDays(1).with(LocalTime.MAX)
+                .truncatedTo(ChronoUnit.MICROS);
     }
 
     private void validateCoupon(String name, Integer discountAmount, Integer minimumOrderAmount) {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,23 +1,15 @@
 package coupon.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@Table(name = "coupon")
 @Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Coupon {
 
@@ -51,27 +43,12 @@ public class Coupon {
     private static final int MINIMUM_ORDER_AMOUNT_MIN = 5000;
     private static final int MINIMUM_ORDER_AMOUNT_MAX = 100000;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(name = "name", nullable = false, columnDefinition = "varchar(30)")
     private String name;
-
-    @Column(name = "discount_amount", columnDefinition = "int")
     private Integer discountAmount;
-
-    @Column(name = "minimum_order_amount", columnDefinition = "int")
     private Integer minimumOrderAmount;
-
-    @Column(name = "category", columnDefinition = "varchar(20)")
-    @Enumerated(value = EnumType.STRING)
     private CouponCategory category;
-
-    @Column(name = "issue_started_at", columnDefinition = "datetime")
     private LocalDateTime issueStartedAt;
-
-    @Column(name = "issue_ended_at", columnDefinition = "datetime")
     private LocalDateTime issueEndedAt;
 
     public Coupon(String name, Integer discountAmount, Integer minimumOrderAmount) {

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -2,10 +2,12 @@ package coupon.domain;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@EqualsAndHashCode(of = "id")
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -1,24 +1,16 @@
 package coupon.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@Table(name = "member")
 @Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     private String name;
 
     public Member(String name) {

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -49,6 +50,7 @@ public class MemberCoupon {
         this.coupon = coupon;
         this.used = false;
         this.issuedAt = LocalDateTime.now();
-        this.expiredAt = issuedAt.plusDays(EXPIRATION_DAYS - 1).with(LocalTime.MAX);
+        this.expiredAt = issuedAt.plusDays(EXPIRATION_DAYS).minusDays(1).with(LocalTime.MAX)
+                .truncatedTo(ChronoUnit.MICROS);
     }
 }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,21 +1,15 @@
 package coupon.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@Table(name = "member_coupon")
 @Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberCoupon {
 
@@ -24,23 +18,11 @@ public class MemberCoupon {
      */
     private static final int EXPIRATION_DAYS = 7;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(name = "member_id", nullable = false)
     private Long memberId;
-
-    @Column(name = "coupon_id", nullable = false)
     private Long couponId;
-
-    @Column(name = "used", columnDefinition = "boolean")
     private Boolean used;
-
-    @Column(name = "issued_at", columnDefinition = "datetime(6)")
     private LocalDateTime issuedAt;
-
-    @Column(name = "expired_at", columnDefinition = "datetime(6)")
     private LocalDateTime expiredAt;
 
     public MemberCoupon(Member member, Coupon coupon) {

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -2,11 +2,9 @@ package coupon.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -30,11 +28,11 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    private Member member;
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    private Coupon coupon;
+    @Column(name = "coupon_id", nullable = false)
+    private Long couponId;
 
     @Column(name = "used", columnDefinition = "boolean")
     private Boolean used;
@@ -46,8 +44,8 @@ public class MemberCoupon {
     private LocalDateTime expiredAt;
 
     public MemberCoupon(Member member, Coupon coupon) {
-        this.member = member;
-        this.coupon = coupon;
+        this.memberId = member.getId();
+        this.couponId = coupon.getId();
         this.used = false;
         this.issuedAt = LocalDateTime.now();
         this.expiredAt = issuedAt.plusDays(EXPIRATION_DAYS).minusDays(1).with(LocalTime.MAX)

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -15,6 +15,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberCoupon {
 
+    public static final int ISSUED_COUPON_LIMIT = 5;
+
     /*
     회원에게 발급된 쿠폰은 발급일 포함 7일 동안 사용 가능하다. 만료 일의 23:59:59.999999 까지 사용할 수 있다.
      */

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -5,10 +5,12 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@EqualsAndHashCode(of = "id")
 @AllArgsConstructor(access = AccessLevel.PUBLIC)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberCoupon {
@@ -19,18 +21,29 @@ public class MemberCoupon {
     private static final int EXPIRATION_DAYS = 7;
 
     private Long id;
-    private Long memberId;
-    private Long couponId;
+    private Member member;
+    private Coupon coupon;
     private Boolean used;
     private LocalDateTime issuedAt;
     private LocalDateTime expiredAt;
 
-    public MemberCoupon(Member member, Coupon coupon) {
-        this.memberId = member.getId();
-        this.couponId = coupon.getId();
-        this.used = false;
-        this.issuedAt = LocalDateTime.now();
-        this.expiredAt = issuedAt.plusDays(EXPIRATION_DAYS).minusDays(1).with(LocalTime.MAX)
+    private MemberCoupon(Member member, Coupon coupon, Boolean used, LocalDateTime issuedAt, LocalDateTime expiredAt) {
+        this.member = member;
+        this.coupon = coupon;
+        this.used = used;
+        this.issuedAt = issuedAt;
+        this.expiredAt = expiredAt;
+    }
+
+    public static MemberCoupon issue(Member member, Coupon coupon) {
+        LocalDateTime issuedAt = LocalDateTime.now();
+        return new MemberCoupon(member, coupon, false, issuedAt, getExpiredAt(issuedAt));
+    }
+
+    private static LocalDateTime getExpiredAt(LocalDateTime issuedAt) {
+        return issuedAt.plusDays(EXPIRATION_DAYS)
+                .minusDays(1)
+                .with(LocalTime.MAX)
                 .truncatedTo(ChronoUnit.MICROS);
     }
 }

--- a/src/main/java/coupon/entity/CouponEntity.java
+++ b/src/main/java/coupon/entity/CouponEntity.java
@@ -1,0 +1,61 @@
+package coupon.entity;
+
+import coupon.domain.Coupon;
+import coupon.domain.CouponCategory;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "coupon")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, columnDefinition = "varchar(30)")
+    private String name;
+
+    @Column(name = "discount_amount", columnDefinition = "int")
+    private Integer discountAmount;
+
+    @Column(name = "minimum_order_amount", columnDefinition = "int")
+    private Integer minimumOrderAmount;
+
+    @Column(name = "category", columnDefinition = "varchar(20)")
+    @Enumerated(value = EnumType.STRING)
+    private CouponCategory category;
+
+    @Column(name = "issue_started_at", columnDefinition = "datetime")
+    private LocalDateTime issueStartedAt;
+
+    @Column(name = "issue_ended_at", columnDefinition = "datetime")
+    private LocalDateTime issueEndedAt;
+
+    public CouponEntity(Coupon coupon) {
+        this.name = coupon.getName();
+        this.discountAmount = coupon.getDiscountAmount();
+        this.minimumOrderAmount = coupon.getMinimumOrderAmount();
+        this.category = coupon.getCategory();
+        this.issueStartedAt = coupon.getIssueStartedAt();
+        this.issueEndedAt = coupon.getIssueEndedAt();
+    }
+
+    public Coupon toDomain() {
+        return new Coupon(id, name, discountAmount, minimumOrderAmount, category, issueStartedAt, issueEndedAt);
+    }
+}

--- a/src/main/java/coupon/entity/MemberCouponEntity.java
+++ b/src/main/java/coupon/entity/MemberCouponEntity.java
@@ -1,5 +1,7 @@
 package coupon.entity;
 
+import coupon.domain.Coupon;
+import coupon.domain.Member;
 import coupon.domain.MemberCoupon;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,14 +42,14 @@ public class MemberCouponEntity {
     private LocalDateTime expiredAt;
 
     public MemberCouponEntity(MemberCoupon memberCoupon) {
-        this.memberId = memberCoupon.getMemberId();
-        this.couponId = memberCoupon.getCouponId();
+        this.memberId = memberCoupon.getMember().getId();
+        this.couponId = memberCoupon.getCoupon().getId();
         this.used = memberCoupon.getUsed();
         this.issuedAt = memberCoupon.getIssuedAt();
         this.expiredAt = memberCoupon.getExpiredAt();
     }
 
-    public MemberCoupon toDomain() {
-        return new MemberCoupon(id, memberId, couponId, used, issuedAt, expiredAt);
+    public MemberCoupon toDomain(Member member, Coupon coupon) {
+        return new MemberCoupon(id, member, coupon, used, issuedAt, expiredAt);
     }
 }

--- a/src/main/java/coupon/entity/MemberCouponEntity.java
+++ b/src/main/java/coupon/entity/MemberCouponEntity.java
@@ -1,0 +1,53 @@
+package coupon.entity;
+
+import coupon.domain.MemberCoupon;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_coupon")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberCouponEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "coupon_id", nullable = false)
+    private Long couponId;
+
+    @Column(name = "used", columnDefinition = "boolean")
+    private Boolean used;
+
+    @Column(name = "issued_at", columnDefinition = "datetime(6)")
+    private LocalDateTime issuedAt;
+
+    @Column(name = "expired_at", columnDefinition = "datetime(6)")
+    private LocalDateTime expiredAt;
+
+    public MemberCouponEntity(MemberCoupon memberCoupon) {
+        this.memberId = memberCoupon.getMemberId();
+        this.couponId = memberCoupon.getCouponId();
+        this.used = memberCoupon.getUsed();
+        this.issuedAt = memberCoupon.getIssuedAt();
+        this.expiredAt = memberCoupon.getExpiredAt();
+    }
+
+    public MemberCoupon toDomain() {
+        return new MemberCoupon(id, memberId, couponId, used, issuedAt, expiredAt);
+    }
+}

--- a/src/main/java/coupon/entity/MemberEntity.java
+++ b/src/main/java/coupon/entity/MemberEntity.java
@@ -1,0 +1,34 @@
+package coupon.entity;
+
+import coupon.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public MemberEntity(Member member) {
+        this.name = member.getName();
+    }
+
+    public Member toDomain() {
+        return new Member(id, name);
+    }
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,14 +1,14 @@
 package coupon.repository;
 
-import coupon.domain.MemberCoupon;
+import coupon.entity.MemberCouponEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+public interface MemberCouponRepository extends JpaRepository<MemberCouponEntity, Long> {
 
-    List<MemberCoupon> findAllByMemberIdAndCouponId(Long memberId, Long couponId);
+    List<MemberCouponEntity> findAllByMemberIdAndCouponId(Long memberId, Long couponId);
 
-    List<MemberCoupon> findAllByMemberId(Long memberId);
+    List<MemberCouponEntity> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,14 @@
+package coupon.repository;
+
+import coupon.domain.MemberCoupon;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+    List<MemberCoupon> findAllByMemberIdAndCouponId(Long memberId, Long couponId);
+
+    List<MemberCoupon> findAllByMemberId(Long memberId);
+}

--- a/src/main/java/coupon/repository/MemberRepository.java
+++ b/src/main/java/coupon/repository/MemberRepository.java
@@ -1,9 +1,9 @@
 package coupon.repository;
 
-import coupon.entity.CouponEntity;
+import coupon.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CouponRepository extends JpaRepository<CouponEntity, Long> {
+public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,6 +1,7 @@
 package coupon.service;
 
 import coupon.domain.Coupon;
+import coupon.entity.CouponEntity;
 import coupon.repository.CouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,13 +14,15 @@ public class CouponService {
     private final CouponRepository couponRepository;
 
     @Transactional
-    public void create(Coupon coupon) {
-        couponRepository.save(coupon);
+    public Coupon create(Coupon coupon) {
+        CouponEntity couponEntity = new CouponEntity(coupon);
+        return couponRepository.save(couponEntity).toDomain();
     }
 
     @Transactional(readOnly = true)
     public Coupon getCoupon(Long id) {
         return couponRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."))
+                .toDomain();
     }
 }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -3,6 +3,7 @@ package coupon.service;
 import coupon.domain.Coupon;
 import coupon.entity.CouponEntity;
 import coupon.repository.CouponRepository;
+import coupon.service.support.CacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final CacheService cacheService;
 
     @Transactional
     public Coupon create(Coupon coupon) {
@@ -21,8 +23,6 @@ public class CouponService {
 
     @Transactional(readOnly = true)
     public Coupon getCoupon(Long id) {
-        return couponRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."))
-                .toDomain();
+        return cacheService.getCoupon(id);
     }
 }

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -1,0 +1,56 @@
+package coupon.service;
+
+import coupon.domain.Coupon;
+import coupon.domain.Member;
+import coupon.domain.MemberCoupon;
+import coupon.entity.MemberCouponEntity;
+import coupon.repository.CouponRepository;
+import coupon.repository.MemberCouponRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberCouponService {
+
+    private final MemberCouponRepository memberCouponRepository;
+    private final CouponRepository couponRepository;
+
+    @Transactional
+    public MemberCoupon create(Member member, Coupon coupon) {
+        List<MemberCoupon> issuedMemberCoupons = getMemberCoupons(member, coupon);
+        validateMemberCouponLimit(issuedMemberCoupons);
+        MemberCoupon memberCoupon = MemberCoupon.issue(member, coupon);
+        memberCouponRepository.save(new MemberCouponEntity(memberCoupon));
+        return memberCoupon;
+    }
+
+    private List<MemberCoupon> getMemberCoupons(Member member, Coupon coupon) {
+        return memberCouponRepository.findAllByMemberIdAndCouponId(member.getId(), coupon.getId()).stream()
+                .map(memberCoupon -> memberCoupon.toDomain(member, coupon))
+                .toList();
+    }
+
+    private void validateMemberCouponLimit(List<MemberCoupon> memberCoupons) {
+        int memberCouponLimit = 5;
+        if (memberCoupons.size() >= memberCouponLimit) {
+            throw new IllegalArgumentException(String.format("이미 %d장의 쿠폰을 발급받았습니다.", memberCouponLimit));
+        }
+    }
+
+    public List<MemberCoupon> findAllByMember(Member member) {
+        List<MemberCouponEntity> issuedMemberCoupons = memberCouponRepository.findAllByMemberId(member.getId());
+        return issuedMemberCoupons.stream()
+                .map(memberCoupon -> memberCoupon.toDomain(member, getCoupon(memberCoupon)))
+                .toList();
+    }
+
+    private Coupon getCoupon(MemberCouponEntity memberCoupon) {
+        return couponRepository.findById(memberCoupon.getCouponId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."))
+                .toDomain();
+    }
+}

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -4,8 +4,8 @@ import coupon.domain.Coupon;
 import coupon.domain.Member;
 import coupon.domain.MemberCoupon;
 import coupon.entity.MemberCouponEntity;
-import coupon.repository.CouponRepository;
 import coupon.repository.MemberCouponRepository;
+import coupon.service.support.CacheService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCouponService {
 
     private final MemberCouponRepository memberCouponRepository;
-    private final CouponRepository couponRepository;
+    private final CacheService cacheService;
 
     @Transactional
     public MemberCoupon create(Member member, Coupon coupon) {
@@ -44,13 +44,7 @@ public class MemberCouponService {
     public List<MemberCoupon> findAllByMember(Member member) {
         List<MemberCouponEntity> issuedMemberCoupons = memberCouponRepository.findAllByMemberId(member.getId());
         return issuedMemberCoupons.stream()
-                .map(memberCoupon -> memberCoupon.toDomain(member, getCoupon(memberCoupon)))
+                .map(memberCoupon -> memberCoupon.toDomain(member, cacheService.getCoupon(memberCoupon)))
                 .toList();
-    }
-
-    private Coupon getCoupon(MemberCouponEntity memberCoupon) {
-        return couponRepository.findById(memberCoupon.getCouponId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."))
-                .toDomain();
     }
 }

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -35,9 +35,8 @@ public class MemberCouponService {
     }
 
     private void validateMemberCouponLimit(List<MemberCoupon> memberCoupons) {
-        int memberCouponLimit = 5;
-        if (memberCoupons.size() >= memberCouponLimit) {
-            throw new IllegalArgumentException(String.format("이미 %d장의 쿠폰을 발급받았습니다.", memberCouponLimit));
+        if (memberCoupons.size() >= MemberCoupon.ISSUED_COUPON_LIMIT) {
+            throw new IllegalArgumentException(String.format("이미 %d장의 쿠폰을 발급받았습니다.", MemberCoupon.ISSUED_COUPON_LIMIT));
         }
     }
 

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCouponService {
 
     private final MemberCouponRepository memberCouponRepository;
-    private final CacheService cacheService;
 
     @Transactional
     public MemberCoupon create(Member member, Coupon coupon) {

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -39,11 +39,4 @@ public class MemberCouponService {
             throw new IllegalArgumentException(String.format("이미 %d장의 쿠폰을 발급받았습니다.", MemberCoupon.ISSUED_COUPON_LIMIT));
         }
     }
-
-    public List<MemberCoupon> findAllByMember(Member member) {
-        List<MemberCouponEntity> issuedMemberCoupons = memberCouponRepository.findAllByMemberId(member.getId());
-        return issuedMemberCoupons.stream()
-                .map(memberCoupon -> memberCoupon.toDomain(member, cacheService.getCoupon(memberCoupon)))
-                .toList();
-    }
 }

--- a/src/main/java/coupon/service/support/CacheService.java
+++ b/src/main/java/coupon/service/support/CacheService.java
@@ -1,0 +1,31 @@
+package coupon.service.support;
+
+import coupon.domain.Coupon;
+import coupon.entity.MemberCouponEntity;
+import coupon.repository.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class CacheService {
+
+    private final CouponRepository couponRepository;
+
+    @Cacheable(value = "coupons", key = "#memberCoupon.couponId")
+    public Coupon getCoupon(MemberCouponEntity memberCoupon) {
+        return getCouponById(memberCoupon.getCouponId());
+    }
+
+    @Cacheable(value = "coupons", key = "#id")
+    public Coupon getCoupon(Long id) {
+        return getCouponById(id);
+    }
+
+    private Coupon getCouponById(Long id) {
+        return couponRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."))
+                .toDomain();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
       host: localhost
       port: 36379
       password: root
-      ttl: 3
+      ttl: 30
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
+  data:
+    redis:
+      host: localhost
+      port: 36379
+      password: root
+      ttl: 3
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
-        show_sql: false
+        show_sql: true
         use_sql_comments: true
         hbm2ddl.auto: validate
         check_nullability: true
@@ -21,7 +21,7 @@ spring:
       host: localhost
       port: 36379
       password: root
-      ttl: 30
+      ttl: 10080 # 7 days
 
 coupon.datasource:
   writer:

--- a/src/test/java/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/MemberCouponTest.java
@@ -2,8 +2,6 @@ package coupon.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,9 +14,8 @@ class MemberCouponTest {
         Member member = new Member("망쵸");
         Coupon coupon = new Coupon("망쵸 쿠폰", 1000, 10000);
         MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
-        LocalDateTime dayAfterWeek = LocalDateTime.now().plusDays(6).with(LocalTime.MAX);
 
         // when, then
-        assertThat(memberCoupon.getExpiredAt()).isEqualTo(dayAfterWeek);
+        assertThat(memberCoupon.getExpiredAt().toString()).endsWith("23:59:59.999999");
     }
 }

--- a/src/test/java/coupon/domain/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/MemberCouponTest.java
@@ -13,7 +13,7 @@ class MemberCouponTest {
         // given
         Member member = new Member("망쵸");
         Coupon coupon = new Coupon("망쵸 쿠폰", 1000, 10000);
-        MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
+        MemberCoupon memberCoupon = MemberCoupon.issue(member, coupon);
 
         // when, then
         assertThat(memberCoupon.getExpiredAt().toString()).endsWith("23:59:59.999999");

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -4,12 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import coupon.config.DataSourceHelper;
 import coupon.domain.Coupon;
+import coupon.support.CacheCleanerExtension;
+import coupon.support.DatabaseCleanerExtension;
 import coupon.support.Fixture;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
+@ExtendWith(value = {DatabaseCleanerExtension.class, CacheCleanerExtension.class})
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 public class CouponServiceTest {
 

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import coupon.config.DataSourceHelper;
 import coupon.domain.Coupon;
+import coupon.support.Fixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 public class CouponServiceTest {
 
     @Autowired
@@ -19,8 +21,7 @@ public class CouponServiceTest {
 
     @Test
     void 복제_지연_테스트() {
-        Coupon coupon = new Coupon("망쵸 쿠폰", 1000, 10000);
-        couponService.create(coupon);
+        Coupon coupon = couponService.create(Fixture.COUPON);
         Coupon savedCoupon = dataSourceHelper.executeOnWrite(() -> couponService.getCoupon(coupon.getId()));
         assertThat(savedCoupon).isNotNull();
     }

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -1,0 +1,101 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import coupon.domain.Coupon;
+import coupon.domain.Member;
+import coupon.domain.MemberCoupon;
+import coupon.entity.CouponEntity;
+import coupon.entity.MemberEntity;
+import coupon.repository.CouponRepository;
+import coupon.repository.MemberRepository;
+import coupon.support.DatabaseCleanerExtension;
+import coupon.support.Fixture;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class MemberCouponServiceTest {
+
+    @Autowired
+    private MemberCouponService memberCouponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Coupon coupon;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        coupon = couponRepository.save(new CouponEntity(Fixture.COUPON)).toDomain();
+        member = memberRepository.save(new MemberEntity(Fixture.MEMBER)).toDomain();
+    }
+
+    @DisplayName("쿠폰이 5장 발급됐다면, 추가 발급이 불가하다.")
+    @Test
+    void memberCouponIssueTest() throws Exception {
+        // given
+        IntStream.range(0, 5).forEach(i -> memberCouponService.create(member, coupon));
+        waitForSeconds(3);
+
+        // when, then
+        assertThatThrownBy(() -> memberCouponService.create(member, coupon))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 5장의 쿠폰을 발급받았습니다.");
+    }
+
+    @DisplayName("쿠폰이 4장 발급됐다면, 한 장 더 발급 가능하다.")
+    @Test
+    void memberCouponIssueTest2() throws Exception {
+        // given
+        IntStream.range(0, 4).forEach(i -> memberCouponService.create(member, coupon));
+        waitForSeconds(3);
+
+        // when
+        assertThatCode(() -> memberCouponService.create(member, coupon))
+                .doesNotThrowAnyException();
+        waitForSeconds(3);
+
+        // then
+        assertThatThrownBy(() -> memberCouponService.create(member, coupon))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 5장의 쿠폰을 발급받았습니다.");
+    }
+
+    @DisplayName("회원이 발급받은 쿠폰을 조회한다.")
+    @Test
+    void findAllByMemberTest() throws Exception {
+        // given
+        IntStream.range(0, 3).forEach(i -> memberCouponService.create(member, coupon));
+        waitForSeconds(3);
+
+        // when
+        List<MemberCoupon> memberCoupons = memberCouponService.findAllByMember(member);
+
+        // then
+        assertAll(
+                () -> assertThat(memberCoupons).hasSize(3),
+                () -> assertThat(memberCoupons).allMatch(memberCoupon -> memberCoupon.getMember().equals(member)),
+                () -> assertThat(memberCoupons).allMatch(memberCoupon -> memberCoupon.getCoupon().equals(coupon))
+        );
+    }
+
+    void waitForSeconds(int seconds) throws Exception {
+        Thread.sleep(1000L * seconds);
+    }
+}

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -38,11 +38,15 @@ class MemberCouponServiceTest {
     private MemberRepository memberRepository;
 
     private Coupon coupon;
+    private List<Coupon> coupons;
     private Member member;
 
     @BeforeEach
     void setUp() {
         coupon = couponRepository.save(new CouponEntity(Fixture.COUPON)).toDomain();
+        coupons = IntStream.range(0, 3)
+                .mapToObj(i -> couponRepository.save(new CouponEntity(Fixture.COUPON)).toDomain())
+                .toList();
         member = memberRepository.save(new MemberEntity(Fixture.MEMBER)).toDomain();
     }
 
@@ -81,7 +85,7 @@ class MemberCouponServiceTest {
     @Test
     void findAllByMemberTest() throws Exception {
         // given
-        IntStream.range(0, 3).forEach(i -> memberCouponService.create(member, coupon));
+        IntStream.range(0, 3).forEach(i -> memberCouponService.create(member, coupons.get(i)));
         waitForSeconds(3);
 
         // when
@@ -90,8 +94,9 @@ class MemberCouponServiceTest {
         // then
         assertAll(
                 () -> assertThat(memberCoupons).hasSize(3),
-                () -> assertThat(memberCoupons).allMatch(memberCoupon -> memberCoupon.getMember().equals(member)),
-                () -> assertThat(memberCoupons).allMatch(memberCoupon -> memberCoupon.getCoupon().equals(coupon))
+                () -> assertThat(memberCoupons)
+                        .extracting(MemberCoupon::getCoupon)
+                        .containsExactlyElementsOf(coupons)
         );
     }
 

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -1,13 +1,10 @@
 package coupon.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import coupon.domain.Coupon;
 import coupon.domain.Member;
-import coupon.domain.MemberCoupon;
 import coupon.entity.CouponEntity;
 import coupon.entity.MemberEntity;
 import coupon.repository.CouponRepository;
@@ -80,25 +77,6 @@ class MemberCouponServiceTest {
         assertThatThrownBy(() -> memberCouponService.create(member, coupon))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("이미 5장의 쿠폰을 발급받았습니다.");
-    }
-
-    @DisplayName("회원이 발급받은 쿠폰을 조회한다.")
-    @Test
-    void findAllByMemberTest() throws Exception {
-        // given
-        IntStream.range(0, 3).forEach(i -> memberCouponService.create(member, coupons.get(i)));
-        waitForSeconds(3);
-
-        // when
-        List<MemberCoupon> memberCoupons = memberCouponService.findAllByMember(member);
-
-        // then
-        assertAll(
-                () -> assertThat(memberCoupons).hasSize(3),
-                () -> assertThat(memberCoupons)
-                        .extracting(MemberCoupon::getCoupon)
-                        .containsExactlyElementsOf(coupons)
-        );
     }
 
     void waitForSeconds(int seconds) throws Exception {

--- a/src/test/java/coupon/service/support/CacheServiceTest.java
+++ b/src/test/java/coupon/service/support/CacheServiceTest.java
@@ -30,7 +30,7 @@ class CacheServiceTest {
     void getCouponWithCacheTest() throws Exception {
         // given
         Coupon coupon = couponService.create(Fixture.COUPON);
-        waitForSeconds(2);
+        waitForSeconds(3);
         couponService.getCoupon(coupon.getId());
 
         databaseCleaner.execute();

--- a/src/test/java/coupon/service/support/CacheServiceTest.java
+++ b/src/test/java/coupon/service/support/CacheServiceTest.java
@@ -1,0 +1,46 @@
+package coupon.service.support;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import coupon.domain.Coupon;
+import coupon.service.CouponService;
+import coupon.support.CacheCleanerExtension;
+import coupon.support.DatabaseCleaner;
+import coupon.support.DatabaseCleanerExtension;
+import coupon.support.Fixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@ExtendWith(value = {DatabaseCleanerExtension.class, CacheCleanerExtension.class})
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class CacheServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @DisplayName("쿠폰이 캐시되었는지 확인한다.")
+    @Test
+    void getCouponWithCacheTest() throws Exception {
+        // given
+        Coupon coupon = couponService.create(Fixture.COUPON);
+        waitForSeconds(2);
+        couponService.getCoupon(coupon.getId());
+
+        databaseCleaner.execute();
+
+        // when, then
+        assertThatCode(() -> couponService.getCoupon(coupon.getId()))
+                .doesNotThrowAnyException();
+    }
+
+    void waitForSeconds(int seconds) throws Exception {
+        Thread.sleep(1000L * seconds);
+    }
+}

--- a/src/test/java/coupon/support/CacheCleaner.java
+++ b/src/test/java/coupon/support/CacheCleaner.java
@@ -1,0 +1,16 @@
+package coupon.support;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CacheCleaner {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    public void execute() {
+        cacheManager.getCacheNames().forEach(cacheName -> cacheManager.getCache(cacheName).clear());
+    }
+}

--- a/src/test/java/coupon/support/CacheCleanerExtension.java
+++ b/src/test/java/coupon/support/CacheCleanerExtension.java
@@ -4,11 +4,11 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-public class DatabaseCleanerExtension implements AfterEachCallback {
+public class CacheCleanerExtension implements AfterEachCallback {
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        DatabaseCleaner cleaner = SpringExtension.getApplicationContext(context).getBean(DatabaseCleaner.class);
+        CacheCleaner cleaner = SpringExtension.getApplicationContext(context).getBean(CacheCleaner.class);
         cleaner.execute();
     }
 }

--- a/src/test/java/coupon/support/DatabaseCleaner.java
+++ b/src/test/java/coupon/support/DatabaseCleaner.java
@@ -1,0 +1,37 @@
+package coupon.support;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+
+    private static final String FOREIGN_KEY_CHECKS_SQL = "set foreign_key_checks = %d";
+    private static final String TRUNCATE_TABLE_SQL = "truncate table %s";
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public void execute() {
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECKS_SQL, 0)).executeUpdate();
+        getTableNames().forEach(this::truncateTable);
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_CHECKS_SQL, 1)).executeUpdate();
+    }
+
+    private List<String> getTableNames() {
+        String sql = """
+                select table_name
+                from information_schema.tables
+                where table_schema = 'coupon'
+                """;
+        return entityManager.createNativeQuery(sql).getResultList();
+    }
+
+    private void truncateTable(String tableName) {
+        entityManager.createNativeQuery(String.format(TRUNCATE_TABLE_SQL, tableName)).executeUpdate();
+    }
+}

--- a/src/test/java/coupon/support/DatabaseCleanerExtension.java
+++ b/src/test/java/coupon/support/DatabaseCleanerExtension.java
@@ -1,0 +1,14 @@
+package coupon.support;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        DatabaseCleaner cleaner = SpringExtension.getApplicationContext(context).getBean(DatabaseCleaner.class);
+        cleaner.execute();
+    }
+}

--- a/src/test/java/coupon/support/Fixture.java
+++ b/src/test/java/coupon/support/Fixture.java
@@ -1,0 +1,10 @@
+package coupon.support;
+
+import coupon.domain.Coupon;
+import coupon.domain.Member;
+
+public class Fixture {
+
+    public final static Coupon COUPON = new Coupon("망쵸 쿠폰", 1000, 10000);
+    public final static Member MEMBER = new Member("망쵸");
+}


### PR DESCRIPTION
커비, 안녕하세요. 망쵸에요 😀 
2단계를 구현했어요. 이번 미션은 캐시를 적용해서 성능 최적화하는 것인데요. 제가 구현한 사항은 다음과 같아요. 

- 날짜 관련 버그 픽스 (커밋 초반)
- Entity 객체와 Domain 객체 분리
- RedisManager와 Cachable을 사용해서 캐시 적용

캐시는 TTL 7일로 쿠폰을 조회할 때 저장하게 했어요! 만료 기간에 대해 쿠폰 자체의 만료 기한이 있다면, 그렇게 두면 좋을 것 같아요. 관련된 명확한 정책이 없어서, 만료 기간과 멤버 쿠폰의 만료 기간과 동일하게 두었어요. 멤버 쿠폰이 유효한 기간 동안은 멤버 쿠폰과 연관되어 있는 쿠폰의 조회가 빈번할 거라 생각하기 때문이에요. 메모리에 여유가 있다면 쿠폰 만료 시간을 더 늘려도 좋겠어요. 

고려할 사항으로, 쿠폰에 삭제나 업데이트가 발생하면 캐시 무효화가 필요할 것 같아요! 하지만 삭제나 업데이트 로직이 아직 없네요. 

또, 핫키가 만료되는 경우에는 데이터베이스에 접근이 폭주할 수 있어요. 이 상황을 어떻게 방지할지 고민해 보았는데요. 캐싱된 쿠폰을 재조회할 때마다 ttl 초기화, 캐시를 조회하는 스레드에 락 걸기 등을 고민하였고, `@Cachable`에 `sync`를 적용하기로 결정했어요. `sync`는 동일한 키에 접근하려고 하는 여러 스레드가 있으면 캐시 연산이 끝날 때까지 다른 스레드를 기다리게 하는 옵션이에요. 스프링이 추상화를 잘해둔 덕분에 캐시를 적용하기 편하네요 😀 

코드 리뷰 잘 부탁드려요! 