### PR TITLE
 [2단계 - DB 복제와 캐시] 폴라(장유진) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.3.2'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/docker/init/init.sql
+++ b/docker/init/init.sql
@@ -1,33 +1,36 @@
 CREATE DATABASE IF NOT EXISTS coupon;
 USE coupon;
 
-create table coupon (
-                        discount_price integer not null,
-                        issue_date date not null,
-                        issue_end_date date not null,
-                        minimum_order_price integer not null,
-                        createdAt datetime(6),
-                        id bigint not null auto_increment,
-                        name varchar(30) not null,
-                        category enum ('FASHION','HOME_APPLIANCES','FURNITURE','FOOD') not null,
-                        primary key (id)
+create table coupon
+(
+    id                  bigint                                                not null auto_increment,
+    discount_price      integer                                               not null,
+    issue_date          date                                                  not null,
+    issue_end_date      date                                                  not null,
+    minimum_order_price integer                                               not null,
+    created_at          TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    name                varchar(30)                                           not null,
+    category            enum ('FASHION','HOME_APPLIANCES','FURNITURE','FOOD') not null,
+    primary key (id)
 );
 
-create table member (
-                        createdAt datetime(6),
-                        id bigint not null auto_increment,
-                        name varchar(255) not null,
-                        primary key (id)
+create table member
+(
+    id         bigint       not null auto_increment,
+    created_at datetime(6),
+    name       varchar(255) not null,
+    primary key (id)
 );
 
-create table member_coupon (
-                               is_used bit not null,
-                               coupon_id bigint not null,
-                               createdAt datetime(6),
-                               expired_at datetime(6) not null,
-                               id bigint not null auto_increment,
-                               issued_at datetime(6) not null,
-                               member_id bigint not null,
-                               primary key (id),
-                               foreign key (member_id) references member(id) on delete cascade
+create table member_coupon
+(
+    id         bigint      not null auto_increment,
+    is_used    bit         not null,
+    coupon_id  bigint      not null,
+    created_at datetime(6),
+    expired_at datetime(6) not null,
+    issued_at  datetime(6) not null,
+    member_id  bigint      not null,
+    primary key (id),
+    foreign key (member_id) references member (id) on delete cascade
 );

--- a/src/main/java/coupon/api/repository/CouponRedisRepository.java
+++ b/src/main/java/coupon/api/repository/CouponRedisRepository.java
@@ -20,7 +20,7 @@ public class CouponRedisRepository {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Coupon> getCoupon(Long id) {
+    public Optional<Coupon> findCoupon(Long id) {
         return Optional.ofNullable(couponRedisTemplate.opsForValue().get(String.valueOf(id)));
     }
 }

--- a/src/main/java/coupon/api/repository/CouponRedisRepository.java
+++ b/src/main/java/coupon/api/repository/CouponRedisRepository.java
@@ -7,16 +7,23 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Repository
 @RequiredArgsConstructor
 public class CouponRedisRepository {
 
+    private static final int ONE_DAY = 1;
+
     private final RedisTemplate<String, Coupon> couponRedisTemplate;
 
     @Transactional
     public void addCoupon(Coupon coupon) {
-        couponRedisTemplate.opsForValue().set(String.valueOf(coupon.getId()), coupon);
+        couponRedisTemplate.opsForValue().set(
+                String.valueOf(coupon.getId()),
+                coupon, coupon.issueDayDeadLine() + ONE_DAY,
+                TimeUnit.DAYS
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/coupon/api/repository/CouponRedisRepository.java
+++ b/src/main/java/coupon/api/repository/CouponRedisRepository.java
@@ -1,0 +1,26 @@
+package coupon.api.repository;
+
+import coupon.entity.Coupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRedisRepository {
+
+    private final RedisTemplate<String, Coupon> couponRedisTemplate;
+
+    @Transactional
+    public void addCoupon(Coupon coupon) {
+        couponRedisTemplate.opsForValue().set(String.valueOf(coupon.getId()), coupon);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Coupon> getCoupon(Long id) {
+        return Optional.ofNullable(couponRedisTemplate.opsForValue().get(String.valueOf(id)));
+    }
+}

--- a/src/main/java/coupon/api/repository/CouponRepository.java
+++ b/src/main/java/coupon/api/repository/CouponRepository.java
@@ -3,16 +3,8 @@ package coupon.api.repository;
 import coupon.entity.Coupon;
 import org.springframework.data.repository.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface CouponRepository extends Repository<Coupon, Long> {
 
-    List<Coupon> findAll();
+    Coupon save(Coupon coupon);
 
-    void save(Coupon coupon);
-
-    Optional<Coupon> findCouponById(Long couponId);
-
-    void deleteAll();
 }

--- a/src/main/java/coupon/api/repository/CouponRepository.java
+++ b/src/main/java/coupon/api/repository/CouponRepository.java
@@ -3,8 +3,11 @@ package coupon.api.repository;
 import coupon.entity.Coupon;
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface CouponRepository extends Repository<Coupon, Long> {
 
     Coupon save(Coupon coupon);
 
+    Optional<Coupon> findCouponById(Long couponId);
 }

--- a/src/main/java/coupon/api/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/api/repository/MemberCouponRepository.java
@@ -1,0 +1,9 @@
+package coupon.api.repository;
+
+import coupon.entity.MemberCoupon;
+import org.springframework.data.repository.Repository;
+
+public interface MemberCouponRepository extends Repository<MemberCoupon, Long> {
+
+    void save(MemberCoupon memberCoupon);
+}

--- a/src/main/java/coupon/api/repository/MemberRepository.java
+++ b/src/main/java/coupon/api/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package coupon.api.repository;
+
+import coupon.entity.Member;
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends Repository<Member, Long> {
+
+    Optional<Member> findMemberById(Long memberId);
+
+    void save(Member member);
+}

--- a/src/main/java/coupon/api/service/CouponService.java
+++ b/src/main/java/coupon/api/service/CouponService.java
@@ -1,35 +1,77 @@
 package coupon.api.service;
 
+import coupon.api.repository.CouponRedisRepository;
 import coupon.api.repository.CouponRepository;
+import coupon.api.repository.MemberCouponRepository;
+import coupon.api.repository.MemberRepository;
 import coupon.common.exception.CouponNotFoundException;
-import coupon.common.manager.TransactionManager;
+import coupon.common.exception.MemberNotFoundException;
+import coupon.common.response.StorageCouponResponse;
 import coupon.domain.coupon.CouponDomain;
+import coupon.domain.coupon.UserStorageCoupon;
 import coupon.entity.Coupon;
+import coupon.entity.Member;
+import coupon.entity.MemberCoupon;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final MemberRepository memberRepository;
+    private final MemberCouponRepository memberCouponRepository;
+    private final CouponRedisRepository couponRedisRepository;
 
     @Transactional
-    public void create(CouponDomain coupon) {
-        couponRepository.save(new Coupon(coupon));
+    public Coupon create(CouponDomain couponDomain) {
+        Coupon coupon = new Coupon(couponDomain);
+
+        couponRepository.save(coupon);
+        couponRedisRepository.addCoupon(coupon);
+
+        return coupon;
+    }
+
+    @Transactional
+    public void issueCoupon(Long memberId, Long couponId) {
+        LocalDateTime issueDate = LocalDateTime.now();
+
+        Member member = memberRepository.findMemberById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        MemberCoupon memberCoupon = member.issueCoupon(couponId, issueDate);
+
+        memberCouponRepository.save(memberCoupon);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StorageCouponResponse> searchAllCoupons(Long memberId) {
+        Member member = memberRepository.findMemberById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+        List<MemberCoupon> memberCoupons = member.getUnusedMemberCoupons();
+
+        return memberCoupons.stream()
+                .map(this::makeStorageCoupon)
+                .toList();
+
     }
 
     @Transactional(readOnly = true)
     public Coupon searchCoupon(Long couponId) {
-        return couponRepository.findCouponById(couponId)
-                .orElse(searchFromReader(couponId));
+        return couponRedisRepository.getCoupon(couponId)
+                .orElseThrow(CouponNotFoundException::new);
     }
 
-    private Coupon searchFromReader(Long couponId) {
-        return new TransactionManager().newTransaction(
-                () -> couponRepository.findCouponById(couponId)
-                        .orElseThrow(CouponNotFoundException::new)
-        );
+    private StorageCouponResponse makeStorageCoupon(MemberCoupon memberCoupon) {
+        UserStorageCoupon coupon = couponRedisRepository.getCoupon(memberCoupon.getCouponId())
+                .orElseThrow(CouponNotFoundException::new)
+                .toUserStorageCoupon();
+
+        return new StorageCouponResponse(coupon, memberCoupon.getIssuedAt(), memberCoupon.getExpiredAt());
     }
 }

--- a/src/main/java/coupon/api/service/CouponService.java
+++ b/src/main/java/coupon/api/service/CouponService.java
@@ -71,7 +71,7 @@ public class CouponService {
                 .or(() -> couponRepository.findCouponById(couponId))
                 .orElseThrow(CouponNotFoundException::new);
 
-        if (coupon.isIssuableCoupon()) {
+        if (coupon.notEndDateCoupon()) {
             couponRedisRepository.addCoupon(coupon);
         }
         return coupon;

--- a/src/main/java/coupon/api/service/CouponService.java
+++ b/src/main/java/coupon/api/service/CouponService.java
@@ -63,12 +63,12 @@ public class CouponService {
 
     @Transactional(readOnly = true)
     public Coupon searchCoupon(Long couponId) {
-        return couponRedisRepository.getCoupon(couponId)
+        return couponRedisRepository.findCoupon(couponId)
                 .orElseThrow(CouponNotFoundException::new);
     }
 
     private StorageCouponResponse makeStorageCoupon(MemberCoupon memberCoupon) {
-        UserStorageCoupon coupon = couponRedisRepository.getCoupon(memberCoupon.getCouponId())
+        UserStorageCoupon coupon = couponRedisRepository.findCoupon(memberCoupon.getCouponId())
                 .orElseThrow(CouponNotFoundException::new)
                 .toUserStorageCoupon();
 

--- a/src/main/java/coupon/common/ErrorConstant.java
+++ b/src/main/java/coupon/common/ErrorConstant.java
@@ -16,7 +16,8 @@ public enum ErrorConstant {
     NOT_AVAILABLE_UNIT_PRICE(HttpStatus.BAD_REQUEST, "가능한 금액 단위가 아닙니다."),
     COUPON_ISSUE_DATE_IS_NULL(HttpStatus.BAD_REQUEST, "쿠폰의 날짜는 비어있을 수 없습니다."),
     NOT_AVAILABLE_COUPON_DATE(HttpStatus.BAD_REQUEST, "쿠폰의 시작일이 끝나는 날보다 늦을 수 없습니다."),
-    MEMBER_NAME_IS_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "이름은 비어있을 수 없습니다.");
+    MEMBER_NAME_IS_NULL_OR_BLANK(HttpStatus.BAD_REQUEST, "이름은 비어있을 수 없습니다."),
+    ISSUED_COUPON_MAX(HttpStatus.BAD_REQUEST, "이미 최대로 발급받은 쿠폰입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/coupon/common/exception/MemberNotFoundException.java
+++ b/src/main/java/coupon/common/exception/MemberNotFoundException.java
@@ -1,0 +1,16 @@
+package coupon.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class MemberNotFoundException extends RuntimeException {
+
+    private static final String MESSAGE = "해당하는 회원을 찾을 수 없습니다.";
+
+    private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+    public MemberNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/coupon/common/response/StorageCouponResponse.java
+++ b/src/main/java/coupon/common/response/StorageCouponResponse.java
@@ -1,0 +1,8 @@
+package coupon.common.response;
+
+import coupon.domain.coupon.UserStorageCoupon;
+
+import java.time.LocalDateTime;
+
+public record StorageCouponResponse(UserStorageCoupon coupon, LocalDateTime issuedAt, LocalDateTime expiredAt) {
+}

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -1,0 +1,49 @@
+package coupon.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import coupon.entity.Coupon;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, Coupon> redisTemplate() {
+        RedisTemplate<String, Coupon> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+        Jackson2JsonRedisSerializer<Coupon> serializer = new Jackson2JsonRedisSerializer<>(objectMapper(), Coupon.class);
+        redisTemplate.setValueSerializer(serializer);
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -3,11 +3,9 @@ package coupon.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import coupon.entity.Coupon;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -17,21 +15,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.data.redis.host}")
-    private String host;
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
     @Bean
-    public LettuceConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
-    }
-
-    @Bean
-    public RedisTemplate<String, Coupon> redisTemplate() {
+    public RedisTemplate<String, Coupon> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Coupon> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
 
         Jackson2JsonRedisSerializer<Coupon> serializer = new Jackson2JsonRedisSerializer<>(objectMapper(), Coupon.class);

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package coupon.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import coupon.entity.Coupon;
@@ -31,6 +33,7 @@ public class RedisConfig {
     public ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
         return mapper;
     }
 }

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -1,8 +1,6 @@
 package coupon.config;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import coupon.entity.Coupon;
 import org.springframework.context.annotation.Bean;
@@ -30,10 +28,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public ObjectMapper objectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-        return mapper;
+    public JsonMapper objectMapper() {
+        return JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .build();
     }
 }

--- a/src/main/java/coupon/domain/coupon/Category.java
+++ b/src/main/java/coupon/domain/coupon/Category.java
@@ -1,8 +1,10 @@
 package coupon.domain.coupon;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum Category {
 

--- a/src/main/java/coupon/domain/coupon/UserStorageCoupon.java
+++ b/src/main/java/coupon/domain/coupon/UserStorageCoupon.java
@@ -1,0 +1,15 @@
+package coupon.domain.coupon;
+
+import coupon.entity.Coupon;
+
+public record UserStorageCoupon(String name, int discountPrice, int minimumPrice, String categoryName) {
+
+    public static UserStorageCoupon of(Coupon coupon) {
+        return new UserStorageCoupon(
+                coupon.getName(),
+                coupon.getDiscountPrice(),
+                coupon.getMinimumOrderPrice(),
+                coupon.getCategory().getName()
+        );
+    }
+}

--- a/src/main/java/coupon/entity/Coupon.java
+++ b/src/main/java/coupon/entity/Coupon.java
@@ -2,6 +2,7 @@ package coupon.entity;
 
 import coupon.domain.coupon.Category;
 import coupon.domain.coupon.CouponDomain;
+import coupon.domain.coupon.UserStorageCoupon;
 import coupon.entity.base.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -50,5 +51,9 @@ public class Coupon extends BaseEntity {
                 coupon.getStartDate(),
                 coupon.getEndDate()
         );
+    }
+
+    public UserStorageCoupon toUserStorageCoupon() {
+        return UserStorageCoupon.of(this);
     }
 }

--- a/src/main/java/coupon/entity/Coupon.java
+++ b/src/main/java/coupon/entity/Coupon.java
@@ -5,14 +5,12 @@ import coupon.domain.coupon.CouponDomain;
 import coupon.domain.coupon.UserStorageCoupon;
 import coupon.entity.base.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
+@ToString
 @Getter
 @Table(name = "coupon")
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -55,5 +53,14 @@ public class Coupon extends BaseEntity {
 
     public UserStorageCoupon toUserStorageCoupon() {
         return UserStorageCoupon.of(this);
+    }
+
+    public int issueDayDeadLine() {
+        return issueEndDate.compareTo(LocalDate.now());
+    }
+
+    public boolean isIssuableCoupon() {
+        LocalDate now = LocalDate.now();
+        return now.isAfter(getIssueDate()) && now.isBefore(getIssueEndDate());
     }
 }

--- a/src/main/java/coupon/entity/Coupon.java
+++ b/src/main/java/coupon/entity/Coupon.java
@@ -59,8 +59,8 @@ public class Coupon extends BaseEntity {
         return issueEndDate.compareTo(LocalDate.now());
     }
 
-    public boolean isIssuableCoupon() {
+    public boolean notEndDateCoupon() {
         LocalDate now = LocalDate.now();
-        return now.isAfter(getIssueDate()) && now.isBefore(getIssueEndDate());
+        return now.isBefore(getIssueEndDate());
     }
 }

--- a/src/main/java/coupon/entity/Member.java
+++ b/src/main/java/coupon/entity/Member.java
@@ -44,10 +44,6 @@ public class Member extends BaseEntity {
         return MemberCoupon.issueOf(this, couponId, issuedAt);
     }
 
-    public MemberDomain toDomain() {
-        return new MemberDomain(name);
-    }
-
     public void validateCanIssueMember() {
         if (memberCoupons.size() > MAX_ISSUE_COUPON) {
             throw new CouponException(ErrorConstant.ISSUED_COUPON_MAX);

--- a/src/main/java/coupon/entity/Member.java
+++ b/src/main/java/coupon/entity/Member.java
@@ -1,5 +1,7 @@
 package coupon.entity;
 
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
 import coupon.domain.member.MemberDomain;
 import coupon.entity.base.BaseEntity;
 import jakarta.persistence.*;
@@ -9,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,6 +20,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
+    public static final int MAX_ISSUE_COUPON = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,12 +29,34 @@ public class Member extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @OneToMany(mappedBy = "member")
+    private List<MemberCoupon> memberCoupons;
+
+
     public Member(MemberDomain memberDomain) {
         this(null,
-                memberDomain.getMemberName());
+                memberDomain.getMemberName(),
+                List.of());
     }
 
     public MemberCoupon issueCoupon(Long couponId, LocalDateTime issuedAt) {
+        validateCanIssueMember();
         return MemberCoupon.issueOf(this, couponId, issuedAt);
+    }
+
+    public MemberDomain toDomain() {
+        return new MemberDomain(name);
+    }
+
+    public void validateCanIssueMember() {
+        if (memberCoupons.size() > MAX_ISSUE_COUPON) {
+            throw new CouponException(ErrorConstant.ISSUED_COUPON_MAX);
+        }
+    }
+
+    public List<MemberCoupon> getUnusedMemberCoupons() {
+        return memberCoupons.stream()
+                .filter(memberCoupon -> !memberCoupon.getIsUsed())
+                .toList();
     }
 }

--- a/src/main/java/coupon/entity/Member.java
+++ b/src/main/java/coupon/entity/Member.java
@@ -52,7 +52,7 @@ public class Member extends BaseEntity {
 
     public List<MemberCoupon> getUnusedMemberCoupons() {
         return memberCoupons.stream()
-                .filter(memberCoupon -> !memberCoupon.getIsUsed())
+                .filter(MemberCoupon::isUsableCoupon)
                 .toList();
     }
 }

--- a/src/main/java/coupon/entity/MemberCoupon.java
+++ b/src/main/java/coupon/entity/MemberCoupon.java
@@ -23,7 +23,7 @@ public class MemberCoupon extends BaseEntity {
     @Column(name = "coupon_id", nullable = false)
     private Long couponId;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/src/main/java/coupon/entity/MemberCoupon.java
+++ b/src/main/java/coupon/entity/MemberCoupon.java
@@ -39,4 +39,8 @@ public class MemberCoupon extends BaseEntity {
     public static MemberCoupon issueOf(Member member, Long couponId, LocalDateTime issuedAt) {
         return new MemberCoupon(null, couponId, member, false, issuedAt, issuedAt.plusDays(7));
     }
+
+    public boolean isUsableCoupon() {
+        return !isUsed;
+    }
 }

--- a/src/main/java/coupon/entity/base/BaseEntity.java
+++ b/src/main/java/coupon/entity/base/BaseEntity.java
@@ -15,6 +15,6 @@ import java.time.LocalDateTime;
 public class BaseEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
         query.in_clause_parameter_padding: true
     open-in-view: false
 
+  data:
+    redis:
+      host: localhost
+      port: 36379
+
 coupon.datasource:
   writer:
     type: com.zaxxer.hikari.HikariDataSource

--- a/src/test/java/coupon/api/service/CouponServiceTest.java
+++ b/src/test/java/coupon/api/service/CouponServiceTest.java
@@ -1,19 +1,27 @@
 package coupon.api.service;
 
 import coupon.api.repository.CouponRepository;
+import coupon.api.repository.MemberRepository;
+import coupon.common.ErrorConstant;
+import coupon.common.exception.CouponException;
 import coupon.common.exception.CouponNotFoundException;
+import coupon.common.response.StorageCouponResponse;
 import coupon.domain.coupon.Category;
 import coupon.domain.coupon.CouponDomain;
+import coupon.domain.member.MemberDomain;
 import coupon.entity.Coupon;
+import coupon.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CouponServiceTest {
@@ -22,22 +30,15 @@ public class CouponServiceTest {
     private CouponService couponService;
     @Autowired
     private CouponRepository couponRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Test
     @DisplayName("Replication이 딜레이 되더라도 쿠폰 조회에 영향이 가지 않는다.")
     void replicationDelay() {
-        int couponSize = couponRepository.findAll().size();
+        Coupon insertedCoupon = createCoupon();
 
-        CouponDomain coupon = new CouponDomain("coupon",
-                1000,
-                10000,
-                Category.FASHION,
-                LocalDate.now(),
-                LocalDate.now().plusDays(3)
-        );
-        couponService.create(coupon);
-
-        Coupon savedCoupon = couponService.searchCoupon((long) (couponSize + 1));
+        Coupon savedCoupon = couponService.searchCoupon(insertedCoupon.getId());
         assertThat(savedCoupon).isNotNull();
     }
 
@@ -46,5 +47,54 @@ public class CouponServiceTest {
     void searchCoupon_whenNotExist() {
         assertThatThrownBy(() -> couponService.searchCoupon(Long.MAX_VALUE))
                 .isInstanceOf(CouponNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이미 같은 쿠폰을 최대로 발행한 경우 에러를 발생한다.")
+    void issueCoupon() {
+        Member member = createMember();
+        Coupon createdCoupon = createCoupon();
+
+        for (int i = 0; i <= Member.MAX_ISSUE_COUPON; i++) {
+            couponService.issueCoupon(member.getId(), createdCoupon.getId());
+        }
+
+        assertThatThrownBy(() -> couponService.issueCoupon(member.getId(), createdCoupon.getId()))
+                .isInstanceOf(CouponException.class)
+                .hasMessage(ErrorConstant.ISSUED_COUPON_MAX.getMessage());
+    }
+
+    @Test
+    @DisplayName("필요한 쿠폰 정보를 조회할 수 있다.")
+    void searchAllCoupon() {
+        Member member = createMember();
+        Coupon createdCoupon = createCoupon();
+
+        couponService.issueCoupon(member.getId(), createdCoupon.getId());
+
+        List<StorageCouponResponse> storageCouponResponses = couponService.searchAllCoupons(member.getId());
+        assertAll(
+                () -> assertThat(storageCouponResponses.size()).isEqualTo(1),
+                () -> assertThat(storageCouponResponses.get(0).coupon()).isEqualTo(createdCoupon.toUserStorageCoupon())
+        );
+    }
+
+    private Coupon createCoupon() {
+        CouponDomain coupon = new CouponDomain("coupon",
+                1000,
+                10000,
+                Category.FASHION,
+                LocalDate.now(),
+                LocalDate.now().plusDays(3)
+        );
+
+        return couponService.create(coupon);
+    }
+
+    private Member createMember() {
+        Member member = new Member(new MemberDomain("polla"));
+        memberRepository.save(member);
+
+        return member;
     }
 }


### PR DESCRIPTION
안녕하세요 리니! 폴라입니다! 🍇

드디어 2단계 미션을 가져왔는데요! 이번에는 기존 요구사항대로 캐싱을 이용해서 가져오도록 구현해봤어요!

몇가지 특이점이있는데요.

## 1. UserStorageCoupon

```java
public record UserStorageCoupon(String name, int discountPrice, int minimumPrice, String categoryName) {
...
```
> 회원의 쿠폰 목록 조회 시 쿠폰, 회원에게 발급된 쿠폰의 정보를 모두 보여줄 수 있어야 한다.

라는 요구사항에 따라 구현하던 도중 

**_유저에게 보여지는 쿠폰의 정보가 원래 쿠폰에서 담고있는 정보가 조금 다를 수 있겠다_**
는 생각이 들었습니다.

예를 들어, **본 쿠폰이 언제까지 발급이 가능한지**, **언제까지 발급 이벤트가 진행되는지**, **이미 사용된 쿠폰** 등은 유저가 알지 않아도 되는 정보라고 생각했고,
반대로 **Category**는 영어 `Enum` 이 아닌, `패션`, `가구`, `식품` 으로 보여져야 한다고 생각했어요.

그래서 `Coupon` 에서 해당 객체를 만들수 있도록 구현했습니다.

## 2. MemberCoupon의 생성을 Member에서

```java
    public MemberCoupon issueCoupon(Long couponId, LocalDateTime issuedAt) {
        validateCanIssueMember();
        return MemberCoupon.issueOf(this, couponId, issuedAt);
    }

    public void validateCanIssueMember() {
        if (memberCoupons.size() > MAX_ISSUE_COUPON) {
            throw new CouponException(ErrorConstant.ISSUED_COUPON_MAX);
        }
    }
```

`MemberCoupon` 의 생성을 `Member` 엔티티에 넘겨주었는데요.

```java
        MemberCoupon memberCoupon = member.issueCoupon(couponId, issueDate);
        memberCouponRepository.save(memberCoupon);
```
그 이유는 `Service`에서 생성되는 것보다 훨씬 직관적이라고 느꼈습니다. 🤔
`Member` 내에서 쿠폰을 발행하면서 에러를 발생하도록 하는 것이 좀더 서비스 레이어의 부담을 덜어준다고 생각했어요.

리니는 이에 대해 어떻게 생각하는지 궁금하네요!
이번 리뷰도 잘 부탁드립니다 리니! ☺️