### PR TITLE
[2단계 - DB 복제와 캐시] 콜리(김건우) 미션 제출합니다 🥦 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis' //redis 의존성
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/docker/init/init.sql
+++ b/docker/init/init.sql
@@ -9,6 +9,16 @@ CREATE TABLE IF NOT EXISTS coupon
     discount_price   INT          NOT NULL,
     category         varchar(256) NOT NULL,
     sale_order_price INT          NOT NULL,
-    start_at         datetime     NOT NULL,
-    end_at           datetime     NOT NULL
+    start_at         DATETIME     NOT NULL,
+    end_at           DATETIME     NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS member_coupon
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id        BIGINT,
+    coupon_id        BIGINT,
+    used             TINYINT(1)    NOT NULL,
+    issued_at        DATETIME     NOT NULL,
+    expired_at       DATEITME     NOT NULL
+)

--- a/docker/init/init.sql
+++ b/docker/init/init.sql
@@ -20,10 +20,10 @@ CREATE TABLE IF NOT EXISTS member_coupon
     coupon_id        BIGINT,
     used             TINYINT(1)    NOT NULL,
     issued_at        DATETIME     NOT NULL,
-    expired_at       DATEITME     NOT NULL
-)
+    expired_at       DATETIME     NOT NULL
+);
 
 CREATE TABLE IF NOT EXISTS member
 (
-    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
-)
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY
+);

--- a/docker/init/init.sql
+++ b/docker/init/init.sql
@@ -22,3 +22,8 @@ CREATE TABLE IF NOT EXISTS member_coupon
     issued_at        DATETIME     NOT NULL,
     expired_at       DATEITME     NOT NULL
 )
+
+CREATE TABLE IF NOT EXISTS member
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+)

--- a/src/main/java/coupon/config/cache/redis/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/redis/RedisConfig.java
@@ -62,7 +62,7 @@ public class RedisConfig {
             //직렬화 시 type 정보를 저장할 scope 지정
             objectMapper.activateDefaultTyping(
                     BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(), //커스텀 objectmapper에게 클래스 정보도 함께 저장
-                    DefaultTyping.NON_FINAL
+                    DefaultTyping.EVERYTHING
             );
 
             return objectMapper;

--- a/src/main/java/coupon/config/cache/redis/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/redis/RedisConfig.java
@@ -1,0 +1,52 @@
+package coupon.config.cache.redis;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+@EnableConfigurationProperties(RedisProperties.class)
+public class RedisConfig {
+
+    @Autowired
+    private RedisProperties redisProperties;
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory, RedisCacheConfiguration config) {
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .transactionAware() //트랜잭션이 적용된 메소드에서 cache의 commit/rollback 동기화
+                .build();
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        //spring의 default redis client : 비동기 이벤트 기반이라 jedis에 비해 고성능
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(
+                redisProperties.getHost(),
+                redisProperties.getPort())
+        );
+    }
+
+    @Bean
+    public RedisCacheConfiguration redisConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10L))
+                .disableCachingNullValues()
+                .serializeKeysWith(SerializationPair.fromSerializer(new StringRedisSerializer())) //키는 string으로 직렬화
+                .serializeValuesWith(
+                        SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())); //값은 json으로 직렬화
+    }
+}

