### PR TITLE
[2단계 - DB 복제와 캐시] 다온(조형익) 미션 제출합니다.

### DIFF
--- a/src/main/java/coupon/CouponApplication.java
+++ b/src/main/java/coupon/CouponApplication.java
@@ -2,7 +2,9 @@ package coupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class CouponApplication {
 

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -20,4 +20,9 @@ public class Member {
     private String name;
 
     private String password;
+
+    public Member(String name, String password) {
+        this.name = name;
+        this.password = password;
+    }
 }

--- a/src/main/java/coupon/domain/member/Member.java
+++ b/src/main/java/coupon/domain/member/Member.java
@@ -1,0 +1,23 @@
+package coupon.domain.member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String password;
+}

--- a/src/main/java/coupon/domain/member/MemberRepository.java
+++ b/src/main/java/coupon/domain/member/MemberRepository.java
@@ -1,0 +1,6 @@
+package coupon.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/coupon/domain/membercounpon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/membercounpon/MemberCoupon.java
@@ -39,14 +39,12 @@ public class MemberCoupon {
 
     public MemberCoupon(
             Coupon coupon,
-            Member member,
-            boolean isUsed,
-            LocalDateTime createdAt
+            Member member
     ) {
         this.coupon = coupon;
         this.member = member;
-        this.isUsed = isUsed;
-        this.createdAt = createdAt;
+        this.isUsed = false;
+        this.createdAt = LocalDateTime.now();
         this.expiredAt = LocalDateTime.of(createdAt.toLocalDate().plusDays(VALID_PERIOD), LocalTime.MAX);
     }
 }

--- a/src/main/java/coupon/domain/membercounpon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/membercounpon/MemberCoupon.java
@@ -1,9 +1,13 @@
 package coupon.domain.membercounpon;
 
+import coupon.domain.coupon.Coupon;
+import coupon.domain.member.Member;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
@@ -21,9 +25,11 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long couponId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Coupon coupon;
 
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
 
     private boolean isUsed;
 
