### PR TITLE
[2단계 - DB 복제와 캐시] 프린(남기범) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/coupon/config/CacheConfig.java
+++ b/src/main/java/coupon/config/CacheConfig.java
@@ -27,7 +27,8 @@ public class CacheConfig {
         RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(mapper())))
-                .entryTtl(TTL);
+                .entryTtl(TTL)
+                .enableTimeToIdle();
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(cacheConfiguration)

--- a/src/main/java/coupon/config/CacheConfig.java
+++ b/src/main/java/coupon/config/CacheConfig.java
@@ -1,0 +1,48 @@
+package coupon.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    private static final Duration TTL = Duration.ofMinutes(30);
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(mapper())))
+                .entryTtl(TTL);
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(cacheConfiguration)
+                .build();
+    }
+
+    private ObjectMapper mapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(Object.class)
+                        .build(),
+                DefaultTyping.NON_FINAL
+        );
+        return objectMapper;
+    }
+}

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -60,6 +61,12 @@ public class Coupon {
         if (discountRate < MIN_DISCOUNT_RATE || discountRate > MAX_DISCOUNT_RATE) {
             throw new IllegalArgumentException("할인율은 %d%% 이상 %d%% 이하여야 합니다."
                     .formatted(MIN_DISCOUNT_RATE, MAX_DISCOUNT_RATE));
+        }
+    }
+
+    public void issue(LocalDateTime now) {
+        if (!issuePeriod.isIssuable(now)) {
+            throw new IllegalArgumentException("쿠폰 발급 기간이 아닙니다.");
         }
     }
 }

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -69,24 +69,4 @@ public class Coupon {
             throw new IllegalArgumentException("쿠폰 발급 기간이 아닙니다.");
         }
     }
-
-    public String getName() {
-        return name.getName();
-    }
-
-    public int getDiscountAmount() {
-        return discountAmount.getDiscountAmount();
-    }
-
-    public int getMinOrderAmount() {
-        return minOrderAmount.getMinOrderAmount();
-    }
-
-    public LocalDateTime getIssueStartedAt() {
-        return issuePeriod.getIssueStartedAt();
-    }
-
-    public LocalDateTime getIssueEndedAt() {
-        return issuePeriod.getIssueEndedAt();
-    }
 }

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -69,4 +69,24 @@ public class Coupon {
             throw new IllegalArgumentException("쿠폰 발급 기간이 아닙니다.");
         }
     }
