### PR TITLE
[2단계 - DB 복제와 캐시] 알파카(최휘용) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/coupon/CacheConfig.java
+++ b/src/main/java/coupon/CacheConfig.java
@@ -38,7 +38,7 @@ public class CacheConfig {
         GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofHours(24))
+                .entryTtl(Duration.ofHours(1))
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))

--- a/src/main/java/coupon/CacheConfig.java
+++ b/src/main/java/coupon/CacheConfig.java
@@ -1,0 +1,51 @@
+package coupon;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    private final ObjectMapper objectMapper;
+
+    public CacheConfig() {
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(typeValidator, DefaultTyping.NON_FINAL);
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(24))
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))
+                .disableCachingNullValues();
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+}

--- a/src/main/java/coupon/CouponApplication.java
+++ b/src/main/java/coupon/CouponApplication.java
@@ -2,8 +2,10 @@ package coupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class CouponApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -11,12 +11,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MemberCoupon {
 
     @Id
@@ -32,12 +34,20 @@ public class MemberCoupon {
     private LocalDate issueDate;
     private LocalDate expirationDate;
 
-    public MemberCoupon(Long id, Coupon coupon, Member member, boolean used, LocalDate issueDate) {
-        this.id = id;
+    public MemberCoupon(Coupon coupon, Member member, boolean used, LocalDate issueDate) {
         this.coupon = coupon;
         this.member = member;
         this.used = used;
         this.issueDate = issueDate;
         this.expirationDate = issueDate.plusDays(6);
+    }
+
+    public static MemberCoupon issue(Member member, Coupon coupon) {
+        return new MemberCoupon(
+                coupon,
+                member,
+                false,
+                LocalDate.now()
+        );
     }
 }

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,6 +1,5 @@
 package coupon.domain;
 
-import coupon.domain.coupon.Coupon;
 import coupon.domain.member.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -24,9 +23,7 @@ public class MemberCoupon {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "coupon_id")
-    private Coupon coupon;
+    private Long couponId;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -34,17 +31,17 @@ public class MemberCoupon {
     private LocalDate issueDate;
     private LocalDate expirationDate;
 
-    public MemberCoupon(Coupon coupon, Member member, boolean used, LocalDate issueDate) {
-        this.coupon = coupon;
+    public MemberCoupon(Long couponId, Member member, boolean used, LocalDate issueDate) {
+        this.couponId = couponId;
         this.member = member;
         this.used = used;
         this.issueDate = issueDate;
         this.expirationDate = issueDate.plusDays(6);
     }
 
-    public static MemberCoupon issue(Member member, Coupon coupon) {
+    public static MemberCoupon issue(Member member, Long couponId) {
         return new MemberCoupon(
-                coupon,
+                couponId,
                 member,
                 false,
                 LocalDate.now()

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -6,12 +6,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Member {
 
     @Id
@@ -20,8 +22,7 @@ public class Member {
     @Embedded
     private MemberName memberName;
 
-    public Member(Long id, MemberName memberName) {
-        this.id = id;
+    public Member(MemberName memberName) {
         this.memberName = memberName;
     }
 }

--- a/src/main/java/coupon/domain/member/MemberName.java
+++ b/src/main/java/coupon/domain/member/MemberName.java
@@ -1,13 +1,15 @@
 package coupon.domain.member;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class MemberName {
 
     private static final int MAX_LENGTH = 30;
 
-    private final String name;
+    private String name;
 
     public MemberName(String name) {
         validate(name);

--- a/src/main/java/coupon/dto/CouponAndMemberCouponResponse.java
+++ b/src/main/java/coupon/dto/CouponAndMemberCouponResponse.java
@@ -1,0 +1,8 @@
+package coupon.dto;
+
+import coupon.domain.MemberCoupon;
+import coupon.domain.coupon.Coupon;
+import java.util.List;
+
+public record CouponAndMemberCouponResponse(List<Coupon> coupons, List<MemberCoupon> memberCoupons) {
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,14 @@
+package coupon.repository;
+
+import coupon.domain.MemberCoupon;
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+    public List<MemberCoupon> findAllByMemberAndCoupon(Member member, Coupon coupon);
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,7 +1,6 @@
 package coupon.repository;
 
 import coupon.domain.MemberCoupon;
-import coupon.domain.coupon.Coupon;
 import coupon.domain.member.Member;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,5 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
-    public List<MemberCoupon> findAllByMemberAndCoupon(Member member, Coupon coupon);
+    public List<MemberCoupon> findAllByMember(Member member);
+
+    public List<MemberCoupon> findAllByMemberAndCouponId(Member member, Long couponId);
 }

--- a/src/main/java/coupon/repository/MemberRepository.java
+++ b/src/main/java/coupon/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package coupon.repository;
+
+import coupon.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -9,6 +9,7 @@ import coupon.repository.MemberCouponRepository;
 import coupon.service.support.DataSourceSupport;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ public class CouponService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "coupon", key = "#couponId")
     public Coupon getCoupon(Long couponId) {
         return couponRepository.findById(couponId)
                 .orElse(getCouponFromWriter(couponId));
@@ -60,8 +62,7 @@ public class CouponService {
         List<Coupon> coupons = memberCoupons.stream()
                 .map(MemberCoupon::getCouponId)
                 .distinct()
-                .map(couponId -> couponRepository.findById(couponId)
-                        .orElseThrow(() -> new IllegalArgumentException("쿠폰을 조회하던 중 예외가 발생했습니다.")))
+                .map(this::getCoupon)
                 .toList();
         return new CouponAndMemberCouponResponse(coupons, memberCoupons);
     }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -42,7 +42,7 @@ public class CouponService {
         Coupon coupon = couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰 id입니다."));
         validateIssueLimit(member, coupon);
-        MemberCoupon memberCoupon = MemberCoupon.issue(member, coupon);
+        MemberCoupon memberCoupon = MemberCoupon.issue(member, coupon.getId());
         return memberCouponRepository.save(memberCoupon);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6379
+      port: 36379
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
+  cache:
+    type: redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 coupon.datasource:
   writer:

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,6 +1,7 @@
 package coupon.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import coupon.domain.Category;
 import coupon.domain.coupon.Coupon;
@@ -8,7 +9,14 @@ import coupon.domain.coupon.CouponName;
 import coupon.domain.coupon.DiscountMount;
 import coupon.domain.coupon.MinimumMount;
 import coupon.domain.coupon.Period;
+import coupon.domain.member.Member;
+import coupon.domain.member.MemberName;
+import coupon.repository.CouponRepository;
+import coupon.repository.MemberCouponRepository;
+import coupon.repository.MemberRepository;
 import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,6 +26,19 @@ class CouponServiceTest {
 
     @Autowired
     private CouponService couponService;
+    @Autowired
+    private CouponRepository couponRepository;
+    @Autowired
+    private MemberCouponRepository memberCouponRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void truncateTables() {
+        memberCouponRepository.deleteAll();
+        couponRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
 
     @Test
     void 복제지연테스트() {
@@ -30,5 +51,37 @@ class CouponServiceTest {
         ));
         Coupon savedCoupon = couponService.getCoupon(coupon.getId());
         assertThat(savedCoupon).isNotNull();
+    }
+
+    @DisplayName("존재하지 않는 쿠폰으로는 멤버의 쿠폰을 발급할 수 없다.")
+    @Test
+    void issueMemberCouponWithoutCoupon() {
+        Member member = memberRepository.save(new Member(new MemberName("포케리스웨트")));
+
+        Long notExistId = 2L;
+        couponRepository.deleteById(notExistId);
+        assertThatThrownBy(() -> couponService.issueMemberCoupon(notExistId, member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 쿠폰 id입니다.");
+    }
+
+    @DisplayName("같은 쿠폰을 한 멤버가 5번 넘게 발급할 수 없다.")
+    @Test
+    void issueMemberCouponMoreThanLimit() {
+        Member member = memberRepository.save(new Member(new MemberName("포케리스웨트")));
+        Coupon coupon = couponService.create(new Coupon(
+                new CouponName("쿠폰"),
+                new DiscountMount(1000),
+                new MinimumMount(5000),
+                Category.FASHION,
+                new Period(LocalDate.now().minusDays(1), LocalDate.now().plusDays(1))
+        ));
+
+        for (int i = 0; i < 5; ++i) {
+            couponService.issueMemberCoupon(coupon.getId(), member);
+        }
+        assertThatThrownBy(() -> couponService.issueMemberCoupon(coupon.getId(), member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("쿠폰을 더 발급할 수 없습니다.");
     }
 }


### PR DESCRIPTION
안녕하세요 포케리스웨트. 알파카입니다.
이번 미션에서는 사용자의 쿠폰 정보 조회 기능을 구현하고 쿠폰 조회에 캐싱을 적용했습니다.
캐시는 서버의 다중화를 고려해서 레디스를 사용했습니다.

쿠폰은 한 멤버 당 최대 5개까지 발급할 수 있기 때문에 캐시 읽기를 통한 성능 개선을 고려할 수 있습니다. 따라서 Look Aside 읽기 패턴을 적용하여 쿠폰 읽기의 성능을 개선할 수 있도록 했습니다.
쿠폰을 등록할 때는 따로 캐시를 적용하지 않았습니다. 도메인을 고려했을 때, 쿠폰 등록은 쿠폰 읽기에 비해 호출이 훨씬 적을 것을 예상할 수 있습니다. 또한 이전 pr에서 언급했던 것처럼 쿠폰 생성 직후에 쿠폰이 조회되는 일은 거의 없다고 가정했습니다. 따라서 쿠폰이 캐시에 올라오는 시점을 쿠폰 생성이 아닌, 쿠폰의 첫 조회로 설정하기 위해 쿠폰 등록 시에는 캐시를 사용하지 않도록 구현했습니다.