### PR TITLE
[2단계 - DB 복제와 캐시] 이든(최승준) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/coupon/config/cache/CacheConfig.java
+++ b/src/main/java/coupon/config/cache/CacheConfig.java
@@ -1,9 +1,0 @@
-package coupon.config.cache;
-
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableCaching
-public class CacheConfig {
-}

--- a/src/main/java/coupon/config/cache/CacheConfig.java
+++ b/src/main/java/coupon/config/cache/CacheConfig.java
@@ -1,0 +1,9 @@
+package coupon.config.cache;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/src/main/java/coupon/config/cache/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/RedisConfig.java
@@ -36,7 +36,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
 }

--- a/src/main/java/coupon/config/cache/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/RedisConfig.java
@@ -1,0 +1,33 @@
+package coupon.config.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/coupon/config/cache/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/RedisConfig.java
@@ -7,8 +7,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
-import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;

--- a/src/main/java/coupon/config/cache/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/RedisConfig.java
@@ -1,11 +1,14 @@
 package coupon.config.cache;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -17,9 +20,15 @@ public class RedisConfig {
 
     private final RedisProperties redisProperties;
 
+    @Value("${spring.cache.redis.host}")
+    private String host;
+
+    @Value("${spring.cache.redis.port}")
+    private int port;
+
     @Bean
     public LettuceConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        return new LettuceConnectionFactory(host, port);
     }
 
     @Bean

--- a/src/main/java/coupon/config/cache/RedisKey.java
+++ b/src/main/java/coupon/config/cache/RedisKey.java
@@ -1,0 +1,18 @@
+package coupon.config.cache;
+
+import java.util.Objects;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RedisKey {
+    MEMBER_COUPON_COUNT("member:%d:coupon:%d:count"),
+    COUPON("coupon:%d");
+
+    private final String key;
+
+    public String getKey(Object... args) {
+        return key.formatted(args);
+    }
+}

--- a/src/main/java/coupon/config/cache/RedisKey.java
+++ b/src/main/java/coupon/config/cache/RedisKey.java
@@ -1,13 +1,13 @@
 package coupon.config.cache;
 