+
+    public String getName() {
+        return name.getName();
+    }
+
+    public int getDiscountAmount() {
+        return discountAmount.getDiscountAmount();
+    }
+
+    public int getMinOrderAmount() {
+        return minOrderAmount.getMinOrderAmount();
+    }
+
+    public LocalDateTime getIssueStartedAt() {
+        return issuePeriod.getIssueStartedAt();
+    }
+
+    public LocalDateTime getIssueEndedAt() {
+        return issuePeriod.getIssueEndedAt();
+    }
 }

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -6,8 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Embeddable
+@Getter(value = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CouponName {
 

--- a/src/main/java/coupon/domain/coupon/CouponName.java
+++ b/src/main/java/coupon/domain/coupon/CouponName.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@Getter(value = AccessLevel.PROTECTED)
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CouponName {
 

--- a/src/main/java/coupon/domain/coupon/DiscountAmount.java
+++ b/src/main/java/coupon/domain/coupon/DiscountAmount.java
@@ -6,8 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Embeddable
+@Getter(value = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DiscountAmount {
 

--- a/src/main/java/coupon/domain/coupon/DiscountAmount.java
+++ b/src/main/java/coupon/domain/coupon/DiscountAmount.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@Getter(value = AccessLevel.PROTECTED)
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class DiscountAmount {
 

--- a/src/main/java/coupon/domain/coupon/IssuePeriod.java
+++ b/src/main/java/coupon/domain/coupon/IssuePeriod.java
@@ -8,8 +8,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Embeddable
+@Getter(value = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IssuePeriod {
 

--- a/src/main/java/coupon/domain/coupon/IssuePeriod.java
+++ b/src/main/java/coupon/domain/coupon/IssuePeriod.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@Getter(value = AccessLevel.PROTECTED)
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IssuePeriod {
 

--- a/src/main/java/coupon/domain/coupon/MinOrderAmount.java
+++ b/src/main/java/coupon/domain/coupon/MinOrderAmount.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
-@Getter(value = AccessLevel.PROTECTED)
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MinOrderAmount {
 

--- a/src/main/java/coupon/domain/coupon/MinOrderAmount.java
+++ b/src/main/java/coupon/domain/coupon/MinOrderAmount.java
@@ -6,8 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @Embeddable
+@Getter(value = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MinOrderAmount {
 

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -1,5 +1,6 @@
 package coupon.domain.member;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,4 +17,11 @@ public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    public Member(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -5,9 +5,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 

--- a/src/main/java/coupon/domain/membercoupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/membercoupon/MemberCoupon.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -53,9 +54,6 @@ public class MemberCoupon {
 
     private LocalDateTime toExpiredAt(LocalDateTime issuedAt) {
         return issuedAt.plusDays(COUPON_EXPIRATION_DAYS)
-                .withHour(23)
-                .withMinute(59)
-                .withSecond(59)
-                .withNano(999_999_000);
+                .with(LocalTime.of(23, 59, 59, 999_999_000));
     }
 }

--- a/src/main/java/coupon/domain/membercoupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/membercoupon/MemberCoupon.java
@@ -1,15 +1,10 @@
 package coupon.domain.membercoupon;
 
-import coupon.domain.coupon.Coupon;
-import coupon.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
@@ -36,20 +31,18 @@ public class MemberCoupon {
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(nullable = false)
-    private Member member;
+    @Column(nullable = false)
+    private Long memberId;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(nullable = false)
-    private Coupon coupon;
+    @Column(nullable = false)
+    private Long couponId;
 
-    public MemberCoupon(Member member, Coupon coupon, LocalDateTime issuedAt) {
-        this.member = member;
-        this.coupon = coupon;
+    public MemberCoupon(LocalDateTime issuedAt, Long memberId, Long couponId) {
         this.used = false;
         this.issuedAt = issuedAt;
         this.expiredAt = toExpiredAt(issuedAt);
+        this.memberId = memberId;
+        this.couponId = couponId;
     }
 
     private LocalDateTime toExpiredAt(LocalDateTime issuedAt) {

--- a/src/main/java/coupon/domain/membercoupon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/membercoupon/MemberCoupon.java
@@ -1,5 +1,7 @@
 package coupon.domain.membercoupon;
 
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -43,6 +45,11 @@ public class MemberCoupon {
         this.expiredAt = toExpiredAt(issuedAt);
         this.memberId = memberId;
         this.couponId = couponId;
+    }
+
+    public static MemberCoupon issue(LocalDateTime issuedAt, Member member, Coupon coupon) {
+        coupon.issue(issuedAt);
+        return new MemberCoupon(issuedAt, member.getId(), coupon.getId());
     }
 
     private LocalDateTime toExpiredAt(LocalDateTime issuedAt) {

--- a/src/main/java/coupon/domain/membercoupon/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/membercoupon/MemberCouponRepository.java
@@ -1,6 +1,9 @@
 package coupon.domain.membercoupon;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+    List<MemberCoupon> findByMemberIdAndCouponId(Long memberId, Long couponId);
 }

--- a/src/main/java/coupon/domain/membercoupon/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/membercoupon/MemberCouponRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
     List<MemberCoupon> findByMemberIdAndCouponId(Long memberId, Long couponId);
+
+    List<MemberCoupon> findByMemberId(Long memberId);
 }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -4,6 +4,7 @@ import coupon.domain.coupon.Coupon;
 import coupon.domain.coupon.CouponRepository;
 import coupon.support.TransactionSupport;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "coupons", key = "#couponId")
     public Coupon getCoupon(Long couponId) {
         return couponRepository.findById(couponId)
                 .orElseGet(() -> getCouponWithWriter(couponId));

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -1,0 +1,47 @@
+package coupon.service;
+
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
+import coupon.domain.member.MemberRepository;
+import coupon.domain.membercoupon.MemberCoupon;
+import coupon.domain.membercoupon.MemberCouponRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCouponService {
+
+    private static final int MAX_MEMBER_COUPON_COUNT = 5;
+
+    private final CouponService couponService;
+
+    private final MemberRepository memberRepository;
+
+    private final MemberCouponRepository memberCouponRepository;
+
+    @Transactional
+    public void issue(Long memberId, Long couponId) {
+        Member member = getMember(memberId);
+        Coupon coupon = couponService.getCoupon(couponId); // todo
+        validateMemberCouponCount(memberId, couponId);
+
+        MemberCoupon memberCoupon = MemberCoupon.issue(LocalDateTime.now(), member, coupon);
+        memberCouponRepository.save(memberCoupon);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+    }
+
+    private void validateMemberCouponCount(Long memberId, Long couponId) {
+        List<MemberCoupon> memberCoupons = memberCouponRepository.findByMemberIdAndCouponId(memberId, couponId);
+        if (memberCoupons.size() >= MAX_MEMBER_COUPON_COUNT) {
+            throw new IllegalArgumentException("이미 %d장의 쿠폰을 발급받았습니다.".formatted(MAX_MEMBER_COUPON_COUNT));
+        }
+    }
+}

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -5,6 +5,7 @@ import coupon.domain.member.Member;
 import coupon.domain.member.MemberRepository;
 import coupon.domain.membercoupon.MemberCoupon;
 import coupon.domain.membercoupon.MemberCouponRepository;
+import coupon.service.dto.MemberCouponResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,7 @@ public class MemberCouponService {
     @Transactional
     public void issue(Long memberId, Long couponId) {
         Member member = getMember(memberId);
-        Coupon coupon = couponService.getCoupon(couponId); // todo
+        Coupon coupon = couponService.getCoupon(couponId);
         validateMemberCouponCount(memberId, couponId);
 
         MemberCoupon memberCoupon = MemberCoupon.issue(LocalDateTime.now(), member, coupon);
@@ -43,5 +44,18 @@ public class MemberCouponService {
         if (memberCoupons.size() >= MAX_MEMBER_COUPON_COUNT) {
             throw new IllegalArgumentException("이미 %d장의 쿠폰을 발급받았습니다.".formatted(MAX_MEMBER_COUPON_COUNT));
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberCouponResponse> findMemberCoupons(Long memberId) {
+        List<MemberCoupon> memberCoupons = memberCouponRepository.findByMemberId(memberId);
+        return memberCoupons.stream()
+                .map(this::toMemberCouponResponse)
+                .toList();
+    }
+
+    private MemberCouponResponse toMemberCouponResponse(MemberCoupon memberCoupon) {
+        Coupon coupon = couponService.getCoupon(memberCoupon.getCouponId());
+        return MemberCouponResponse.of(memberCoupon, coupon);
     }
 }

--- a/src/main/java/coupon/service/dto/CouponResponse.java
+++ b/src/main/java/coupon/service/dto/CouponResponse.java
@@ -16,11 +16,11 @@ public record CouponResponse(
     public static CouponResponse from(Coupon coupon) {
         return new CouponResponse(
                 coupon.getId(),
-                coupon.getName(),
-                coupon.getDiscountAmount(),
-                coupon.getMinOrderAmount(),
-                coupon.getIssueStartedAt(),
-                coupon.getIssueEndedAt(),
+                coupon.getName().getName(),
+                coupon.getDiscountAmount().getDiscountAmount(),
+                coupon.getMinOrderAmount().getMinOrderAmount(),
+                coupon.getIssuePeriod().getIssueStartedAt(),
+                coupon.getIssuePeriod().getIssueEndedAt(),
                 coupon.getCategory().name()
         );
     }

--- a/src/main/java/coupon/service/dto/CouponResponse.java
+++ b/src/main/java/coupon/service/dto/CouponResponse.java
@@ -1,0 +1,27 @@
+package coupon.service.dto;
+
+import coupon.domain.coupon.Coupon;
+import java.time.LocalDateTime;
+
+public record CouponResponse(
+        Long id,
+        String name,
+        int discountAmount,
+        int minOrderAmount,
+        LocalDateTime issueStartedAt,
+        LocalDateTime issueEndedAt,
+        String category
+) {
+
+    public static CouponResponse from(Coupon coupon) {
+        return new CouponResponse(
+                coupon.getId(),
+                coupon.getName(),
+                coupon.getDiscountAmount(),
+                coupon.getMinOrderAmount(),
+                coupon.getIssueStartedAt(),
+                coupon.getIssueEndedAt(),
+                coupon.getCategory().name()
+        );
+    }
+}

--- a/src/main/java/coupon/service/dto/MemberCouponResponse.java
+++ b/src/main/java/coupon/service/dto/MemberCouponResponse.java
@@ -1,0 +1,24 @@
+package coupon.service.dto;
+
+import coupon.domain.coupon.Coupon;
+import coupon.domain.membercoupon.MemberCoupon;
+import java.time.LocalDateTime;
+
+public record MemberCouponResponse(
+        Long id,
+        boolean used,
+        LocalDateTime issuedAt,
+        LocalDateTime expiredAt,
+        CouponResponse coupon
+) {
+
+    public static MemberCouponResponse of(MemberCoupon memberCoupon, Coupon coupon) {
+        return new MemberCouponResponse(
+                memberCoupon.getId(),
+                memberCoupon.isUsed(),
+                memberCoupon.getIssuedAt(),
+                memberCoupon.getExpiredAt(),
+                CouponResponse.from(coupon)
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
+  data:
+    redis:
+      port: 36379
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,4 +35,9 @@ coupon.datasource:
 
 logging:
   level:
-    coupon.config: debug
+    coupon:
+      config: debug
+    org:
+      springframework:
+        transaction:
+          interceptor: TRACE

--- a/src/test/java/coupon/domain/coupon/CouponTest.java
+++ b/src/test/java/coupon/domain/coupon/CouponTest.java
@@ -3,6 +3,8 @@ package coupon.domain.coupon;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -18,5 +20,19 @@ class CouponTest {
         assertThatThrownBy(() -> new Coupon("쿠폰", discountAmount, minOrderAmount, NOW, NOW, CATEGORY))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("할인율은 3% 이상 20% 이하여야 합니다.");
+    }
+
+    @Test
+    void 쿠폰이_발급_가능한_기간이_아닐_때_발급할_경우_예외가_발생한다() {
+        // given
+        LocalDate issueStartedDate = LocalDate.parse("2024-10-14");
+        LocalDate issueEndedDate = LocalDate.parse("2024-10-15");
+        Coupon coupon = new Coupon("쿠폰", 1_000, 5_000, issueStartedDate, issueEndedDate, CATEGORY);
+        LocalDateTime now = LocalDateTime.parse("2024-10-13T23:59:59.999999");
+
+        // when & then
+        assertThatThrownBy(() -> coupon.issue(now))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰 발급 기간이 아닙니다.");
     }
 }

--- a/src/test/java/coupon/domain/coupon/IssuePeriodTest.java
+++ b/src/test/java/coupon/domain/coupon/IssuePeriodTest.java
@@ -1,5 +1,6 @@
 package coupon.domain.coupon;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -79,5 +80,35 @@ class IssuePeriodTest {
         assertThatThrownBy(() -> new IssuePeriod(issueStartedDate, issueEndedDate))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("발급 시작일은 종료일보다 빠를 수 없습니다.");
+    }
+
+    @Test
+    void 발급_가능한_기간이_아니면_false를_반환한다() {
+        // given
+        LocalDate issueStartedDate = LocalDate.parse("2024-10-14");
+        LocalDate issueEndedDate = LocalDate.parse("2024-10-15");
+        IssuePeriod issuePeriod = new IssuePeriod(issueStartedDate, issueEndedDate);
+        LocalDateTime now = LocalDateTime.parse("2024-10-16T00:00:00");
+
+        // when
+        boolean issuable = issuePeriod.isIssuable(now);
+
+        // then
+        assertThat(issuable).isFalse();
+    }
+
+    @Test
+    void 발급_가능한_기간이면_true를_반환한다() {
+        // given
+        LocalDate issueStartedDate = LocalDate.parse("2024-10-14");
+        LocalDate issueEndedDate = LocalDate.parse("2024-10-15");
+        IssuePeriod issuePeriod = new IssuePeriod(issueStartedDate, issueEndedDate);
+        LocalDateTime now = LocalDateTime.parse("2024-10-14T00:00:00.000001");
+
+        // when
+        boolean issuable = issuePeriod.isIssuable(now);
+
+        // then
+        assertThat(issuable).isTrue();
     }
 }

--- a/src/test/java/coupon/domain/membercoupon/MemberCouponTest.java
+++ b/src/test/java/coupon/domain/membercoupon/MemberCouponTest.java
@@ -15,7 +15,7 @@ class MemberCouponTest {
     })
     void 멤버_쿠폰을_생성하면_만료_일은_발급_일을_포함한_7일_이후이다(LocalDateTime issuedAt, LocalDateTime expiredAt) {
         // when
-        MemberCoupon memberCoupon = new MemberCoupon(null, null, issuedAt);
+        MemberCoupon memberCoupon = new MemberCoupon(issuedAt, 1L, 1L);
 
         // then
         assertThat(memberCoupon.getExpiredAt()).isEqualTo(expiredAt);

--- a/src/test/java/coupon/service/BaseServiceTest.java
+++ b/src/test/java/coupon/service/BaseServiceTest.java
@@ -1,0 +1,24 @@
+package coupon.service;
+
+import coupon.domain.coupon.CouponRepository;
+import coupon.domain.member.MemberRepository;
+import coupon.domain.membercoupon.MemberCouponRepository;
+import coupon.support.extension.DatabaseCleanerExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+public abstract class BaseServiceTest {
+
+    @Autowired
+    protected CouponRepository couponRepository;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected MemberCouponRepository memberCouponRepository;
+}

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -7,16 +7,15 @@ import coupon.domain.coupon.Coupon;
 import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
-public class CouponServiceTest {
+public class CouponServiceTest extends BaseServiceTest {
 
     @Autowired
     private CouponService couponService;
 
     @Test
     void 복제지연테스트() {
+        // given
         Coupon coupon = new Coupon("우테코치킨 첫주문 할인",
                 1_000,
                 5_000,
@@ -24,7 +23,10 @@ public class CouponServiceTest {
                 LocalDate.parse("2024-10-20"),
                 Category.FASHION);
 
+        // when
         couponService.create(coupon);
+
+        // then
         Coupon savedCoupon = couponService.getCoupon(coupon.getId());
         assertThat(savedCoupon).isNotNull();
     }

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -14,14 +14,14 @@ public class CouponServiceTest extends BaseServiceTest {
     private CouponService couponService;
 
     @Test
-    void 복제지연테스트() {
+    void 복제_지연_테스트() {
         // given
         Coupon coupon = new Coupon("우테코치킨 첫주문 할인",
                 1_000,
                 5_000,
                 LocalDate.parse("2024-10-14"),
                 LocalDate.parse("2024-10-20"),
-                Category.FASHION);
+                Category.FOOD);
 
         // when
         couponService.create(coupon);

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -68,7 +68,7 @@ class MemberCouponServiceTest extends BaseServiceTest {
 
         // when
         List<MemberCouponResponse> responses = transactionSupport.executeWithWriter(
-                () -> memberCouponService.findMemberCoupons(member.getId())); // todo : transactionSupport 제거
+                () -> memberCouponService.findMemberCoupons(member.getId()));
 
         // then
         assertThat(responses).hasSize(3);

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -1,0 +1,56 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.domain.coupon.Category;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
+import coupon.domain.membercoupon.MemberCoupon;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MemberCouponServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private MemberCouponService memberCouponService;
+
+    private Member member;
+
+    private Coupon coupon;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(new Member("alpaca"));
+        coupon = couponRepository.save(
+                new Coupon("coupon", 1_000, 5_000, LocalDate.now(), LocalDate.now(), Category.FOOD));
+    }
+
+    @Test
+    void 멤버_쿠폰을_발급한다() {
+        // when
+        memberCouponService.issue(member.getId(), coupon.getId());
+
+        // then
+        List<MemberCoupon> memberCoupons =
+                memberCouponRepository.findByMemberIdAndCouponId(member.getId(), coupon.getId());
+        assertThat(memberCoupons).hasSize(1);
+    }
+
+    @Test
+    void 한_멤버가_동일한_쿠폰을_5장_초과해서_발급하면_예외가_발생한다() {
+        // given
+        for (int i = 0; i < 5; i++) {
+            memberCouponRepository.save(MemberCoupon.issue(LocalDateTime.now(), member, coupon));
+        }
+
+        // when & then
+        assertThatThrownBy(() -> memberCouponService.issue(member.getId(), coupon.getId()))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 5장의 쿠폰을 발급받았습니다.");
+    }
+}

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -7,6 +7,8 @@ import coupon.domain.coupon.Category;
 import coupon.domain.coupon.Coupon;
 import coupon.domain.member.Member;
 import coupon.domain.membercoupon.MemberCoupon;
+import coupon.service.dto.MemberCouponResponse;
+import coupon.support.TransactionSupport;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class MemberCouponServiceTest extends BaseServiceTest {
+
+    @Autowired
+    private TransactionSupport transactionSupport;
 
     @Autowired
     private MemberCouponService memberCouponService;
@@ -27,7 +32,7 @@ class MemberCouponServiceTest extends BaseServiceTest {
     void setUp() {
         member = memberRepository.save(new Member("alpaca"));
         coupon = couponRepository.save(
-                new Coupon("coupon", 1_000, 5_000, LocalDate.now(), LocalDate.now(), Category.FOOD));
+                new Coupon("알파카 털뭉치 할인", 1_000, 5_000, LocalDate.now(), LocalDate.now(), Category.FOOD));
     }
 
     @Test
@@ -52,5 +57,20 @@ class MemberCouponServiceTest extends BaseServiceTest {
         assertThatThrownBy(() -> memberCouponService.issue(member.getId(), coupon.getId()))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .hasMessage("이미 5장의 쿠폰을 발급받았습니다.");
+    }
+
+    @Test
+    void 멤버의_모든_멤버_쿠폰을_조회한다() {
+        // given
+        for (int i = 0; i < 3; i++) {
+            memberCouponRepository.save(MemberCoupon.issue(LocalDateTime.now(), member, coupon));
+        }
+
+        // when
+        List<MemberCouponResponse> responses = transactionSupport.executeWithWriter(
+                () -> memberCouponService.findMemberCoupons(member.getId())); // todo : transactionSupport 제거
+
+        // then
+        assertThat(responses).hasSize(3);
     }
 }

--- a/src/test/java/coupon/support/extension/DatabaseCleanerExtension.java
+++ b/src/test/java/coupon/support/extension/DatabaseCleanerExtension.java
@@ -9,7 +9,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionTemplate;
 
-
 public class DatabaseCleanerExtension implements BeforeEachCallback {
 
     @Override

--- a/src/test/java/coupon/support/extension/DatabaseCleanerExtension.java
+++ b/src/test/java/coupon/support/extension/DatabaseCleanerExtension.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -15,6 +16,7 @@ public class DatabaseCleanerExtension implements BeforeEachCallback {
     public void beforeEach(ExtensionContext extensionContext) {
         ApplicationContext context = SpringExtension.getApplicationContext(extensionContext);
         cleanup(context);
+        cleanCache(context);
     }
 
     private void cleanup(ApplicationContext context) {
@@ -39,5 +41,13 @@ public class DatabaseCleanerExtension implements BeforeEachCallback {
     @SuppressWarnings("unchecked")
     private List<String> findTableNames(EntityManager em) {
         return em.createNativeQuery("SHOW TABLES").getResultList();
+    }
+
+    private void cleanCache(ApplicationContext context) {
+        RedisTemplate<?, ?> redisTemplate = context.getBean("redisTemplate", RedisTemplate.class);
+        redisTemplate.getConnectionFactory()
+                .getConnection()
+                .serverCommands()
+                .flushAll();
     }
 }

--- a/src/test/java/coupon/support/extension/DatabaseCleanerExtension.java
+++ b/src/test/java/coupon/support/extension/DatabaseCleanerExtension.java
@@ -1,0 +1,43 @@
+package coupon.support.extension;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.support.TransactionTemplate;
+
+
+public class DatabaseCleanerExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) {
+        ApplicationContext context = SpringExtension.getApplicationContext(extensionContext);
+        cleanup(context);
+    }
+
+    private void cleanup(ApplicationContext context) {
+        EntityManager em = context.getBean(EntityManager.class);
+        TransactionTemplate transactionTemplate = context.getBean(TransactionTemplate.class);
+
+        transactionTemplate.execute(action -> {
+            em.clear();
+            truncateTables(em);
+            return null;
+        });
+    }
+
+    private void truncateTables(EntityManager em) {
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS=0").executeUpdate();
+        for (String tableName : findTableNames(em)) {
+            em.createNativeQuery("TRUNCATE TABLE %s".formatted(tableName)).executeUpdate();
+        }
+        em.createNativeQuery("SET FOREIGN_KEY_CHECKS=1").executeUpdate();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> findTableNames(EntityManager em) {
+        return em.createNativeQuery("SHOW TABLES").getResultList();
+    }
+}


### PR DESCRIPTION
안녕하세요 알파카 🦙🦙
1단계에서 WAS 이중화를 가정했기 때문에 Redis를 캐시 서버로 사용하고, 캐시에 데이터가 없으면 DB를 조회하는 `Look Aside` 전략을 선택했습니다
1. 캐시 서버에 데이터가 있는지 확인 (cache hit)
2. 캐시 서버에 없으면 DB에서 데이터 조회 (cache miss)
3. DB에서 조회한 데이터를 캐시 서버에 업데이트

쿠폰을 생성할 때는 캐시에 저장하지 않기 때문에 캐시 쓰기 전략은 고려하지 않았어요

캐시된 데이터의 TTL은 30분입니다
쿠폰 중에서도 자주 조회되는 쿠폰(ex. BBQ와 같은 프랜차이즈 가게)과 자주 조회되지 않는 쿠폰(ex. 개인 자영업자 가게)이 있을 것이라고 생각했고, 자주 조회되지 않는 쿠폰이 불필요하게 메모리를 점유하지 않도록 하기 위함이에요
자주 조회되는 쿠폰은 TTL이 지속적으로 갱신되기 때문에 TTL을 30분으로 잡더라도 cache miss가 자주 발생하지 않을 것 같고, 더 적절한 TTL 값은 cache miss를 모니터링하면서 찾아보지 않을까 싶어요

> Redis는 TTL 이전에 데이터를 읽거나 업데이트했을 때 TTL 값을 다시 초기화하는 TTI(Time To Idle)를 지원하지 않아요
하지만 Spring Data Redis에서는 TTI 활성화 기능을 제공해서 TTL을 초기화할 수 있습니다
reference: https://docs.spring.io/spring-data/redis/reference/redis/redis-cache.html#redis:support:cache-abstraction:expiration:tti2

3단계는 진행하지 않을 예정이라서 2단계가 마지막이 될 것 같습니다 이번 리뷰도 감사합니다 👍🏻 