### PR TITLE
[2단계 - DB 복제와 캐시] 도비(김도엽) 미션 제출합니다.

### DIFF
--- a/src/main/java/coupon/config/CacheConfig.java
+++ b/src/main/java/coupon/config/CacheConfig.java
@@ -1,0 +1,10 @@
+package coupon.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+}

--- a/src/main/java/coupon/config/JpaConfig.java
+++ b/src/main/java/coupon/config/JpaConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -23,9 +24,10 @@ public class JpaConfig {
     private String propertyHbm2ddlAuto;
 
     @Bean
-    public LocalContainerEntityManagerFactoryBean entityManagerFactory(@Qualifier("writerDataSource") DataSource writerDataSource) {
+    @DependsOn("routerDataSource")
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(@Qualifier("routerDataSource") DataSource routingDataSource) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
-        em.setDataSource(writerDataSource);
+        em.setDataSource(routingDataSource);
         em.setPackagesToScan("coupon.domain");
         JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
         em.setJpaVendorAdapter(vendorAdapter);

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -7,7 +7,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -41,6 +43,12 @@ public class Coupon {
     @Column(nullable = false)
     private LocalDateTime endDate;
 
+    @Column(nullable = false)
+    private int availableCount; // 발급 가능한 쿠폰 수량
+
+    @OneToMany(mappedBy = "coupon")
+    private List<MemberCoupon> memberCoupons;
+
     public Coupon(
             Long id,
             String name,
@@ -48,9 +56,10 @@ public class Coupon {
             int minimumOrderAmount,
             Category category,
             LocalDateTime startDate,
-            LocalDateTime endDate
+            LocalDateTime endDate,
+            int availableCount
     ) {
-        validateCoupon(name, discountAmount, minimumOrderAmount, category, startDate, endDate);
+        validateCoupon(name, discountAmount, minimumOrderAmount, category, startDate, endDate, availableCount);
         this.id = id;
         this.name = name;
         this.discountAmount = discountAmount;
@@ -58,6 +67,7 @@ public class Coupon {
         this.category = category;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.availableCount = availableCount;
     }
 
     public Coupon(
@@ -66,9 +76,10 @@ public class Coupon {
             int minimumOrderAmount,
             Category category,
             LocalDateTime startDate,
-            LocalDateTime endDate
+            LocalDateTime endDate,
+            int availableCount
     ) {
-        this(null, name, discountAmount, minimumOrderAmount, category, startDate, endDate);
+        this(null, name, discountAmount, minimumOrderAmount, category, startDate, endDate, availableCount);
     }
 
     private void validateCoupon(
@@ -77,12 +88,20 @@ public class Coupon {
             int minimumOrderAmount,
             Category category,
             LocalDateTime startDate,
-            LocalDateTime endDate
+            LocalDateTime endDate,
+            int availableCount
     ) {
         validateName(name);
         validateDiscount(discountAmount, minimumOrderAmount);
         validateCategory(category);
         validateDate(startDate, endDate);
+        validateAvailableCount(availableCount);
+    }
+
+    private void validateAvailableCount(int availableCount) {
+        if (availableCount < 0) {
+            throw new IllegalArgumentException("발급 가능한 쿠폰 수량은 0 이상이어야 합니다.");
+        }
     }
 
     private void validateName(String name) {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -7,9 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -46,8 +44,17 @@ public class Coupon {
     @Column(nullable = false)
     private int availableCount;
 
-    @OneToMany(mappedBy = "coupon")
-    private List<MemberCoupon> memberCoupons;
+    public Coupon(
+            String name,
+            int discountAmount,
+            int minimumOrderAmount,
+            Category category,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            int availableCount
+    ) {
+        this(null, name, discountAmount, minimumOrderAmount, category, startDate, endDate, availableCount);
+    }
 
     public Coupon(
             Long id,
@@ -70,18 +77,6 @@ public class Coupon {
         this.availableCount = availableCount;
     }
 
-    public Coupon(
-            String name,
-            int discountAmount,
-            int minimumOrderAmount,
-            Category category,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            int availableCount
-    ) {
-        this(null, name, discountAmount, minimumOrderAmount, category, startDate, endDate, availableCount);
-    }
-
     private void validateCoupon(
             String name,
             int discountAmount,
@@ -96,12 +91,6 @@ public class Coupon {
         validateCategory(category);
         validateDate(startDate, endDate);
         validateAvailableCount(availableCount);
-    }
-
-    private void validateAvailableCount(int availableCount) {
-        if (availableCount < 0) {
-            throw new IllegalArgumentException("발급 가능한 쿠폰 수량은 0 이상이어야 합니다.");
-        }
     }
 
     private void validateName(String name) {
@@ -141,6 +130,12 @@ public class Coupon {
     private void validateDate(LocalDateTime startDate, LocalDateTime endDate) {
         if (startDate.isAfter(endDate)) {
             throw new IllegalArgumentException("시작일은 종료일 이전일 수 없습니다.");
+        }
+    }
+
+    private void validateAvailableCount(int availableCount) {
+        if (availableCount < 0) {
+            throw new IllegalArgumentException("발급 가능한 쿠폰 수량은 0 이상이어야 합니다.");
         }
     }
 

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -44,7 +44,7 @@ public class Coupon {
     private LocalDateTime endDate;
 
     @Column(nullable = false)
-    private int availableCount; // 발급 가능한 쿠폰 수량
+    private int availableCount;
 
     @OneToMany(mappedBy = "coupon")
     private List<MemberCoupon> memberCoupons;
@@ -142,5 +142,12 @@ public class Coupon {
         if (startDate.isAfter(endDate)) {
             throw new IllegalArgumentException("시작일은 종료일 이전일 수 없습니다.");
         }
+    }
+
+    public void decrementAvailableCount() {
+        if (availableCount <= 0) {
+            throw new IllegalArgumentException("발급 가능한 쿠폰 수량이 부족합니다.");
+        }
+        availableCount--;
     }
 }

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -5,12 +5,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
 
 @Entity
 @Getter
@@ -26,19 +23,10 @@ public class Member {
     @Column(nullable = false)
     private int couponCount = 0;
 
-    @OneToMany(mappedBy = "member")
-    private List<MemberCoupon> memberCoupons;
-
     public void incrementCouponCount() {
         if (couponCount >= 5) {
             throw new IllegalArgumentException("한 회원은 최대 5장의 쿠폰만 발급받을 수 있습니다.");
         }
         couponCount++;
-    }
-
-    public void decrementCouponCount() {
-        if (couponCount > 0) {
-            couponCount--;
-        }
     }
 }

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+
 @Entity
 @Getter
 @Setter
@@ -27,4 +28,17 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<MemberCoupon> memberCoupons;
+
+    public void incrementCouponCount() {
+        if (couponCount >= 5) {
+            throw new IllegalArgumentException("한 회원은 최대 5장의 쿠폰만 발급받을 수 있습니다.");
+        }
+        couponCount++;
+    }
+
+    public void decrementCouponCount() {
+        if (couponCount > 0) {
+            couponCount--;
+        }
+    }
 }

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -1,0 +1,30 @@
+package coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private int couponCount = 0;
+
+    @OneToMany(mappedBy = "member")
+    private List<MemberCoupon> memberCoupons;
+}

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,0 +1,50 @@
+package coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_coupon_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private Boolean isUsed = false;
+
+    @Column(nullable = false)
+    private LocalDateTime issuedOn;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresOn;
+
+    public MemberCoupon(Coupon coupon, Member member, LocalDateTime issuedOn, LocalDateTime expiresOn) {
+        this.coupon = coupon;
+        this.member = member;
+        this.issuedOn = issuedOn;
+        this.expiresOn = expiresOn;
+    }
+}
+

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,13 +21,9 @@ public class MemberCoupon {
     @Column(name = "member_coupon_id")
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "coupon_id", nullable = false)
-    private Coupon coupon;
+    private Long couponId;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    private Long memberId;
 
     @Column(nullable = false)
     private Boolean isUsed = false;
@@ -41,8 +35,8 @@ public class MemberCoupon {
     private LocalDateTime expiresOn;
 
     public MemberCoupon(Coupon coupon, Member member, LocalDateTime issuedOn, LocalDateTime expiresOn) {
-        this.coupon = coupon;
-        this.member = member;
+        this.couponId = coupon.getId();
+        this.memberId = member.getId();
         this.issuedOn = issuedOn;
         this.expiresOn = expiresOn;
     }

--- a/src/main/java/coupon/domain/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/repository/MemberCouponRepository.java
@@ -1,0 +1,8 @@
+package coupon.domain.repository;
+
+import coupon.domain.MemberCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+}

--- a/src/main/java/coupon/domain/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/repository/MemberCouponRepository.java
@@ -1,8 +1,11 @@
 package coupon.domain.repository;
 
+import coupon.domain.Member;
 import coupon.domain.MemberCoupon;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
+    List<MemberCoupon> findByMember(Member member);
 }

--- a/src/main/java/coupon/domain/repository/MemberRepository.java
+++ b/src/main/java/coupon/domain/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package coupon.domain.repository;
+
+import coupon.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -83,10 +83,6 @@ public class CouponService {
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalArgumentException("쿠폰이 존재하지 않습니다."));
 
-        if (member.getCouponCount() >= 5) {
-            throw new IllegalArgumentException("한 회원은 최대 5장의 쿠폰만 발급받을 수 있습니다.");
-        }
-
         coupon.decrementAvailableCount();
         member.incrementCouponCount();
         MemberCoupon memberCoupon = new MemberCoupon(coupon, member, LocalDateTime.now(), LocalDateTime.now().plusDays(7));

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,7 +1,12 @@
 package coupon.service;
 
 import coupon.domain.Coupon;
+import coupon.domain.Member;
+import coupon.domain.MemberCoupon;
 import coupon.domain.repository.CouponRepository;
+import coupon.domain.repository.MemberCouponRepository;
+import coupon.domain.repository.MemberRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final MemberCouponRepository memberCouponRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void createCoupon(Coupon coupon) {
@@ -27,6 +34,22 @@ public class CouponService {
     public Coupon getCouponFromWriter(Long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(IllegalArgumentException::new);
+    }
+
+    @Transactional
+    public void issueCouponToMember(Long memberId, Long couponId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("쿠폰이 존재하지 않습니다."));
+
+        if (member.getCouponCount() >= 5) {
+            throw new IllegalArgumentException("한 회원은 최대 5장의 쿠폰만 발급받을 수 있습니다.");
+        }
+
+        coupon.decrementAvailableCount();
+        MemberCoupon memberCoupon = new MemberCoupon(coupon, member, LocalDateTime.now(), LocalDateTime.now().plusDays(7));
+        memberCouponRepository.save(memberCoupon);
     }
 }
 

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -10,10 +10,12 @@ import jakarta.persistence.EntityManagerFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,14 @@ public class CouponService {
     private final MemberRepository memberRepository;
     private final CacheManager cacheManager;
 
+    private CouponService self;
+
+    @Autowired
+    @Lazy
+    public void setSelf(CouponService self) {
+        this.self = self;
+    }
+
     @Transactional
     public void createCoupon(Coupon coupon) {
         couponRepository.save(coupon);
@@ -37,7 +47,7 @@ public class CouponService {
         Coupon coupon = couponRepository.findById(couponId)
                 .orElse(null);
         if (coupon == null) {
-            return getCouponFromWriter(couponId);
+            return self.getCouponFromWriter(couponId);
         }
         return coupon;
     }
@@ -49,7 +59,7 @@ public class CouponService {
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
         List<MemberCoupon> memberCoupons = memberCouponRepository.findByMember(member);
         if (memberCoupons.isEmpty()) {
-            return getMemberCouponsFromWriter(member);
+            return self.getMemberCouponsFromWriter(member);
         }
         return memberCoupons;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -72,7 +72,7 @@ class CouponServiceTest {
         // Writer DB로부터 직접 데이터를 확인하여 일관성을 보장합니다.
         List<MemberCoupon> memberCoupons = couponService.getMemberCouponsFromWriter(member);
         assertThat(memberCoupons).hasSize(1);
-        assertThat(memberCoupons.get(0).getCoupon().getName()).isEqualTo("Test Coupon 2");
+        assertThat(memberCoupons.get(0).getCouponId()).isEqualTo(coupon.getId());
     }
 
     @Test

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -24,7 +24,8 @@ class CouponServiceTest {
                 30000,
                 Category.FASHION,
                 LocalDateTime.now(),
-                LocalDateTime.now().plusDays(7)
+                LocalDateTime.now().plusDays(7),
+                5
         );
         couponService.createCoupon(coupon);
 

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,20 +1,37 @@
 package coupon.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import coupon.CouponApplication;
 import coupon.domain.Category;
 import coupon.domain.Coupon;
+import coupon.domain.Member;
+import coupon.domain.MemberCoupon;
+import coupon.domain.repository.CouponRepository;
+import coupon.domain.repository.MemberRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest(classes = CouponApplication.class)
 class CouponServiceTest {
 
     @Autowired
     CouponService couponService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    CacheManager cacheManager;
 
     @Test
     void 복제지연테스트() {
@@ -27,9 +44,137 @@ class CouponServiceTest {
                 LocalDateTime.now().plusDays(7),
                 5
         );
-        couponService.createCoupon(coupon);
+        couponRepository.save(coupon);
 
         Coupon savedCoupon = couponService.getCoupon(coupon.getId());
         assertThat(savedCoupon).isNotNull();
+    }
+
+    @Test
+    @Transactional
+    void 회원에게_쿠폰_발급_테스트() {
+        Member member = new Member();
+        memberRepository.save(member);
+
+        Coupon coupon = new Coupon(
+                "Test Coupon 2",
+                1500,
+                20000,
+                Category.FOOD,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(10),
+                10
+        );
+        couponRepository.save(coupon);
+
+        couponService.issueCouponToMember(member.getId(), coupon.getId());
+
+        // Writer DB로부터 직접 데이터를 확인하여 일관성을 보장합니다.
+        List<MemberCoupon> memberCoupons = couponService.getMemberCouponsFromWriter(member);
+        assertThat(memberCoupons).hasSize(1);
+        assertThat(memberCoupons.get(0).getCoupon().getName()).isEqualTo("Test Coupon 2");
+    }
+
+    @Test
+    @Transactional
+    void 쿠폰_발급_제한_테스트() {
+        Member member = new Member();
+        memberRepository.save(member);
+
+        Coupon coupon = new Coupon(
+                "Limited Coupon",
+                2000,
+                25000,
+                Category.FASHION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(5),
+                10
+        );
+        couponRepository.save(coupon);
+
+        for (int i = 0; i < 5; i++) {
+            couponService.issueCouponToMember(member.getId(), coupon.getId());
+        }
+
+        List<MemberCoupon> memberCoupons = couponService.getMemberCouponsFromWriter(member);
+        assertThat(memberCoupons).hasSize(5);
+        assertThrows(IllegalArgumentException.class, () -> {
+            couponService.issueCouponToMember(member.getId(), coupon.getId());
+        });
+    }
+
+    @Test
+    void 캐시_조회_테스트() {
+        Coupon coupon = new Coupon(
+                "Cached Coupon",
+                3000,
+                40000,
+                Category.FASHION,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(15),
+                20
+        );
+        couponRepository.save(coupon);
+
+        Coupon firstFetch = couponService.getCoupon(coupon.getId());
+        assertThat(firstFetch).isNotNull();
+
+        Coupon cachedCoupon = (Coupon) cacheManager.getCache("coupons").get(coupon.getId()).get();
+        assertThat(cachedCoupon).isNotNull();
+        assertThat(cachedCoupon.getName()).isEqualTo("Cached Coupon");
+
+        coupon.setName("Updated Cached Coupon");
+        couponService.updateCoupon(coupon.getId(), coupon);
+
+        Coupon updatedFetch = couponService.getCoupon(coupon.getId());
+        assertThat(updatedFetch.getName()).isEqualTo("Updated Cached Coupon");
+    }
+
+    @Test
+    @Transactional
+    void 잘못된_회원_또는_쿠폰_ID_발급_테스트() {
+        Member member = new Member();
+        memberRepository.save(member);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            couponService.issueCouponToMember(member.getId(), 999L);
+        });
+
+        Coupon coupon = new Coupon(
+                "Invalid Test Coupon",
+                1500,
+                20000,
+                Category.FOOD,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(10),
+                10
+        );
+        couponRepository.save(coupon);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            couponService.issueCouponToMember(999L, coupon.getId());
+        });
+    }
+
+    @Test
+    @Transactional
+    void 쿠폰_수량_감소_테스트() {
+        Member member = new Member();
+        memberRepository.save(member);
+
+        Coupon coupon = new Coupon(
+                "Count Test Coupon",
+                1500,
+                20000,
+                Category.FOOD,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(10),
+                3
+        );
+        couponRepository.save(coupon);
+
+        couponService.issueCouponToMember(member.getId(), coupon.getId());
+        Coupon updatedCoupon = couponService.getCouponFromWriter(coupon.getId());
+        assertThat(updatedCoupon.getAvailableCount()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
안녕하세요 종이 :>

많이 바쁘시죠! 미션 내용을 학습해보면서 적용해보니 조금은 재미가 있었던 것 같습니다.

캐싱 관련하여 구현 내용에 대해 설명드리자면 다음과 같습니다.



### 쿠폰 조회 캐싱 (getCoupon(Long couponId)):

`@Cacheable(value = "coupons", key = "#couponId")`
 쿠폰 ID로 쿠폰을 조회할 때 캐시에서 먼저 검색합니다. 캐시에 쿠폰 데이터가 존재한다면 DB에 접근하지 않고 즉시 반환합니다.
Fallback 전략: 캐시 및 Reader DB에 데이터가 없을 경우 Writer DB에서 데이터를 강제로 조회하여 반환하는 방식입니다. 요 방법을 통해 지연 복제나 캐시 미스 문제를 해결할 수 있습니다.

### 회원의 쿠폰 목록 조회 캐싱 (getMemberCoupons(Long memberId)):

`@Cacheable(value = "memberCoupons", key = "#memberId")`
 회원이 발급받은 쿠폰 목록을 조회할 때 캐시를 먼저 확인하고, 캐시가 없는 경우 DB에서 조회하여 반환합니다.
Fallback 전략: 캐시와 Reader DB에 데이터가 없을 경우, Writer DB에서 데이터를 조회하는 메서드(getMemberCouponsFromWriter())를 사용하여 데이터 일관성을 유지합니다.


### 회원에게 쿠폰 발급 시 캐시 갱신 (issueCouponToMember(Long memberId, Long couponId)):

`@CachePut(value = "memberCoupons", key = "#memberId")`
 회원에게 쿠폰을 발급하는 경우, 해당 회원의 쿠폰 목록을 캐시에 다시 저장하여 최신 상태를 유지하고, 다음 번 조회 시 바로 최신의 쿠폰 정보를 제공할 수 있게 됩니다.
캐시 직접 갱신: 쿠폰을 발급하고 나면 cacheManager를 통해 직접 memberCoupons 캐시를 갱신하는 부분도 포함되어 있어, 캐시와 DB의 데이터 불일치를 최소화하도록 만들었습니다!

### 쿠폰 정보 수정 시 캐시 무효화 (updateCoupon(Long couponId, Coupon updatedCoupon)):

`@CacheEvict(value = "coupons", key = "#couponId")`
쿠폰 정보를 업데이트할 때 캐시에 저장된 이전 정보를 무효화시켰습니다! 이렇게 되면 더 이상 유효하지 않은 데이터가 캐시에서 사용되지 않도록 보장합니다.

---

어느덧 벌써 우테코에서의 마지막 리뷰 요청을 보내게 되었네요!
마지막까지 잘부탁드렵니다!!