-import java.util.Objects;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
 public enum RedisKey {
-    MEMBER_COUPON_COUNT("member:%d:coupon:%d:count"),
+    MEMBER_COUPON("member:%d:coupon:%d"),
+    MEMBER_COUPONS("member:%d:coupons"),
     COUPON("coupon:%d");
 
     private final String key;

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -63,4 +63,8 @@ public class Coupon {
     public boolean issueAvailable(LocalDate date) {
         return couponIssueDate.isDateAvailable(date);
     }
+
+    public String getCouponName() {
+        return name.getName();
+    }
 }

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -2,8 +2,10 @@ package coupon.domain.coupon;
 
 import coupon.exception.CouponNameValidationException;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 
 @Embeddable
+@Getter
 public class CouponName {
     public static final int MAX_LENGTH = 30;
 

--- a/src/main/java/coupon/domain/coupon/repository/CouponCacheRepository.java
+++ b/src/main/java/coupon/domain/coupon/repository/CouponCacheRepository.java
@@ -1,0 +1,48 @@
+package coupon.domain.coupon.repository;
+
+import coupon.config.cache.RedisKey;
+import coupon.domain.coupon.Coupon;
+import coupon.exception.MemberCouponIssueLimitException;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponCacheRepository {
+
+    private static final String COUPON_ISSUE_COUNT_UP_SCRIPT =
+            "local value = redis.call('GET', KEYS[1]); " +
+                    "if not value then " +
+                    "    value = 0; " +
+                    "    redis.call('SET', KEYS[1], value); " +
+                    "end; " +
+                    "if tonumber(value) >= 5 then " +
+                    "    return '-1'; " +
+                    "else " +
+                    "    value = tonumber(value) + 1; " +
+                    "    redis.call('SET', KEYS[1], value); " +
+                    "    return tostring(value); " +
+                    "end";
+
+    private final RedisTemplate redisTemplate;
+
+    public Coupon getCoupon(long couponId) {
+        String couponKey = RedisKey.COUPON.getKey(couponId);
+        return (Coupon) redisTemplate.opsForValue().get(couponKey);
+    }
+
+    public void updateIssuedMemberCouponCount(long memberId, long couponId) {
+        String key = RedisKey.MEMBER_COUPONS.getKey(memberId, couponId);
+        DefaultRedisScript<Object> script = new DefaultRedisScript<>();
+        script.setScriptText(COUPON_ISSUE_COUNT_UP_SCRIPT);
+        script.setResultType(Object.class);
+
+        int result = (Integer) redisTemplate.execute(script, Collections.singletonList(key));
+        if(result == -1) {
+            throw new MemberCouponIssueLimitException();
+        }
+    }
+}

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -4,9 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class Member {
 

--- a/src/main/java/coupon/domain/member/repository/MemberRepository.java
+++ b/src/main/java/coupon/domain/member/repository/MemberRepository.java
@@ -1,7 +1,14 @@
 package coupon.domain.member.repository;
 
 import coupon.domain.member.Member;
+import coupon.exception.MemberNotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Member getById(long id) {
+        return findById(id)
+                .orElseThrow(() -> new MemberNotFoundException("조회하신 회원 정보가 존재하지 않습니다. (memberId: %d)"
+                        .formatted(id)));
+    }
 }

--- a/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
@@ -1,10 +1,9 @@
 package coupon.domain.member_coupon;
 
 import coupon.domain.coupon.Coupon;
-import coupon.domain.member.Member;
 import coupon.exception.CouponIssueDateException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,6 +23,7 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "member_id")
     private long memberId;
 
     @ManyToOne
@@ -38,7 +38,7 @@ public class MemberCoupon {
 
     public static MemberCoupon issue(long mebmerId, Coupon coupon) {
         LocalDate issuedAt = LocalDate.now();
-        if(!coupon.issueAvailable(issuedAt)) {
+        if (!coupon.issueAvailable(issuedAt)) {
             throw new CouponIssueDateException();
         }
 

--- a/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
@@ -22,11 +22,9 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_id")
-    private Member member;
+    private long memberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "coupon_id")
     private Coupon coupon;
 
@@ -36,18 +34,18 @@ public class MemberCoupon {
 
     private LocalDate expiredAt;
 
-    public static MemberCoupon issue(Member member, Coupon coupon) {
+    public static MemberCoupon issue(long mebmerId, Coupon coupon) {
         LocalDate issuedAt = LocalDate.now();
         if(!coupon.issueAvailable(issuedAt)) {
             throw new CouponIssueDateException();
         }
 
         LocalDate expiredAt = issuedAt.plusDays(DEFAULT_USING_PERIOD);
-        return new MemberCoupon(member, coupon, false, issuedAt, expiredAt);
+        return new MemberCoupon(mebmerId, coupon, false, issuedAt, expiredAt);
     }
 
-    public MemberCoupon(Member member, Coupon coupon, boolean isUsed, LocalDate issuedAt, LocalDate expiredAt) {
-        this.member = member;
+    public MemberCoupon(long memberId, Coupon coupon, boolean isUsed, LocalDate issuedAt, LocalDate expiredAt) {
+        this.memberId = memberId;
         this.coupon = coupon;
         this.isUsed = isUsed;
         this.issuedAt = issuedAt;

--- a/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
@@ -57,4 +57,8 @@ public class MemberCoupon {
     public String getCouponName() {
         return coupon.getCouponName();
     }
+
+    public long getCouponId() {
+        return coupon.getId();
+    }
 }

--- a/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
@@ -4,6 +4,7 @@ import coupon.domain.coupon.Coupon;
 import coupon.exception.CouponIssueDateException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,7 +27,7 @@ public class MemberCoupon {
     @Column(name = "member_id")
     private long memberId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coupon_id")
     private Coupon coupon;
 

--- a/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/member_coupon/MemberCoupon.java
@@ -11,10 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@Getter
 public class MemberCoupon {
     private static final int DEFAULT_USING_PERIOD = 6;
 
@@ -50,5 +52,9 @@ public class MemberCoupon {
         this.isUsed = isUsed;
         this.issuedAt = issuedAt;
         this.expiredAt = expiredAt;
+    }
+
+    public String getCouponName() {
+        return coupon.getCouponName();
     }
 }

--- a/src/main/java/coupon/domain/member_coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/member_coupon/repository/MemberCouponRepository.java
@@ -1,7 +1,16 @@
 package coupon.domain.member_coupon.repository;
 
 import coupon.domain.member_coupon.MemberCoupon;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+    @Query("""
+        SELECT mc
+        FROM MemberCoupon mc
+        JOIN FETCH Coupon c ON mc.coupon = c
+        WHERE mc.memberId = :memberId
+    """)
+    List<MemberCoupon> findByMemberId(long memberId);
 }

--- a/src/main/java/coupon/exception/MemberCouponIssueLimitException.java
+++ b/src/main/java/coupon/exception/MemberCouponIssueLimitException.java
@@ -1,0 +1,24 @@
+package coupon.exception;
+
+public class MemberCouponIssueLimitException extends CouponException {
+    public MemberCouponIssueLimitException() {
+        super("이미 발급 가능한 모든 쿠폰을 발급하였습니다.");
+    }
+
+    public MemberCouponIssueLimitException(String message) {
+        super(message);
+    }
+
+    public MemberCouponIssueLimitException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemberCouponIssueLimitException(Throwable cause) {
+        super(cause);
+    }
+
+    public MemberCouponIssueLimitException(String message, Throwable cause, boolean enableSuppression,
+                                           boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/coupon/exception/MemberNotFoundException.java
+++ b/src/main/java/coupon/exception/MemberNotFoundException.java
@@ -1,0 +1,24 @@
+package coupon.exception;
+
+public class MemberNotFoundException extends CouponException {
+    public MemberNotFoundException() {
+        super();
+    }
+
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+
+    public MemberNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemberNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public MemberNotFoundException(String message, Throwable cause, boolean enableSuppression,
+                                   boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/coupon/service/coupon/dto/CouponIssueResponse.java
+++ b/src/main/java/coupon/service/coupon/dto/CouponIssueResponse.java
@@ -1,0 +1,15 @@
+package coupon.service.coupon.dto;
+
+import coupon.domain.member_coupon.MemberCoupon;
+import java.time.LocalDate;
+
+public record CouponIssueResponse(
+        long issuedCouponId,
+        String couponName,
+        LocalDate couponExpiredAt
+) {
+
+    public static CouponIssueResponse from(MemberCoupon memberCoupon) {
+        return new CouponIssueResponse(memberCoupon.getId(), memberCoupon.getCouponName(), memberCoupon.getExpiredAt());
+    }
+}

--- a/src/main/java/coupon/service/member_coupon/MemberCouponService.java
+++ b/src/main/java/coupon/service/member_coupon/MemberCouponService.java
@@ -1,0 +1,75 @@
+package coupon.service.member_coupon;
+
+import coupon.config.cache.RedisKey;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.repository.CouponRepository;
+import coupon.domain.member.repository.MemberRepository;
+import coupon.domain.member_coupon.MemberCoupon;
+import coupon.domain.member_coupon.repository.MemberCouponRepository;
+import coupon.exception.MemberCouponIssueLimitException;
+import coupon.service.coupon.dto.CouponIssueResponse;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCouponService {
+
+    private static final String COUPON_ISSUE_COUNT_UP_SCRIPT =
+            "local value = redis.call('GET', KEYS[1]); " +
+                    "if not value then " +
+                    "    value = 0; " +
+                    "    redis.call('SET', KEYS[1], value); " +
+                    "end; " +
+                    "if tonumber(value) >= 5 then " +
+                    "    return '-1'; " +
+                    "else " +
+                    "    value = tonumber(value) + 1; " +
+                    "    redis.call('SET', KEYS[1], value); " +
+                    "    return tostring(value); " +
+                    "end";
+
+    private final CouponRepository couponRepository;
+    private final MemberRepository memberRepository;
+    private final MemberCouponRepository memberCouponRepository;
+    private final RedisTemplate redisTemplate;
+
+    @Transactional
+    public CouponIssueResponse issueMemberCoupon(long memberId, long couponId) {
+        memberRepository.getById(memberId);
+
+        MemberCoupon issuedMemberCoupon = MemberCoupon.issue(memberId, getCoupon(couponId));
+        memberCouponRepository.save(issuedMemberCoupon);
+        updateIssuedMemberCouponCount(memberId, couponId);
+
+        return CouponIssueResponse.from(issuedMemberCoupon);
+    }
+
+    private int updateIssuedMemberCouponCount(long memberId, long couponId) {
+        String key = RedisKey.MEMBER_COUPON_COUNT.getKey(memberId, couponId);
+        DefaultRedisScript<String> script = new DefaultRedisScript<>();
+        script.setScriptText(COUPON_ISSUE_COUNT_UP_SCRIPT);
+        script.setResultType(String.class);
+
+        String result = (String) redisTemplate.execute(script, Collections.singletonList(key));
+        if(result.equals("-1")) {
+            throw new MemberCouponIssueLimitException();
+        }
+
+        return Integer.parseInt(result);
+    }
+
+    private Coupon getCoupon(long couponId) {
+        String couponKey = RedisKey.COUPON.getKey(couponId);
+        Coupon coupon = (Coupon) redisTemplate.opsForValue().get(couponKey);
+        if(coupon == null) {
+            coupon = couponRepository.getById(couponId);
+        }
+
+        return coupon;
+    }
+}

--- a/src/main/java/coupon/service/member_coupon/MemberCouponService.java
+++ b/src/main/java/coupon/service/member_coupon/MemberCouponService.java
@@ -1,20 +1,15 @@
 package coupon.service.member_coupon;
 
-import coupon.config.cache.RedisKey;
 import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.repository.CouponCacheRepository;
 import coupon.domain.coupon.repository.CouponRepository;
 import coupon.domain.member.repository.MemberRepository;
 import coupon.domain.member_coupon.MemberCoupon;
 import coupon.domain.member_coupon.repository.MemberCouponRepository;
-import coupon.exception.MemberCouponIssueLimitException;
 import coupon.service.coupon.dto.CouponIssueResponse;
 import coupon.service.member_coupon.dto.MemberCouponsResponse;
-import jakarta.persistence.criteria.CriteriaBuilder.In;
-import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,24 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberCouponService {
 
-    private static final String COUPON_ISSUE_COUNT_UP_SCRIPT =
-            "local value = redis.call('GET', KEYS[1]); " +
-                    "if not value then " +
-                    "    value = 0; " +
-                    "    redis.call('SET', KEYS[1], value); " +
-                    "end; " +
-                    "if tonumber(value) >= 5 then " +
-                    "    return '-1'; " +
-                    "else " +
-                    "    value = tonumber(value) + 1; " +
-                    "    redis.call('SET', KEYS[1], value); " +
-                    "    return tostring(value); " +
-                    "end";
 
     private final CouponRepository couponRepository;
     private final MemberRepository memberRepository;
     private final MemberCouponRepository memberCouponRepository;
-    private final RedisTemplate redisTemplate;
+    private final CouponCacheRepository couponCacheRepository;
 
     @Transactional(readOnly = true)
     public MemberCouponsResponse getMemberCoupons(long memberId) {
@@ -53,28 +35,15 @@ public class MemberCouponService {
 
         MemberCoupon issuedMemberCoupon = MemberCoupon.issue(memberId, getCoupon(couponId));
         memberCouponRepository.save(issuedMemberCoupon);
-        updateIssuedMemberCouponCount(memberId, couponId);
+        couponCacheRepository.updateIssuedMemberCouponCount(memberId, couponId);
 
         return CouponIssueResponse.from(issuedMemberCoupon);
     }
 
-    private int updateIssuedMemberCouponCount(long memberId, long couponId) {
-        String key = RedisKey.MEMBER_COUPONS.getKey(memberId, couponId);
-        DefaultRedisScript<Object> script = new DefaultRedisScript<>();
-        script.setScriptText(COUPON_ISSUE_COUNT_UP_SCRIPT);
-        script.setResultType(Object.class);
 
-        int result = (Integer) redisTemplate.execute(script, Collections.singletonList(key));
-        if(result == -1) {
-            throw new MemberCouponIssueLimitException();
-        }
-
-        return result;
-    }
 
     private Coupon getCoupon(long couponId) {
-        String couponKey = RedisKey.COUPON.getKey(couponId);
-        Coupon coupon = (Coupon) redisTemplate.opsForValue().get(couponKey);
+        Coupon coupon = couponCacheRepository.getCoupon(couponId);
         if(coupon == null) {
             coupon = couponRepository.getById(couponId);
         }

--- a/src/main/java/coupon/service/member_coupon/MemberCouponService.java
+++ b/src/main/java/coupon/service/member_coupon/MemberCouponService.java
@@ -69,7 +69,7 @@ public class MemberCouponService {
             throw new MemberCouponIssueLimitException();
         }
 
-        return Integer.parseInt("1");
+        return result;
     }
 
     private Coupon getCoupon(long couponId) {

--- a/src/main/java/coupon/service/member_coupon/dto/MemberCouponResponse.java
+++ b/src/main/java/coupon/service/member_coupon/dto/MemberCouponResponse.java
@@ -1,0 +1,21 @@
+package coupon.service.member_coupon.dto;
+
+import coupon.domain.member_coupon.MemberCoupon;
+import java.time.LocalDate;
+
+public record MemberCouponResponse(
+        long memberCouponId,
+        long couponId,
+        String couponName,
+        String category,
+        boolean isUsed,
+        LocalDate issuedAt,
+        LocalDate expiredAt
+) {
+
+    public static MemberCouponResponse from(MemberCoupon memberCoupon) {
+        return new MemberCouponResponse(memberCoupon.getId(), memberCoupon.getCouponId(), memberCoupon.getCouponName(),
+                memberCoupon.getCoupon().getCategory().getTypeName(), memberCoupon.isUsed(), memberCoupon.getIssuedAt(),
+                memberCoupon.getExpiredAt());
+    }
+}

--- a/src/main/java/coupon/service/member_coupon/dto/MemberCouponsResponse.java
+++ b/src/main/java/coupon/service/member_coupon/dto/MemberCouponsResponse.java
@@ -1,0 +1,17 @@
+package coupon.service.member_coupon.dto;
+
+import coupon.domain.member_coupon.MemberCoupon;
+import java.util.List;
+import java.util.Set;
+
+public record MemberCouponsResponse(
+        List<MemberCouponResponse> memberCoupons
+) {
+    public static MemberCouponsResponse from(List<MemberCoupon> memberCoupons) {
+        List<MemberCouponResponse> response = memberCoupons.stream()
+                .map(MemberCouponResponse::from)
+                .toList();
+
+        return new MemberCouponsResponse(response);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
       time-to-live: 360000
       host: localhost
       port: 36379
-
   jpa:
     hibernate:
       naming:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,11 @@
 spring:
+  cache:
+    type: redis
+    redis:
+      time-to-live: 360000
+      host: localhost
+      port: 36379
+
   jpa:
     hibernate:
       naming:
@@ -6,13 +13,13 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
         default_batch_fetch_size: 128
         id.new_generator_mappings: true
         format_sql: true
         show_sql: false
         use_sql_comments: true
-        hbm2ddl.auto: create
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/test/java/coupon/domain/member_coupon/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/member_coupon/MemberCouponTest.java
@@ -31,7 +31,7 @@ class MemberCouponTest {
                 issueStartDate,
                 issueEndDate);
 
-        Assertions.assertThatThrownBy(() -> MemberCoupon.issue(member, coupon))
+        Assertions.assertThatThrownBy(() -> MemberCoupon.issue(member.getId(), coupon))
                 .isExactlyInstanceOf(CouponIssueDateException.class);
     }
 }

--- a/src/test/java/coupon/domain/member_coupon/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/member_coupon/MemberCouponTest.java
@@ -4,16 +4,24 @@ import coupon.domain.coupon.Category;
 import coupon.domain.coupon.Coupon;
 import coupon.domain.coupon.discount.DiscountType;
 import coupon.domain.member.Member;
+import coupon.domain.member.repository.MemberRepository;
 import coupon.exception.CouponIssueDateException;
 import java.time.LocalDate;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
+@SpringBootTest
 class MemberCouponTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Test
     void 쿠폰_발급기간이_아니라면_쿠폰을_발급받을_수_없다() {
-        Member member = new Member();
+        Member member = memberRepository.save(new Member());
+
         int minDiscountRange = 3;
         int maxDiscountRange = 20;
         LocalDate today = LocalDate.now();

--- a/src/test/java/coupon/service/member_coupon/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/member_coupon/MemberCouponServiceTest.java
@@ -1,5 +1,9 @@
 package coupon.service.member_coupon;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import coupon.domain.coupon.Category;
 import coupon.domain.coupon.Coupon;
 import coupon.domain.coupon.discount.DiscountType;
@@ -8,12 +12,16 @@ import coupon.domain.member.Member;
 import coupon.domain.member.repository.MemberRepository;
 import coupon.exception.MemberCouponIssueLimitException;
 import coupon.service.coupon.dto.CouponIssueResponse;
+import coupon.service.member_coupon.dto.MemberCouponResponse;
+import coupon.service.member_coupon.dto.MemberCouponsResponse;
 import java.time.LocalDate;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 class MemberCouponServiceTest {
@@ -71,5 +79,22 @@ class MemberCouponServiceTest {
         // when & then
         Assertions.assertThatThrownBy(() -> memberCouponService.issueMemberCoupon(member.getId(), coupon.getId()))
                 .isExactlyInstanceOf(MemberCouponIssueLimitException.class);
+    }
+
+    @Test
+    @Transactional
+    void 회원의_쿠폰_정보를_조회한다() {
+        // given
+        MemberCouponService memberCouponService = mock(MemberCouponService.class);
+        Member member = memberRepository.save(new Member());
+        List<MemberCouponResponse> memberCouponResponses = List.of(
+                new MemberCouponResponse(1L, 1L, "테스트쿠폰", Category.FOOD.getTypeName(),
+                        false, LocalDate.now(), LocalDate.now()));
+
+        when(memberCouponService.getMemberCoupons(anyLong()))
+                .thenReturn(new MemberCouponsResponse(memberCouponResponses));
+
+        // then
+        Assertions.assertThat(memberCouponService.getMemberCoupons(member.getId()).memberCoupons()).hasSize(1);
     }
 }

--- a/src/test/java/coupon/service/member_coupon/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/member_coupon/MemberCouponServiceTest.java
@@ -1,0 +1,75 @@
+package coupon.service.member_coupon;
+
+import coupon.domain.coupon.Category;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.discount.DiscountType;
+import coupon.domain.coupon.repository.CouponRepository;
+import coupon.domain.member.Member;
+import coupon.domain.member.repository.MemberRepository;
+import coupon.exception.MemberCouponIssueLimitException;
+import coupon.service.coupon.dto.CouponIssueResponse;
+import java.time.LocalDate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MemberCouponServiceTest {
+
+    @Autowired
+    MemberCouponService memberCouponService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    private Coupon coupon;
+
+    @BeforeEach
+    void issueCoupon() {
+        String couponName = "testCoupon";
+        int discountPrice = 1000;
+        int minOrderPrice = 5000;
+        int minDiscountRange = 3;
+        int maxDiscountRange = 20;
+        Category category = Category.FASHION;
+        LocalDate issueStartDate = LocalDate.now().minusDays(3);
+        LocalDate issueEndDate = LocalDate.now().plusDays(3);
+
+        coupon = couponRepository.save(
+                new Coupon(couponName, DiscountType.PERCENT, minDiscountRange, maxDiscountRange, discountPrice,
+                minOrderPrice, category, issueStartDate, issueEndDate)
+        );
+    }
+
+    @Test
+    void 쿠폰을_발급한다() {
+        // given
+        Member member = memberRepository.save(new Member());
+
+        // when
+        CouponIssueResponse couponIssueResponse = memberCouponService.issueMemberCoupon(member.getId(), coupon.getId());
+
+        // then
+        Assertions.assertThat(couponIssueResponse.couponName()).isEqualTo(coupon.getCouponName());
+    }
+
+    @Test
+    void 쿠폰을_5회_초과로_발급받을_수_없다() {
+        //given
+        Member member = memberRepository.save(new Member());
+        memberCouponService.issueMemberCoupon(member.getId(), coupon.getId());
+        memberCouponService.issueMemberCoupon(member.getId(), coupon.getId());
+        memberCouponService.issueMemberCoupon(member.getId(), coupon.getId());
+        memberCouponService.issueMemberCoupon(member.getId(), coupon.getId());
+        memberCouponService.issueMemberCoupon(member.getId(), coupon.getId());
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> memberCouponService.issueMemberCoupon(member.getId(), coupon.getId()))
+                .isExactlyInstanceOf(MemberCouponIssueLimitException.class);
+    }
+}


### PR DESCRIPTION
안녕하세요 폴라~ 이든입니다!
사실 이번 미션은 선택과 집중을 위해 프로젝트에 좀 더 공수를 많이들이느라 제대로 코드를 작성하지 못해서 죄송하단 말씀부터 드리고 싶네요
리뷰를 통해 같이 배워나가는 것이 있어야할텐데 그걸 드리지 못해서 굉장히 죄송하게 생각합니다 ㅠ
그래도 제가 가진 시간내에서 최선을 다했으니 리뷰 잘부탁드립니다!

그리고 현재는 테스트 코드 중, 쿠폰 발급 기능 같은 경우에 실제로 Redis에 값을 저장하는 문제가 있습니다.
이는 제가 인지하고 있기 때문에, 이후에 꼭 해결할테니 믿어주십쇼,,!
> 현재는 이로 인해 문제가 발생하는 회원의 쿠폰 정보 조회를 Mock으로 처리하였는데 이후에 다시 변경하겠습니다!

캐싱 전략은 `Write Through` 를 사용했고 적용 부분은 `쿠폰 생성`과 `회원 쿠폰 발급`에 사용하였습니다.
`쿠폰 생성` 후에는 Cache를 통해 DB에 접근하지 않고 Redis에서 쿠폰을 조회할 수 있도록 구현하였고
`회원 쿠폰 발급` 시에는 회원이 발급받은 쿠폰의 수를 갱신하면서 최대 5개보다 많은 쿠폰을 발급받지 못하도록 처리했어요. (이 부분은 그리고 LuaScript를 사용해서 원자성을 보장해주었습니다.)

그리고 요구사항과는 조금 다르게 멤버가 발급받은 쿠폰이 아닌 쿠폰 개수를 캐싱하도록 구현했어요.
요구사항을 이해한 건 MemberCoupon Object 자체를 저장하는 걸로 이해했지만, 아직 해보지 않은 방식이고 시간이 없어서 제 방식대로 해석해서 구현했어요.

마지막으로 `매직 리터럴`, `매직 넘버` 등의 처리가 미흡한 부분도 많이 있습니다.
이 부분도 인지하고 있으니 눈에 띄는 부분만 리뷰해주시면 제가 인지하고 있는 부분은 이후에 별도로 수정하도록 하겠습니다!

설명은 이정도로 드리고 이번 리뷰도 잘 부탁드립니다..!
감사합니다!