@@ -32,13 +38,13 @@ public class MemberCoupon {
     private LocalDateTime expiredAt;
 
     public MemberCoupon(
-            Long couponId,
-            Long memberId,
+            Coupon coupon,
+            Member member,
             boolean isUsed,
             LocalDateTime createdAt
     ) {
-        this.couponId = couponId;
-        this.memberId = memberId;
+        this.coupon = coupon;
+        this.member = member;
         this.isUsed = isUsed;
         this.createdAt = createdAt;
         this.expiredAt = LocalDateTime.of(createdAt.toLocalDate().plusDays(VALID_PERIOD), LocalTime.MAX);

--- a/src/main/java/coupon/domain/membercounpon/MemberCoupon.java
+++ b/src/main/java/coupon/domain/membercounpon/MemberCoupon.java
@@ -1,13 +1,9 @@
 package coupon.domain.membercounpon;
 
-import coupon.domain.coupon.Coupon;
-import coupon.domain.member.Member;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.AccessLevel;
@@ -25,11 +21,9 @@ public class MemberCoupon {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Coupon coupon;
+    private Long couponId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    private Long memberId;
 
     private boolean isUsed;
 
@@ -38,11 +32,11 @@ public class MemberCoupon {
     private LocalDateTime expiredAt;
 
     public MemberCoupon(
-            Coupon coupon,
-            Member member
+            Long couponId,
+            Long memberId
     ) {
-        this.coupon = coupon;
-        this.member = member;
+        this.couponId = couponId;
+        this.memberId = memberId;
         this.isUsed = false;
         this.createdAt = LocalDateTime.now();
         this.expiredAt = LocalDateTime.of(createdAt.toLocalDate().plusDays(VALID_PERIOD), LocalTime.MAX);

--- a/src/main/java/coupon/domain/membercounpon/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/membercounpon/MemberCouponRepository.java
@@ -1,9 +1,8 @@
 package coupon.domain.membercounpon;
 
-import coupon.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
-    long countMemberCouponByMember(Member member);
+    long countMemberCouponByMemberId(Long memberId);
 }

--- a/src/main/java/coupon/domain/membercounpon/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/membercounpon/MemberCouponRepository.java
@@ -1,8 +1,11 @@
 package coupon.domain.membercounpon;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
     long countMemberCouponByMemberId(Long memberId);
+
+    List<MemberCoupon> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/coupon/domain/membercounpon/MemberCouponRepository.java
+++ b/src/main/java/coupon/domain/membercounpon/MemberCouponRepository.java
@@ -1,6 +1,9 @@
 package coupon.domain.membercounpon;
 
+import coupon.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+    long countMemberCouponByMember(Member member);
 }

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -2,6 +2,10 @@ package coupon.service;
 
 import coupon.domain.coupon.Coupon;
 import coupon.domain.coupon.CouponRepository;
+import coupon.domain.member.Member;
+import coupon.domain.member.MemberRepository;
+import coupon.domain.membercounpon.MemberCoupon;
+import coupon.domain.membercounpon.MemberCouponRepository;
 import coupon.executor.TransactionExecutor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,11 +15,26 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CouponService {
 
+    private static final int MAXIMUM_COUPON_PER_MEMBER = 5;
+
     private final CouponRepository couponRepository;
+    private final MemberCouponRepository memberCouponRepository;
+    private final MemberRepository memberRepository;
     private final TransactionExecutor transactionExecutor;
 
-    public Coupon create(Coupon coupon) {
-        return couponRepository.save(coupon);
+    @Transactional
+    public Coupon create(Long memberId, Coupon coupon) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+
+        long count = memberCouponRepository.countMemberCouponByMember(member);
+        if (count >= MAXIMUM_COUPON_PER_MEMBER) {
+            throw new IllegalArgumentException("한 회원당 %d장만 쿠폰 발급이 가능합니다.".formatted(MAXIMUM_COUPON_PER_MEMBER));
+        }
+        Coupon savedCoupon = couponRepository.save(coupon);
+        MemberCoupon memberCoupon = new MemberCoupon(savedCoupon, member);
+        memberCouponRepository.save(memberCoupon);
+        return savedCoupon;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -9,6 +9,8 @@ import coupon.domain.membercounpon.MemberCouponRepository;
 import coupon.executor.TransactionExecutor;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CouponService {
 
+    public static final String COUPON_CACHE_NAME = "couponsCache";
     private static final int MAXIMUM_COUPON_PER_MEMBER = 5;
 
     private final CouponRepository couponRepository;
@@ -23,6 +26,7 @@ public class CouponService {
     private final MemberRepository memberRepository;
     private final TransactionExecutor transactionExecutor;
 
+    @CacheEvict(value = COUPON_CACHE_NAME, key = "#p0")
     @Transactional
     public Coupon create(Long memberId, Coupon coupon) {
         Member member = memberRepository.findById(memberId)
@@ -38,6 +42,7 @@ public class CouponService {
         return savedCoupon;
     }
 
+    @Cacheable(value = COUPON_CACHE_NAME, key = "#p0")
     @Transactional(readOnly = true)
     public List<Coupon> findAllCoupons(Long memberId) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/coupon/service/CouponService.java
+++ b/src/main/java/coupon/service/CouponService.java
@@ -27,12 +27,12 @@ public class CouponService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
-        long count = memberCouponRepository.countMemberCouponByMember(member);
+        long count = memberCouponRepository.countMemberCouponByMemberId(member.getId());
         if (count >= MAXIMUM_COUPON_PER_MEMBER) {
             throw new IllegalArgumentException("한 회원당 %d장만 쿠폰 발급이 가능합니다.".formatted(MAXIMUM_COUPON_PER_MEMBER));
         }
         Coupon savedCoupon = couponRepository.save(coupon);
-        MemberCoupon memberCoupon = new MemberCoupon(savedCoupon, member);
+        MemberCoupon memberCoupon = new MemberCoupon(savedCoupon.getId(), member.getId());
         memberCouponRepository.save(memberCoupon);
         return savedCoupon;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: false
         use_sql_comments: true
-        hbm2ddl.auto: validate
+        hbm2ddl.auto: update
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/test/java/coupon/domain/coupon/MinimumAmountTest.java
+++ b/src/test/java/coupon/domain/coupon/MinimumAmountTest.java
@@ -12,7 +12,7 @@ class MinimumAmountTest {
     @ParameterizedTest
     @ValueSource(ints = {0, 1, 2, 3, 21, 22, 23, 100})
     void throwsExceptionWhenNotInRange(int amount) {
-        String expectedMessage = "최소 주문 금액은 %d 이상 %d 이하여야 합니다. 입력값 : ".formatted(5_000, 100_000 ) + amount;
+        String expectedMessage = "최소 주문 금액은 %d 이상 %d 이하여야 합니다. 입력값 : ".formatted(5_000, 100_000) + amount;
 
         assertThatThrownBy(() -> new MinimumAmount(amount))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/coupon/fixture/CouponFixture.java
+++ b/src/test/java/coupon/fixture/CouponFixture.java
@@ -6,7 +6,12 @@ import java.time.LocalDate;
 
 public enum CouponFixture {
 
-    PRAM_COUPON("pram", 1_000, 30_000, Category.FOOD, LocalDate.now(), LocalDate.now());
+    PRAM_COUPON("pram", 1_000, 30_000, Category.FOOD, LocalDate.now(), LocalDate.now()),
+    DAON_COUPON("daon", 1_500, 45_000, Category.APPLICATION, LocalDate.now(), LocalDate.now()),
+    BLACKJACK_COUPON("blackjack", 2_000, 60_000, Category.APPLICATION, LocalDate.now(), LocalDate.now()),
+    LOTTO_COUPON("lotto", 2_000, 60_000, Category.FASHION, LocalDate.now(), LocalDate.now()),
+    CHESS_COUPON("chess", 2_500, 75_000, Category.FURNITURE, LocalDate.now(), LocalDate.now()),
+    BASEBALL_COUPON("baseball", 3_000, 90_000, Category.FASHION, LocalDate.now(), LocalDate.now());
 
     private final String name;
     private final int discountAmount;

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -18,7 +18,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class CouponServiceTest {
 
@@ -34,6 +37,9 @@ class CouponServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private CacheManager cacheManager;
+
     private Coupon coupon;
 
     private Member member;
@@ -44,6 +50,7 @@ class CouponServiceTest {
         member = new Member("daon", "1234");
         memberRepository.save(member);
         couponRepository.save(coupon);
+        cacheManager.getCache(CouponService.COUPON_CACHE_NAME).clear();
     }
 
     @AfterEach
@@ -85,6 +92,17 @@ class CouponServiceTest {
                 .hasMessage("한 회원당 %d장만 쿠폰 발급이 가능합니다.".formatted(5));
     }
 
+    @DisplayName("쿠폰을 생성하면 캐시가 무효화된다.")
+    @Test
+    void createCouponsWithCacheEviction() {
+        Coupon newCoupon = CouponFixture.LOTTO_COUPON.coupon();
+
+        couponService.findAllCoupons(member.getId());
+        couponService.create(member.getId(), newCoupon);
+
+        assertThat(cacheManager.getCache(CouponService.COUPON_CACHE_NAME).get(member.getId())).isNull();
+    }
+
     @DisplayName("회원이 소유한 쿠폰을 모두 조회한다.")
     @Test
     void findAllCoupons() {
@@ -105,6 +123,29 @@ class CouponServiceTest {
         List<Coupon> results = couponService.findAllCoupons(member.getId());
 
         assertThat(results).hasSize(5);
+    }
+
+    @DisplayName("회원이 소유한 쿠폰 조획 결과가 쿠키에 존재하면 데이터베이스에 요청을 보내지 않는다.")
+    @Test
+    void findAllCouponsWithCacheHit() {
+        Coupon coupon1 = couponRepository.save(CouponFixture.DAON_COUPON.coupon());
+        Coupon coupon2 = couponRepository.save(CouponFixture.BLACKJACK_COUPON.coupon());
+        Coupon coupon3 = couponRepository.save(CouponFixture.CHESS_COUPON.coupon());
+        Coupon coupon4 = couponRepository.save(CouponFixture.BASEBALL_COUPON.coupon());
+        List<MemberCoupon> memberCoupons = List.of(
+                new MemberCoupon(coupon1.getId(), member.getId()),
+                new MemberCoupon(coupon2.getId(), member.getId()),
+                new MemberCoupon(coupon3.getId(), member.getId()),
+                new MemberCoupon(coupon4.getId(), member.getId())
+        );
+        memberCouponRepository.saveAll(memberCoupons);
+        long memberId = member.getId();
+
+        List<Coupon> coupons = couponService.findAllCoupons(memberId);
+        assertThat(cacheManager.getCache(CouponService.COUPON_CACHE_NAME).get(memberId).get()).isSameAs(coupons);
+        List<Coupon> couponsAgain = couponService.findAllCoupons(memberId);
+        assertThat(couponsAgain).isSameAs(coupons);
+        assertThat(cacheManager.getCache(CouponService.COUPON_CACHE_NAME).get(memberId).get()).isSameAs(coupons);
     }
 
     @DisplayName("id로 조회한다.")

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -1,12 +1,16 @@
 package coupon.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import coupon.domain.coupon.Category;
 import coupon.domain.coupon.Coupon;
 import coupon.domain.coupon.CouponRepository;
+import coupon.domain.member.Member;
+import coupon.domain.member.MemberRepository;
+import coupon.domain.membercounpon.MemberCoupon;
+import coupon.domain.membercounpon.MemberCouponRepository;
 import coupon.fixture.CouponFixture;
-import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,25 +26,63 @@ class CouponServiceTest {
     private CouponService couponService;
 
     @Autowired
+    private MemberCouponRepository memberCouponRepository;
+
+    @Autowired
     private CouponRepository couponRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     private Coupon coupon;
 
+    private Member member;
+
     @BeforeEach
     void setup() {
-        coupon = new Coupon("daon", 3_000, 100_000, Category.FOOD, LocalDate.now(), LocalDate.now());
+        coupon = CouponFixture.PRAM_COUPON.coupon();
+        member = new Member("daon", "1234");
+        memberRepository.save(member);
         couponRepository.save(coupon);
     }
 
     @AfterEach
     void teardown() {
+        memberCouponRepository.deleteAllInBatch();
         couponRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("쿠폰 생성시 회원이 존재하지 않으면 예외가 발생한다.")
+    @Test
+    void insertWithInvalidMemberId() {
+        long id = -1;
+
+        assertThatThrownBy(() -> couponService.create(id, coupon))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("회원이 존재하지 않습니다.");
+    }
+
+    @DisplayName("회원이 소유한 쿠폰이 5장보다 많으면 예외가 발생한다.")
+    @Test
+    void insertWithMoreThanCouponLimitSize() {
+        List<MemberCoupon> memberCoupons = List.of(
+                new MemberCoupon(couponRepository.save(CouponFixture.DAON_COUPON.coupon()), member),
+                new MemberCoupon(couponRepository.save(CouponFixture.BLACKJACK_COUPON.coupon()), member),
+                new MemberCoupon(couponRepository.save(CouponFixture.CHESS_COUPON.coupon()), member),
+                new MemberCoupon(couponRepository.save(CouponFixture.BASEBALL_COUPON.coupon()), member),
+                new MemberCoupon(couponRepository.save(CouponFixture.LOTTO_COUPON.coupon()), member)
+        );
+        memberCouponRepository.saveAll(memberCoupons);
+
+        assertThatThrownBy(() -> couponService.create(member.getId(), coupon))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("한 회원당 %d장만 쿠폰 발급이 가능합니다.".formatted(5));
     }
 
     @DisplayName("id로 조회한다.")
     @Test
-    void findById() throws InterruptedException {
-        Thread.sleep(2000);
+    void findById() {
         Coupon foundCoupon = couponRepository.findById(coupon.getId())
                 .orElseThrow();
         assertThat(foundCoupon).isNotNull();
@@ -50,7 +92,7 @@ class CouponServiceTest {
     @Test
     void replicaDelayTest() {
         Coupon coupon = CouponFixture.PRAM_COUPON.coupon();
-        Coupon savedCoupon = couponService.create(coupon);
+        Coupon savedCoupon = couponService.create(member.getId(), coupon);
         Coupon result = couponService.getCoupon(savedCoupon.getId());
         assertThat(result).isNotNull();
     }

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -85,6 +85,28 @@ class CouponServiceTest {
                 .hasMessage("한 회원당 %d장만 쿠폰 발급이 가능합니다.".formatted(5));
     }
 
+    @DisplayName("회원이 소유한 쿠폰을 모두 조회한다.")
+    @Test
+    void findAllCoupons() {
+        Coupon coupon1 = couponRepository.save(CouponFixture.DAON_COUPON.coupon());
+        Coupon coupon2 = couponRepository.save(CouponFixture.BLACKJACK_COUPON.coupon());
+        Coupon coupon3 = couponRepository.save(CouponFixture.CHESS_COUPON.coupon());
+        Coupon coupon4 = couponRepository.save(CouponFixture.BASEBALL_COUPON.coupon());
+        Coupon coupon5 = couponRepository.save(CouponFixture.LOTTO_COUPON.coupon());
+        List<MemberCoupon> memberCoupons = List.of(
+                new MemberCoupon(coupon1.getId(), member.getId()),
+                new MemberCoupon(coupon2.getId(), member.getId()),
+                new MemberCoupon(coupon3.getId(), member.getId()),
+                new MemberCoupon(coupon4.getId(), member.getId()),
+                new MemberCoupon(coupon5.getId(), member.getId())
+        );
+        memberCouponRepository.saveAll(memberCoupons);
+
+        List<Coupon> results = couponService.findAllCoupons(member.getId());
+
+        assertThat(results).hasSize(5);
+    }
+
     @DisplayName("id로 조회한다.")
     @Test
     void findById() {

--- a/src/test/java/coupon/service/CouponServiceTest.java
+++ b/src/test/java/coupon/service/CouponServiceTest.java
@@ -66,12 +66,17 @@ class CouponServiceTest {
     @DisplayName("회원이 소유한 쿠폰이 5장보다 많으면 예외가 발생한다.")
     @Test
     void insertWithMoreThanCouponLimitSize() {
+        Coupon coupon1 = couponRepository.save(CouponFixture.DAON_COUPON.coupon());
+        Coupon coupon2 = couponRepository.save(CouponFixture.BLACKJACK_COUPON.coupon());
+        Coupon coupon3 = couponRepository.save(CouponFixture.CHESS_COUPON.coupon());
+        Coupon coupon4 = couponRepository.save(CouponFixture.BASEBALL_COUPON.coupon());
+        Coupon coupon5 = couponRepository.save(CouponFixture.LOTTO_COUPON.coupon());
         List<MemberCoupon> memberCoupons = List.of(
-                new MemberCoupon(couponRepository.save(CouponFixture.DAON_COUPON.coupon()), member),
-                new MemberCoupon(couponRepository.save(CouponFixture.BLACKJACK_COUPON.coupon()), member),
-                new MemberCoupon(couponRepository.save(CouponFixture.CHESS_COUPON.coupon()), member),
-                new MemberCoupon(couponRepository.save(CouponFixture.BASEBALL_COUPON.coupon()), member),
-                new MemberCoupon(couponRepository.save(CouponFixture.LOTTO_COUPON.coupon()), member)
+                new MemberCoupon(coupon1.getId(), member.getId()),
+                new MemberCoupon(coupon2.getId(), member.getId()),
+                new MemberCoupon(coupon3.getId(), member.getId()),
+                new MemberCoupon(coupon4.getId(), member.getId()),
+                new MemberCoupon(coupon5.getId(), member.getId())
         );
         memberCouponRepository.saveAll(memberCoupons);
 
@@ -83,8 +88,7 @@ class CouponServiceTest {
     @DisplayName("id로 조회한다.")
     @Test
     void findById() {
-        Coupon foundCoupon = couponRepository.findById(coupon.getId())
-                .orElseThrow();
+        Coupon foundCoupon = couponService.getCoupon(coupon.getId());
         assertThat(foundCoupon).isNotNull();
     }
 


### PR DESCRIPTION
안녕하세요 프람,
최종 데모데이는 잘 마무리하셨나요?

2단계도 열심히 구현해보았습니다.

## 캐시 구현

우선 저는 Redis가 아닌 Spring에 내장된 Cache를 사용하여 구현하였습니다.
현재 단일 서버로 구현되어 있어 관리 비용이 생기는 글로벌 캐시로의 필요성을 느끼지 못했고, Redis에 대한 러닝 커브로 인해 내장된 Cache를 이용하였어요.

## 캐시 전략

제가 선택한 읽기 전략은 `Look Aside` 패턴을, 쓰기 전략은 캐시를 무효화하였습니다.

### 읽기 전략 Look Aside

쿠폰 조회는 반복적으로 읽기가 많이 호출될 것이라 생각하였습니다. 발급한 쿠폰을 사용하려면 결제마다 봐야하니까요.
때문에 1차로 Cache를 조회 하여 Hit한 경우 바로 반환을, 2차로 Miss가 발생한 경우 DB로 조회를 하도록 설정하였습니다.

### 쓰기 전략 캐시 무효화

쿠폰을 발급받으면 쇼핑몰의 경우 바로 사용할거라 생각했어요. 때문에 데이터의 정합성을 중요하게 여겼는데요. 현재 적용한 캐시는 `ConcurrentHashMap`으로 TTL을 지원하지 않기 때문에 캐시를 비우지 않는데요. 때문에 데이터가 추가된 경우 캐시를 무효화 하여 쿠폰 조회시 반드시 DB로 찍어오게끔 구현하였습니다.