--- a/src/main/java/coupon/config/cache/redis/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/redis/RedisConfig.java
@@ -67,7 +67,7 @@ public class RedisConfig {
             //직렬화 시 type 정보를 저장할 scope 지정
             objectMapper.activateDefaultTyping(
                     BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(), //커스텀 objectmapper에게 클래스 정보도 함께 저장
-                    DefaultTyping.EVERYTHING
+                    DefaultTyping.NON_CONCRETE_AND_ARRAYS
             );
 
             return objectMapper;

--- a/src/main/java/coupon/config/cache/redis/RedisConfig.java
+++ b/src/main/java/coupon/config/cache/redis/RedisConfig.java
@@ -1,5 +1,8 @@
 package coupon.config.cache.redis;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -16,6 +19,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -54,7 +58,9 @@ public class RedisConfig {
     }
 
     private ObjectMapper getRedisObjectMapper() {
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = new ObjectMapper()
+                    .setVisibility(PropertyAccessor.ALL, Visibility.NONE)
+                    .setVisibility(PropertyAccessor.FIELD, Visibility.ANY); //getter가 아닌 field로 직렬/역직렬화 하기
 
             //localDateTime 호환을 위한 모듈 추가
             objectMapper.registerModule(new JavaTimeModule());

--- a/src/main/java/coupon/config/cache/redis/RedisProperties.java
+++ b/src/main/java/coupon/config/cache/redis/RedisProperties.java
@@ -1,0 +1,23 @@
+package coupon.config.cache.redis;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisProperties {
+
+    private String host;
+    private int port;
+
+    public RedisProperties(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+}

--- a/src/main/java/coupon/controller/CouponController.java
+++ b/src/main/java/coupon/controller/CouponController.java
@@ -1,8 +1,0 @@
-package coupon.controller;
-
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-public class CouponController {
-
-}

--- a/src/main/java/coupon/controller/CouponController.java
+++ b/src/main/java/coupon/controller/CouponController.java
@@ -1,0 +1,8 @@
+package coupon.controller;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CouponController {
+
+}

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -15,7 +15,6 @@ import java.time.LocalTime;
 import org.springframework.data.redis.core.RedisHash;
 
 @Entity
-@RedisHash(value = "member_coupon")
 public class MemberCoupon {
 
     private static final long COUPON_AVAILABLE_DURATION = 7;

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -4,17 +4,17 @@ import coupon.domain.coupon.Coupon;
 import coupon.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import org.springframework.data.redis.core.RedisHash;
 
 @Entity
+@Table(name = "member_coupon")
 public class MemberCoupon {
 
     private static final long COUPON_AVAILABLE_DURATION = 7;
@@ -42,13 +42,15 @@ public class MemberCoupon {
             Member member,
             Coupon coupon
     ) {
-        validateIssuedAt(coupon, issuedAt);
-        validateExpiration(expiredAt);
+        LocalDateTime temporalIssuedAt = LocalDateTime.now();
+        LocalDateTime temporalExpiredAt = LocalDate.now().plusDays(COUPON_AVAILABLE_DURATION).atTime(LocalTime.MAX);
+        validateIssuedAt(coupon, temporalIssuedAt);
+        validateExpiration(temporalExpiredAt);
         this.memberId = member.getId();
         this.couponId = coupon.getId();
         this.isUsed = false;
-        this.issuedAt = LocalDateTime.now();
-        this.expiredAt = issuedAt.toLocalDate().plusDays(COUPON_AVAILABLE_DURATION).atTime(LocalTime.MAX);
+        this.issuedAt = temporalIssuedAt;
+        this.expiredAt = temporalExpiredAt;
     }
 
     private void validateIssuedAt(Coupon coupon, LocalDateTime issuedAt) {

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -11,11 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 public class MemberCoupon {
 
-    private static final int COUPON_AVAILABLE_DURATION = 7;
+    private static final long COUPON_AVAILABLE_DURATION = 7;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,18 +39,15 @@ public class MemberCoupon {
 
     public MemberCoupon(
             Member member,
-            Coupon coupon,
-            boolean isUsed,
-            LocalDateTime issuedAt,
-            LocalDateTime expiredAt
+            Coupon coupon
     ) {
         validateIssuedAt(coupon, issuedAt);
-        validateExpiration(issuedAt, expiredAt);
+        validateExpiration(expiredAt);
         this.memberId = member.getId();
         this.couponId = coupon.getId();
-        this.isUsed = isUsed;
-        this.issuedAt = issuedAt;
-        this.expiredAt = expiredAt;
+        this.isUsed = false;
+        this.issuedAt = LocalDateTime.now();
+        this.expiredAt = issuedAt.toLocalDate().plusDays(COUPON_AVAILABLE_DURATION).atTime(LocalTime.MAX);
     }
 
     private void validateIssuedAt(Coupon coupon, LocalDateTime issuedAt) {
@@ -58,8 +56,8 @@ public class MemberCoupon {
         }
     }
 
-    private void validateExpiration(LocalDateTime issuedAt, LocalDateTime expiredAt) {
-        long diffDays = Duration.between(issuedAt, expiredAt).toDays();
+    private void validateExpiration(LocalDateTime expiredAt) {
+        long diffDays = Duration.between(LocalDateTime.now(), expiredAt).toDays();
         if (diffDays > COUPON_AVAILABLE_DURATION) {
             throw new IllegalArgumentException("회원 쿠폰의 만료일은 발급일로부터 " + COUPON_AVAILABLE_DURATION + "이내여야 합니다");
         }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -12,8 +12,10 @@ import jakarta.persistence.ManyToOne;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import org.springframework.data.redis.core.RedisHash;
 
 @Entity
+@RedisHash(value = "member_coupon")
 public class MemberCoupon {
 
     private static final long COUPON_AVAILABLE_DURATION = 7;

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -65,4 +65,8 @@ public class MemberCoupon {
 
     protected MemberCoupon() {
     }
+
+    public long getCouponId() {
+        return couponId;
+    }
 }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -4,40 +4,65 @@ import coupon.domain.coupon.Coupon;
 import coupon.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Entity
 public class MemberCoupon {
 
+    private static final int COUPON_AVAILABLE_DURATION = 7;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Coupon coupon;
 
     @Column(name = "used", nullable = false)
     private boolean isUsed;
 
-    @Column(name = "issued_time", nullable = false)
-    private LocalDateTime issuedTime;
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
 
-    @Column(name = "expiration", nullable = false)
-    private LocalDateTime expiration;
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
 
-    public MemberCoupon(Member member, boolean isUsed, LocalDateTime issuedTime, LocalDateTime expiration) {
-        this.id = null;
+    public MemberCoupon(
+            Member member,
+            Coupon coupon,
+            boolean isUsed,
+            LocalDateTime issuedAt,
+            LocalDateTime expiredAt
+    ) {
+        validateIssuedAt(coupon, issuedAt);
+        validateExpiration(issuedAt, expiredAt);
         this.member = member;
+        this.coupon = coupon;
         this.isUsed = isUsed;
-        this.issuedTime = issuedTime;
-        this.expiration = expiration;
+        this.issuedAt = issuedAt;
+        this.expiredAt = expiredAt;
+    }
+
+    private void validateIssuedAt(Coupon coupon, LocalDateTime issuedAt) {
+        if (!coupon.isBetweenIssueDuration(issuedAt)) {
+            throw new IllegalArgumentException("쿠폰 발급 기간에 발급되지 않은 쿠폰입니다.");
+        }
+    }
+
+    private void validateExpiration(LocalDateTime issuedAt, LocalDateTime expiredAt) {
+        long diffDays = Duration.between(issuedAt, expiredAt).toDays();
+        if (diffDays > COUPON_AVAILABLE_DURATION) {
+            throw new IllegalArgumentException("회원 쿠폰의 만료일은 발급일로부터 " + COUPON_AVAILABLE_DURATION + "이내여야 합니다");
+        }
     }
 
     protected MemberCoupon() {

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -74,4 +74,16 @@ public class MemberCoupon {
     public long getCouponId() {
         return couponId;
     }
+
+    public boolean isUsed() {
+        return isUsed;
+    }
+
+    public LocalDateTime getIssuedAt() {
+        return issuedAt;
+    }
+
+    public LocalDateTime getExpiredAt() {
+        return expiredAt;
+    }
 }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -68,6 +68,10 @@ public class MemberCoupon {
     protected MemberCoupon() {
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public long getCouponId() {
         return couponId;
     }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -21,11 +21,11 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    @Column(name = "member_id")
+    private long memberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Coupon coupon;
+    @Column(name = "coupon_id")
+    private long couponId;
 
     @Column(name = "used", nullable = false)
     private boolean isUsed;
@@ -45,8 +45,8 @@ public class MemberCoupon {
     ) {
         validateIssuedAt(coupon, issuedAt);
         validateExpiration(issuedAt, expiredAt);
-        this.member = member;
-        this.coupon = coupon;
+        this.memberId = member.getId();
+        this.couponId = coupon.getId();
         this.isUsed = isUsed;
         this.issuedAt = issuedAt;
         this.expiredAt = expiredAt;

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -1,7 +1,5 @@
 package coupon.domain.coupon;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -16,7 +14,6 @@ import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 
 @Entity
-@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 public class Coupon {
 
     @Id

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -80,12 +80,32 @@ public class Coupon {
         return duration.isBetween(issuedAt);
     }
 
+    @JsonIgnore
+    public DiscountRatio getDiscountRatio() {
+        return new DiscountRatio(100 * discountPrice.getPrice() / saleOrderPrice.getPrice());
+    }
+
     public Long getId() {
         return id;
     }
 
-    @JsonIgnore
-    public DiscountRatio getDiscountRatio() {
-        return new DiscountRatio(100 * discountPrice.getPrice() / saleOrderPrice.getPrice());
+    public CouponName getName() {
+        return name;
+    }
+
+    public DiscountPrice getDiscountPrice() {
+        return discountPrice;
+    }
+
+    public Category getCategory() {
+        return category;
+    }
+
+    public SaleOrderPrice getSaleOrderPrice() {
+        return saleOrderPrice;
+    }
+
+    public IssueDuration getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 public class Coupon {
@@ -72,5 +73,22 @@ public class Coupon {
 
     public DiscountRatio getDiscountRatio() {
         return new DiscountRatio(100 * discountPrice.getPrice() / saleOrderPrice.getPrice());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Coupon coupon = (Coupon) o;
+        return Objects.equals(getId(), coupon.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -12,8 +12,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import org.springframework.data.redis.core.RedisHash;
 
 @Entity
+@RedisHash(value = "coupon")
 public class Coupon {
 
     @Id
@@ -73,22 +75,5 @@ public class Coupon {
 
     public DiscountRatio getDiscountRatio() {
         return new DiscountRatio(100 * discountPrice.getPrice() / saleOrderPrice.getPrice());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Coupon coupon = (Coupon) o;
-        return Objects.equals(getId(), coupon.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -62,6 +62,10 @@ public class Coupon {
     protected Coupon() {
     }
 
+    public boolean isBetweenIssueDuration(LocalDateTime issuedAt) {
+        return duration.isBetween(issuedAt);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/coupon/domain/coupon/Coupon.java
+++ b/src/main/java/coupon/domain/coupon/Coupon.java
@@ -12,8 +12,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Coupon {
 
     @Id
@@ -77,32 +79,7 @@ public class Coupon {
         return duration.isBetween(issuedAt);
     }
 
-    @JsonIgnore
     public DiscountRatio getDiscountRatio() {
         return new DiscountRatio(100 * discountPrice.getPrice() / saleOrderPrice.getPrice());
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public CouponName getName() {
-        return name;
-    }
-
-    public DiscountPrice getDiscountPrice() {
-        return discountPrice;
-    }
-
-    public Category getCategory() {
-        return category;
-    }
-
-    public SaleOrderPrice getSaleOrderPrice() {
-        return saleOrderPrice;
-    }
-
-    public IssueDuration getDuration() {
-        return duration;
     }
 }

--- a/src/main/java/coupon/domain/coupon/DiscountRatio.java
+++ b/src/main/java/coupon/domain/coupon/DiscountRatio.java
@@ -21,7 +21,7 @@ public class DiscountRatio {
         }
     }
 
-    public double getRatio() {
+    public int getRatio() {
         return ratio;
     }
 }

--- a/src/main/java/coupon/domain/coupon/IssueDuration.java
+++ b/src/main/java/coupon/domain/coupon/IssueDuration.java
@@ -31,4 +31,12 @@ public class IssueDuration {
             throw new IllegalArgumentException("시작 시점은 종료 시점보다 이전이어야 합니다");
         }
     }
+
+    public LocalDateTime getStartAt() {
+        return startAt;
+    }
+
+    public LocalDateTime getEndAt() {
+        return endAt;
+    }
 }

--- a/src/main/java/coupon/domain/coupon/IssueDuration.java
+++ b/src/main/java/coupon/domain/coupon/IssueDuration.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 @Embeddable
 public class IssueDuration {
 
+    @Column(name = "start_at")
     private LocalDateTime startAt;
 
     @Column(name = "end_at")

--- a/src/main/java/coupon/domain/coupon/IssueDuration.java
+++ b/src/main/java/coupon/domain/coupon/IssueDuration.java
@@ -9,7 +9,7 @@ public class IssueDuration {
 
     private LocalDateTime startAt;
 
-    @Column(name= "end_at")
+    @Column(name = "end_at")
     private LocalDateTime endAt;
 
     public IssueDuration(LocalDateTime startAt, LocalDateTime endAt) {
@@ -19,6 +19,11 @@ public class IssueDuration {
     }
 
     protected IssueDuration() {
+    }
+
+    public boolean isBetween(LocalDateTime issuedAt) {
+        return (issuedAt.isAfter(startAt) || issuedAt.isEqual(startAt))
+                && (issuedAt.isBefore(endAt) || issuedAt.isEqual(endAt));
     }
 
     private void validate(LocalDateTime startAt, LocalDateTime endAt) {

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -12,7 +12,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    protected Member(){
+    public Member() {
     }
 
     public Long getId() {

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -14,4 +14,8 @@ public class Member {
 
     protected Member(){
     }
+
+    public Long getId() {
+        return id;
+    }
 }

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -4,11 +4,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.util.Objects;
-import org.springframework.data.redis.core.RedisHash;
 
 @Entity
-@RedisHash(value = "member")
 public class Member {
 
     @Id

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -5,8 +5,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.util.Objects;
+import org.springframework.data.redis.core.RedisHash;
 
 @Entity
+@RedisHash(value = "member")
 public class Member {
 
     @Id
@@ -18,22 +20,5 @@ public class Member {
 
     public Long getId() {
         return id;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Member member = (Member) o;
-        return Objects.equals(getId(), member.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.Objects;
 
 @Entity
 public class Member {
@@ -17,5 +18,22 @@ public class Member {
 
     public Long getId() {
         return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Member member = (Member) o;
+        return Objects.equals(getId(), member.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/coupon/dto/MemberCouponResponse.java
+++ b/src/main/java/coupon/dto/MemberCouponResponse.java
@@ -1,0 +1,35 @@
+package coupon.dto;
+
+import coupon.domain.MemberCoupon;
+import coupon.domain.coupon.Coupon;
+
+public record MemberCouponResponse(
+        long id,
+        boolean isUsed,
+        String issuedAt,
+        String expiredAt,
+        String couponName,
+        long discountPrice,
+        long saleOrderPrice,
+        long discountRatio,
+        String category,
+        String issueAvailableStartAt,
+        String issuedAvailableEndAt
+) {
+
+    public MemberCouponResponse(MemberCoupon membercoupon, Coupon coupon) {
+        this(
+                membercoupon.getId(),
+                membercoupon.isUsed(),
+                membercoupon.getIssuedAt().toString(),
+                membercoupon.getExpiredAt().toString(),
+                coupon.getName().getValue(),
+                coupon.getDiscountPrice().getPrice(),
+                coupon.getSaleOrderPrice().getPrice(),
+                coupon.getDiscountRatio().getRatio(),
+                coupon.getCategory().name(),
+                coupon.getDuration().getStartAt().toString(),
+                coupon.getDuration().getEndAt().toString()
+        );
+    }
+}

--- a/src/main/java/coupon/dto/MemberCouponResponses.java
+++ b/src/main/java/coupon/dto/MemberCouponResponses.java
@@ -1,0 +1,8 @@
+package coupon.dto;
+
+import java.util.List;
+
+public record MemberCouponResponses(
+        List<MemberCouponResponse> memberCoupons
+) {
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
     List<MemberCoupon> findAllByMemberId(long memberId);
+
+    List<MemberCoupon> findAllByMemberIdAndCouponId(long memberId, long couponId);
 }

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,10 @@
+package coupon.repository;
+
+import coupon.domain.MemberCoupon;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+    List<MemberCoupon> findAllByMemberId(long memberId);
+}

--- a/src/main/java/coupon/repository/MemberRepository.java
+++ b/src/main/java/coupon/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package coupon.repository;
+
+import coupon.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/coupon/service/CouponDBService.java
+++ b/src/main/java/coupon/service/CouponDBService.java
@@ -3,10 +3,14 @@ package coupon.service;
 import coupon.db.TransactionRouter;
 import coupon.domain.coupon.Coupon;
 import java.util.NoSuchElementException;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CouponDBService {
+
+    private static final String CACHE_NAME = "coupon";
 
     private final CouponWriter couponWriter;
     private final CouponReader couponReader;
@@ -18,13 +22,15 @@ public class CouponDBService {
         this.transactionRouter = transactionRouter;
     }
 
+    @CachePut(value = CACHE_NAME, key = "#coupon.id")
     public Coupon create(Coupon coupon) {
         return couponWriter.save(coupon);
     }
 
+    @Cacheable(value = CACHE_NAME, key = "#id")
     public Coupon findById(long id) {
         return couponReader.findCoupon(id)
                 .or(() -> transactionRouter.route(() -> couponReader.findCoupon(id)))
-                .orElseThrow(() -> new NoSuchElementException("coupon with id " + id + " not found")); //reader에서 못찾으면 write db 조회
+                .orElseThrow(() -> new NoSuchElementException("coupon with id " + id + " not found")); //read db에서 못찾으면 write db 조회
     }
 }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -1,6 +1,7 @@
 package coupon.service;
 
 import coupon.domain.coupon.Coupon;
+import coupon.service.db.CouponDBService;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -31,8 +31,8 @@ public class MemberCouponService {
     }
 
     public MemberCoupon issue(Member member, Coupon coupon) {
-        MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
         validateIssuedCount(member, coupon);
+        MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
         return memberCouponRepository.save(memberCoupon);
     }
 

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -7,8 +7,11 @@ import coupon.repository.MemberCouponRepository;
 import java.util.List;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Service
+@Transactional(readOnly = true)
 public class MemberCouponService {
 
     private static final int MAX_MEMBER_COUPON_COUNT = 5;
@@ -43,6 +46,4 @@ public class MemberCouponService {
                 .map(memberCoupon -> couponService.findCoupon(memberCoupon.getCouponId()))
                 .toList();
     }
-
-
 }

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -1,0 +1,33 @@
+package coupon.service;
+
+import coupon.domain.MemberCoupon;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
+import coupon.repository.MemberCouponRepository;
+import java.util.List;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.transaction.annotation.Transactional;
+
+public class MemberCouponService {
+
+    private final MemberCouponRepository memberCouponRepository;
+
+    public MemberCouponService(MemberCouponRepository memberCouponRepository) {
+        this.memberCouponRepository = memberCouponRepository;
+    }
+
+    @Transactional
+    @CachePut(value = "member_coupon")
+    public MemberCoupon issue(Member member, Coupon coupon) {
+        MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
+        return memberCouponRepository.save(memberCoupon);
+    }
+
+    @Cacheable(value = "member_coupon")
+    public List<MemberCoupon> getMemberCoupon(Member member) {
+        return memberCouponRepository.findAllByMemberId(member.getId());
+    }
+
+
+}

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -1,9 +1,13 @@
 package coupon.service;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
 import coupon.domain.MemberCoupon;
 import coupon.domain.coupon.Coupon;
 import coupon.domain.member.Member;
 import coupon.dto.MemberCouponResponse;
+import coupon.dto.MemberCouponResponses;
 import coupon.repository.MemberCouponRepository;
 import coupon.service.db.CouponDBService;
 import java.util.List;
@@ -12,7 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 public class MemberCouponService {
 
     private static final int MAX_MEMBER_COUPON_COUNT = 5;
@@ -26,7 +30,6 @@ public class MemberCouponService {
         this.couponDBService = couponDBService;
     }
 
-    @Transactional
     public MemberCoupon issue(Member member, Coupon coupon) {
         MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
         validateIssuedCount(member, coupon);
@@ -41,11 +44,11 @@ public class MemberCouponService {
     }
 
     @Cacheable(value = CACHE_NAME, key = "#member.id")
-    public List<MemberCouponResponse> findAllMemberCoupon(Member member) {
+    public MemberCouponResponses findAllMemberCoupon(Member member) {
         List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberId(member.getId());
         return memberCoupons.stream()
                 .map(this::resolveMemberCouponResponse)
-                .toList();
+                .collect(collectingAndThen(toList(), MemberCouponResponses::new));
     }
 
     private MemberCouponResponse resolveMemberCouponResponse(MemberCoupon memberCoupon) {

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -7,7 +7,6 @@ import coupon.dto.MemberCouponResponse;
 import coupon.repository.MemberCouponRepository;
 import coupon.service.db.CouponDBService;
 import java.util.List;
-import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberCouponService {
 
     private static final int MAX_MEMBER_COUPON_COUNT = 5;
+    private static final String CACHE_NAME = "member_coupon";
 
     private final MemberCouponRepository memberCouponRepository;
     private final CouponDBService couponDBService;
@@ -39,7 +40,7 @@ public class MemberCouponService {
         }
     }
 
-    @Cacheable(value = "member_coupon", key = "#member.id")
+    @Cacheable(value = CACHE_NAME, key = "#member.id")
     public List<MemberCouponResponse> findAllMemberCoupon(Member member) {
         List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberId(member.getId());
         return memberCoupons.stream()

--- a/src/main/java/coupon/service/MemberCouponService.java
+++ b/src/main/java/coupon/service/MemberCouponService.java
@@ -11,6 +11,7 @@ import coupon.dto.MemberCouponResponses;
 import coupon.repository.MemberCouponRepository;
 import coupon.service.db.CouponDBService;
 import java.util.List;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +31,7 @@ public class MemberCouponService {
         this.couponDBService = couponDBService;
     }
 
+    @CacheEvict(value = CACHE_NAME, key = "#member.id")
     public MemberCoupon issue(Member member, Coupon coupon) {
         validateIssuedCount(member, coupon);
         MemberCoupon memberCoupon = new MemberCoupon(member, coupon);

--- a/src/main/java/coupon/service/MemberService.java
+++ b/src/main/java/coupon/service/MemberService.java
@@ -1,0 +1,17 @@
+package coupon.service;
+
+import coupon.domain.member.Member;
+import coupon.repository.MemberRepository;
+
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public Member save(Member member) {
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/coupon/service/db/CouponDBService.java
+++ b/src/main/java/coupon/service/db/CouponDBService.java
@@ -24,7 +24,7 @@ public class CouponDBService {
         this.transactionRouter = transactionRouter;
     }
 
-    @CachePut(value = CACHE_NAME, key = "#coupon.id")
+    @CachePut(value = CACHE_NAME, key = "#result.id")
     public Coupon create(Coupon coupon) {
         return couponWriter.save(coupon);
     }

--- a/src/main/java/coupon/service/db/CouponDBService.java
+++ b/src/main/java/coupon/service/db/CouponDBService.java
@@ -1,7 +1,9 @@
-package coupon.service;
+package coupon.service.db;
 
 import coupon.db.TransactionRouter;
 import coupon.domain.coupon.Coupon;
+import coupon.service.db.reader.CouponReader;
+import coupon.service.db.writer.CouponWriter;
 import java.util.NoSuchElementException;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;

--- a/src/main/java/coupon/service/db/reader/CouponReader.java
+++ b/src/main/java/coupon/service/db/reader/CouponReader.java
@@ -1,21 +1,22 @@
-package coupon.service;
+package coupon.service.db.reader;
 
 import coupon.domain.coupon.Coupon;
 import coupon.repository.CouponRepository;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Transactional
-public class CouponWriter {
+@Transactional(readOnly = true)
+public class CouponReader {
 
     private final CouponRepository couponRepository;
 
-    public CouponWriter(CouponRepository couponRepository) {
+    public CouponReader(CouponRepository couponRepository) {
         this.couponRepository = couponRepository;
     }
 
-    public Coupon save(Coupon coupon){
-        return couponRepository.save(coupon);
+    public Optional<Coupon> findCoupon(long couponId) {
+        return couponRepository.findById(couponId);
     }
 }

--- a/src/main/java/coupon/service/db/writer/CouponWriter.java
+++ b/src/main/java/coupon/service/db/writer/CouponWriter.java
@@ -1,22 +1,21 @@
-package coupon.service;
+package coupon.service.db.writer;
 
 import coupon.domain.coupon.Coupon;
 import coupon.repository.CouponRepository;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
-@Transactional(readOnly = true)
-public class CouponReader {
+@Transactional
+public class CouponWriter {
 
     private final CouponRepository couponRepository;
 
-    public CouponReader(CouponRepository couponRepository) {
+    public CouponWriter(CouponRepository couponRepository) {
         this.couponRepository = couponRepository;
     }
 
-    public Optional<Coupon> findCoupon(long couponId) {
-        return couponRepository.findById(couponId);
+    public Coupon save(Coupon coupon){
+        return couponRepository.save(coupon);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
+  data:
+    redis:
+      host: localhost
+      port: 6379 #default port
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,14 +13,14 @@ spring:
         show_sql: false
         use_sql_comments: true
 #        hbm2ddl.auto: validate
-        hbm2ddl.auto: update
+        hbm2ddl.auto: create-drop
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
   data:
     redis:
       host: localhost
-      port: 6379 #default port
+      port: 36379 #redis container port
 
 coupon.datasource:
   writer:

--- a/src/test/java/coupon/domain/IssueDurationTest.java
+++ b/src/test/java/coupon/domain/IssueDurationTest.java
@@ -1,7 +1,9 @@
 package coupon.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import coupon.domain.coupon.IssueDuration;
 import java.time.LocalDateTime;
@@ -28,5 +30,21 @@ class IssueDurationTest {
 
         assertThatCode(() -> new IssueDuration(startAt, endAt))
                 .doesNotThrowAnyException();
+    }
+
+    @DisplayName("발급 기간 내의 시간인지 알 수 있다")
+    @Test
+    void isBetweenDuration() {
+        LocalDateTime startAt = LocalDateTime.now();
+        LocalDateTime endAt = startAt.plusNanos(1L);
+        LocalDateTime inBoundTime = startAt;
+        LocalDateTime outBoundTime = startAt.minusNanos(1L);
+
+        IssueDuration duration = new IssueDuration(startAt, endAt);
+
+        assertAll(
+                () -> assertThat(duration.isBetween(inBoundTime)).isTrue(),
+                () -> assertThat(duration.isBetween(outBoundTime)).isFalse()
+        );
     }
 }

--- a/src/test/java/coupon/fixture/CouponFixture.java
+++ b/src/test/java/coupon/fixture/CouponFixture.java
@@ -1,0 +1,21 @@
+package coupon.fixture;
+
+import coupon.domain.coupon.Category;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.coupon.CouponName;
+import coupon.domain.coupon.DiscountPrice;
+import coupon.domain.coupon.IssueDuration;
+import coupon.domain.coupon.SaleOrderPrice;
+import java.time.LocalDateTime;
+
+public class CouponFixture {
+
+    public static final Coupon COUPON_FIXTURE = new Coupon(
+            1L,
+            new CouponName("쿠폰"),
+            new DiscountPrice(1000),
+            Category.FOOD,
+            new SaleOrderPrice(5000),
+            new IssueDuration(LocalDateTime.now(), LocalDateTime.now().plusDays(3L))
+    );
+}

--- a/src/test/java/coupon/fixture/MemberFixture.java
+++ b/src/test/java/coupon/fixture/MemberFixture.java
@@ -1,0 +1,8 @@
+package coupon.fixture;
+
+import coupon.domain.member.Member;
+
+public class MemberFixture {
+
+    public static Member MEMBER_FIXTURE = new Member();
+}

--- a/src/test/java/coupon/service/CouponDBServiceTest.java
+++ b/src/test/java/coupon/service/CouponDBServiceTest.java
@@ -16,7 +16,7 @@ import coupon.service.db.reader.CouponReader;
 import coupon.service.db.writer.CouponWriter;
 import java.util.Objects;
 import java.util.Optional;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,8 +42,8 @@ class CouponDBServiceTest {
     @MockBean
     CouponReader couponReader;
 
-    @AfterEach
-    void tearDown(){
+    @BeforeEach
+    void setUp(){
         Objects.requireNonNull(cacheManager.getCache(CACHE_NAME))
                 .clear();
     }

--- a/src/test/java/coupon/service/CouponDBServiceTest.java
+++ b/src/test/java/coupon/service/CouponDBServiceTest.java
@@ -10,6 +10,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import coupon.domain.coupon.Coupon;
+import coupon.service.db.CouponDBService;
+import coupon.service.db.reader.CouponReader;
+import coupon.service.db.writer.CouponWriter;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/coupon/service/CouponDBServiceTest.java
+++ b/src/test/java/coupon/service/CouponDBServiceTest.java
@@ -4,28 +4,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import coupon.domain.coupon.Coupon;
+import coupon.fixture.CouponFixture;
 import coupon.service.db.CouponDBService;
 import coupon.service.db.reader.CouponReader;
 import coupon.service.db.writer.CouponWriter;
+import java.util.Objects;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 class CouponDBServiceTest {
 
+    private static final String CACHE_NAME = "coupon";
+
     @Autowired
     CouponDBService couponDBService;
+
+    @Autowired
+    CacheManager cacheManager;
 
     @MockBean
     CouponWriter couponWriter;
@@ -33,11 +42,50 @@ class CouponDBServiceTest {
     @MockBean
     CouponReader couponReader;
 
+    @AfterEach
+    void tearDown(){
+        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME))
+                .clear();
+    }
+
+    @DisplayName("쿠폰을 생성할 경우 cache에 적재된다")
+    @Test
+    void putCouponToCache_When_Created() {
+        Coupon dummy = CouponFixture.COUPON_FIXTURE;
+        when(couponWriter.save(any(Coupon.class))).thenReturn(dummy);
+
+        couponDBService.create(dummy);
+        Coupon actual = cacheManager.getCache(CACHE_NAME)
+                .get(dummy.getId(), Coupon.class);
+
+        assertThat(actual).usingRecursiveComparison().isEqualTo(dummy);
+    }
+
+    @DisplayName("쿠폰 조회 시, DB를 조회하기 전에 선제적으로 캐시를 조회한다")
+    @Test
+    void findCache_When_ReadCoupon() {
+        Coupon dummy = CouponFixture.COUPON_FIXTURE;
+        when(couponReader.findCoupon(dummy.getId())).thenReturn(Optional.of(dummy));
+
+        Coupon firstFoundCoupon = couponDBService.findById(dummy.getId());
+        Coupon secondFoundCoupon = couponDBService.findById(dummy.getId());
+        Coupon cachedCoupon = cacheManager.getCache(CACHE_NAME)
+                .get(dummy.getId(), Coupon.class);
+
+        assertAll(
+                () -> assertThat(firstFoundCoupon).usingRecursiveComparison().isEqualTo(dummy),
+                () -> assertThat(secondFoundCoupon).usingRecursiveComparison().isEqualTo(dummy),
+                () -> assertThat(cachedCoupon).usingRecursiveComparison().isEqualTo(dummy),
+                () -> verify(couponReader, times(1)).findCoupon(eq(dummy.getId()))
+        );
+    }
+
     @DisplayName("reader에서 조회하지 못할 경우 write DB에서 조회한다")
     @Test
     void queryToWriter_When_Reader_CannotRead() {
-        Coupon dummy = mock(Coupon.class);
-        when(couponReader.findCoupon(anyLong())).thenReturn(Optional.empty(), Optional.of(dummy));
+        Coupon dummy = CouponFixture.COUPON_FIXTURE;
+        when(couponReader.findCoupon(anyLong()))
+                .thenReturn(Optional.empty(), Optional.of(dummy));
 
         Coupon actual = couponDBService.findById(1L);
 
@@ -50,8 +98,9 @@ class CouponDBServiceTest {
     @DisplayName("writer를 통해 coupon을 생성한다")
     @Test
     void save_Through_Writer() {
-        Coupon dummy = mock(Coupon.class);
-        when(couponWriter.save(any(Coupon.class))).thenReturn(dummy);
+        Coupon dummy = CouponFixture.COUPON_FIXTURE;
+        when(couponWriter.save(any(Coupon.class)))
+                .thenReturn(dummy);
 
         Coupon actual = couponDBService.create(dummy);
 

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -1,0 +1,112 @@
+package coupon.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import coupon.domain.MemberCoupon;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
+import coupon.dto.MemberCouponResponse;
+import coupon.dto.MemberCouponResponses;
+import coupon.fixture.CouponFixture;
+import coupon.fixture.MemberFixture;
+import coupon.repository.CouponRepository;
+import coupon.repository.MemberRepository;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cache.CacheManager;
+
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MemberCouponServiceTest {
+
+    private static int MAX_ISSUED_COUNT = 5;
+    private static String CACHE_NAME = "member_coupon";
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private MemberCouponService memberCouponService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @AfterEach
+    void tearDown() {
+        Objects.requireNonNull(cacheManager.getCache(CACHE_NAME))
+                .clear();
+    }
+
+    @DisplayName("동일 쿠폰을 최대 발급 수량을 초과하여 발급받을 수 없다")
+    @Test
+    void canNotIssueCoupon_Over_MaxIssuedCount() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_FIXTURE);
+        Coupon coupon = couponRepository.save(CouponFixture.COUPON_FIXTURE);
+
+        for (int i = 0; i < MAX_ISSUED_COUNT; i++) {
+            memberCouponService.issue(member, coupon);
+        }
+
+        assertThatThrownBy(() -> memberCouponService.issue(member, coupon))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @DisplayName("멤버에게 쿠폰을 발급할 수 있다")
+    @Test
+    void issueCoupon() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_FIXTURE);
+        Coupon coupon = couponRepository.save(CouponFixture.COUPON_FIXTURE);
+
+        assertThatCode(() -> memberCouponService.issue(member, coupon))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("멤버에게 해당하는 쿠폰내역을 조회할 수 있다")
+    @Test
+    void readMemberCoupon() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_FIXTURE);
+        Coupon coupon = couponRepository.save(CouponFixture.COUPON_FIXTURE);
+
+        MemberCoupon issuedCoupon1 = memberCouponService.issue(member, coupon);
+        MemberCoupon issuedCoupon2 = memberCouponService.issue(member, coupon);
+
+        List<Long> memberCouponResponseIds = memberCouponService.findAllMemberCoupon(member)
+                .memberCoupons()
+                .stream()
+                .map(memberCouponResponse -> memberCouponResponse.id())
+                .toList();
+
+        assertThat(memberCouponResponseIds).containsOnly(issuedCoupon1.getId(), issuedCoupon2.getId());
+    }
+
+    @DisplayName("멤버의 쿠폰 내역은 캐시를 통해 조회가 가능하다")
+    @Test
+    void readMemberCoupon_Through_Cache() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_FIXTURE);
+        Coupon coupon = couponRepository.save(CouponFixture.COUPON_FIXTURE);
+
+        MemberCoupon issuedCoupon = memberCouponService.issue(member, coupon);
+        memberCouponService.findAllMemberCoupon(member);
+
+        List<MemberCouponResponse> actual = Objects.requireNonNull(cacheManager.getCache(CACHE_NAME))
+                .get(member.getId(), MemberCouponResponses.class)
+                .memberCoupons();
+
+        assertAll(
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actual.get(0).id()).isEqualTo(issuedCoupon.getId())
+        );
+    }
+}

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -13,6 +13,7 @@ import coupon.dto.MemberCouponResponses;
 import coupon.fixture.CouponFixture;
 import coupon.fixture.MemberFixture;
 import coupon.repository.CouponRepository;
+import coupon.repository.MemberCouponRepository;
 import coupon.repository.MemberRepository;
 import java.util.List;
 import java.util.Objects;
@@ -38,13 +39,20 @@ class MemberCouponServiceTest {
     private CouponRepository couponRepository;
 
     @Autowired
+    private MemberCouponRepository memberCouponRepository;
+
+    @Autowired
     private MemberCouponService memberCouponService;
+
 
     @Autowired
     private CacheManager cacheManager;
 
     @AfterEach
     void tearDown() {
+        memberCouponRepository.deleteAll();
+        couponRepository.deleteAll();
+        memberRepository.deleteAll();
         Objects.requireNonNull(cacheManager.getCache(CACHE_NAME))
                 .clear();
     }

--- a/src/test/java/coupon/service/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/service/MemberCouponServiceTest.java
@@ -117,4 +117,18 @@ class MemberCouponServiceTest {
                 () -> assertThat(actual.get(0).id()).isEqualTo(issuedCoupon.getId())
         );
     }
+
+    @DisplayName("멤버에 쿠폰을 발행하면 캐시가 비워진다")
+    @Test
+    void evictCache_When_Issue_MemberCoupon() {
+        Member member = memberRepository.save(MemberFixture.MEMBER_FIXTURE);
+        Coupon coupon = couponRepository.save(CouponFixture.COUPON_FIXTURE);
+
+        MemberCoupon issuedCoupon = memberCouponService.issue(member, coupon);
+
+        Object actual = Objects.requireNonNull(cacheManager.getCache(CACHE_NAME))
+                .get(member.getId());
+
+        assertThat(actual).isNull();
+    }
 }


### PR DESCRIPTION
안녕하세요 폭포! 리뷰이 콜리입니다.

지난 PR 중 저희 PR이 가장 많은 comment 수를 기록했다는 사실 아시나요 ? 😄 
comment 수의 정량이 서로의 성장을 대변하지는 않지만 그럼에도 서로의 생각을 건강하게 나눌 수 있어 너무나 기뻤답니다.

이번 미션은 상세 설정에 있어 그 의미를 해석하고 도입해야 하는 점들이 있어 조금 시간이 걸렸습니다.

## 1. 캐시 구현체 선택 이유? 
도입한 캐시 구현체는 Redis입니다. docker container 이름도 redis가 있기도 하고 다른 자료구조로의 확장성도 자유로운 것으로 알고 있습니다. 다만 상대적으로 다른 vendor의 구현체와 비교우위적으로 redis가 어떠한 장점이 있는지에 대해서는 저도 명확한 결론을 내리지 못한 상태입니다. 폭포는 caffeine을 도입했던데 , 그러한 구현체를 선택한 이유가 있으신가요?

## 2. cache-aside 캐시 전략
두 가지 service에서 cache를 사용하고 있는데요
캐싱 전략 2가지인 cache-aside와 write-around 중 쓰기가 아닌 읽기에 초점을 맞추어 cache-aside 패턴을 적용했습니다.
- *cache-aside : 조회 시 1차적으로 캐시 탐색 > miss 시 db 탐색
- *write-around : 데이터를 캐시에 적재해놓았다가 배치 처리처럼 덮어쓰는 전략

첫번째로 CouponDBService입니다.
- Coupon create > CachePut을 통해 덮어씁니다.
- Coupon findById  > Cacheable을 통해 1차적으로 coupon cache를 탐색합니다

둘째로, MemberCouponService입니다.
- MemberCoupon 조회 시 > 1차적으로 member_coupon cache 탐색 후 DB 조회 

```java
   @Cacheable(value = CACHE_NAME, key = "#member.id")
    public MemberCouponResponses findAllMemberCoupon(Member member) {
        List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberId(member.getId());
        return memberCoupons.stream()
                .map(this::resolveMemberCouponResponse)
                .collect(collectingAndThen(toList(), MemberCouponResponses::new));
    }
```

## 3. replication 고려 x
이번 미션에서는 2가지 관점을 가지고 미션을 진행했습니다
- 회원 쿠폰의 경우 발생 이후 즉시 조회가 많으리라 생각했습니다 > 따라서 W/R 모두 write db로 라우팅되도록 @Transactional을 클래스단에 붙여주었습니다
- 또한, 리플리케이션보다 캐시 설정과 redis config에 조금 더 학습방향을 맞추고 싶다는 생각도 있었습니다

## 4. Spring Abstraction Cache 사용 이유
- 구현체 확장 및 전환이 가능하도록 CacheManager로 관리 로직이 추상화되어있다.
- 애너테이션 기반으로 선언적 cache 조작이 가능하다

---

마지막으로 채용일정으로 인해 폭포도 정신 없을리라 생각하는데요. 미션보다 더 우선인 것은 채용공고이니 폭포 우선순위에 알맞은 리소스 정도를 투입하여 리뷰를 주세요. LGTM도 괜찮습니다. 저의 경우, 아직 학교 졸업 연도가 남아있어 채용대상에 해당되지 않아 상대적으로 여유로운 상황입니다. 폭포의 일정에 맞추어 팔로우업 하겠습니다 👍 