### PR TITLE
[2단계 - DB 복제와 캐시] 도도(김도선) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     annotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/coupon/config/RedisCacheConfig.java
+++ b/src/main/java/coupon/config/RedisCacheConfig.java
@@ -23,7 +23,7 @@ public class RedisCacheConfig {
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
                         new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofMinutes(6L));
+                .entryTtl(Duration.ofMinutes(10L));
 
         return RedisCacheManager
                 .RedisCacheManagerBuilder

--- a/src/main/java/coupon/config/RedisCacheConfig.java
+++ b/src/main/java/coupon/config/RedisCacheConfig.java
@@ -1,5 +1,7 @@
 package coupon.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -18,11 +20,18 @@ public class RedisCacheConfig {
 
     @Bean
     public CacheManager redisCacheManager(RedisConnectionFactory cf) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer(
+                objectMapper
+        );
+
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer()))
+                        genericJackson2JsonRedisSerializer))
                 .entryTtl(Duration.ofMinutes(10L));
 
         return RedisCacheManager

--- a/src/main/java/coupon/config/RedisCacheConfig.java
+++ b/src/main/java/coupon/config/RedisCacheConfig.java
@@ -1,0 +1,34 @@
+package coupon.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(6L));
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(cf)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/coupon/config/RedisCacheConfig.java
+++ b/src/main/java/coupon/config/RedisCacheConfig.java
@@ -20,18 +20,12 @@ public class RedisCacheConfig {
 
     @Bean
     public CacheManager redisCacheManager(RedisConnectionFactory cf) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
-        GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer(
-                objectMapper
-        );
 
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        genericJackson2JsonRedisSerializer))
+                        new GenericJackson2JsonRedisSerializer()))
                 .entryTtl(Duration.ofMinutes(10L));
 
         return RedisCacheManager

--- a/src/main/java/coupon/config/RedisConfig.java
+++ b/src/main/java/coupon/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package coupon.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -21,7 +21,6 @@ import org.hibernate.annotations.CreationTimestamp;
 @Entity
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class Coupon {
 
     public static final int MIN_DISCOUNT_RATE = 3;

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -3,17 +3,20 @@ package coupon.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class Coupon {
 
     public static final int MIN_DISCOUNT_RATE = 3;
@@ -28,8 +31,8 @@ public class Coupon {
     @Column(name = "name", columnDefinition = "varchar(30)", nullable = false)
     private String name;
 
-    @Column(name = "cateory", nullable = false)
-    @Enumerated
+    @Column(name = "category", nullable = false)
+    @Enumerated(value = EnumType.STRING)
     private Category category;
 
     @Column(name = "discount_amount")
@@ -44,7 +47,6 @@ public class Coupon {
 
     @Column(name = "issue_ended_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime issueEndedAt;
-
 
     public Coupon(String name, Category category, int discountAmount, int minimumOrderPrice,
                   LocalDateTime issueStartedAt, LocalDateTime issueEndedAt) {

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,6 +21,7 @@ import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Getter
+@Table(name = "coupon")
 @NoArgsConstructor
 public class Coupon {
 

--- a/src/main/java/coupon/domain/Coupon.java
+++ b/src/main/java/coupon/domain/Coupon.java
@@ -1,5 +1,9 @@
 package coupon.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -12,6 +16,7 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Getter
@@ -42,9 +47,15 @@ public class Coupon {
     @Column(name = "minimum_order_price")
     private MinimumOrderPrice minimumOrderPrice;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @CreationTimestamp
     @Column(name = "issue_started_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime issueStartedAt;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @CreationTimestamp
     @Column(name = "issue_ended_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime issueEndedAt;
 

--- a/src/main/java/coupon/domain/Member.java
+++ b/src/main/java/coupon/domain/Member.java
@@ -7,11 +7,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name="member")
 @NoArgsConstructor
+@Getter
 public class Member {
 
     @Id

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -13,17 +13,19 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.mapping.ToOne;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MemberCoupon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
 
@@ -43,19 +45,9 @@ public class MemberCoupon {
     @Column(name = "used_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime usedAt;
 
-    public MemberCoupon(
-            Member member,
-            Coupon coupon,
-            LocalDateTime now,
-            LocalDateTime localDateTime,
-            boolean used,
-            LocalDateTime usedAt
-    ) {
-
-    }
-
     public MemberCoupon(Member member, Coupon coupon) {
         this(
+                null,
                 member,
                 coupon,
                 LocalDateTime.now(),

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,5 +42,27 @@ public class MemberCoupon {
 
     @Column(name = "used_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime usedAt;
+
+    public MemberCoupon(
+            Member member,
+            Coupon coupon,
+            LocalDateTime now,
+            LocalDateTime localDateTime,
+            boolean used,
+            LocalDateTime usedAt
+    ) {
+
+    }
+
+    public MemberCoupon(Member member, Coupon coupon) {
+        this(
+                member,
+                coupon,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(7).withHour(0).withMinute(0).withSecond(0),
+                false,
+                null
+        );
+    }
 }
 

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -1,5 +1,9 @@
 package coupon.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -12,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Getter
@@ -30,15 +35,24 @@ public class MemberCoupon {
     @JoinColumn(name = "coupon_id")
     private Long couponId;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @CreationTimestamp
     @Column(name = "issued_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime issuedAt;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @CreationTimestamp
     @Column(name = "use_ended_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime useEndedAt;
 
     @Column(name = "used", columnDefinition = "BOOLEAN")
     private boolean used;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @CreationTimestamp
     @Column(name = "used_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime usedAt;
 

--- a/src/main/java/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/domain/MemberCoupon.java
@@ -7,13 +7,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.mapping.ToOne;
 
 @Entity
 @Getter
@@ -29,9 +27,8 @@ public class MemberCoupon {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
     @JoinColumn(name = "coupon_id")
-    private Coupon coupon;
+    private Long couponId;
 
     @Column(name = "issued_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime issuedAt;
@@ -49,7 +46,7 @@ public class MemberCoupon {
         this(
                 null,
                 member,
-                coupon,
+                coupon.getId(),
                 LocalDateTime.now(),
                 LocalDateTime.now().plusDays(7).withHour(0).withMinute(0).withSecond(0),
                 false,

--- a/src/main/java/coupon/dto/FindMemberCouponsDto.java
+++ b/src/main/java/coupon/dto/FindMemberCouponsDto.java
@@ -1,0 +1,30 @@
+package coupon.dto;
+
+import coupon.domain.Coupon;
+import coupon.domain.Member;
+import coupon.domain.MemberCoupon;
+import java.time.LocalDateTime;
+
+public record FindMemberCouponsDto(
+
+        Long id,
+        Member member,
+        Coupon coupon,
+        LocalDateTime issuedAt,
+        LocalDateTime useEndedAt,
+        boolean used,
+        LocalDateTime usedAt
+) {
+
+    public FindMemberCouponsDto(MemberCoupon memberCoupon, Coupon coupon) {
+        this(
+                memberCoupon.getId(),
+                memberCoupon.getMember(),
+                coupon,
+                memberCoupon.getIssuedAt(),
+                memberCoupon.getUseEndedAt(),
+                memberCoupon.isUsed(),
+                memberCoupon.getUsedAt()
+        );
+    }
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,8 @@
+package coupon.repository;
+
+import coupon.domain.MemberCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+}

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -1,9 +1,13 @@
 package coupon.repository;
 
 import coupon.domain.MemberCoupon;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
     long countByMemberIdAndCouponId(Long memberId, Long couponId);
+
+
+    List<MemberCoupon> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/repository/MemberCouponRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
+    long countByMemberIdAndCouponId(Long memberId, Long couponId);
 }

--- a/src/main/java/coupon/repository/MemberRepository.java
+++ b/src/main/java/coupon/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package coupon.repository;
+
+import coupon.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/coupon/service/CouponCommandService.java
+++ b/src/main/java/coupon/service/CouponCommandService.java
@@ -1,11 +1,15 @@
 package coupon.service;
 
+import static coupon.service.CouponQueryService.CACHE_MANAGER;
+
 import coupon.domain.Coupon;
 import coupon.domain.Member;
 import coupon.domain.MemberCoupon;
 import coupon.repository.CouponRepository;
 import coupon.repository.MemberCouponRepository;
 import coupon.repository.MemberRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,10 +34,12 @@ public class CouponCommandService {
         return couponRepository.save(coupon);
     }
 
+    @Cacheable(value = "coupon", key = "#id", cacheManager = CACHE_MANAGER)
     public Coupon getCoupon(Long id) {
         return couponRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
     }
 
+    @CacheEvict(value = "private_coupons", key = "#memberId")
     public MemberCoupon issueCoupon(Long memberId, Long couponId) {
         validateIssuedCouponCount(memberId, couponId);
 

--- a/src/main/java/coupon/service/CouponCommandService.java
+++ b/src/main/java/coupon/service/CouponCommandService.java
@@ -1,7 +1,11 @@
 package coupon.service;
 
-import coupon.repository.CouponRepository;
 import coupon.domain.Coupon;
+import coupon.domain.Member;
+import coupon.domain.MemberCoupon;
+import coupon.repository.CouponRepository;
+import coupon.repository.MemberCouponRepository;
+import coupon.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,9 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponCommandService {
 
     private final CouponRepository couponRepository;
+    private final MemberRepository memberRepository;
+    private final MemberCouponRepository memberCouponRepository;
 
-    public CouponCommandService(CouponRepository couponRepository) {
+    public CouponCommandService(CouponRepository couponRepository, MemberRepository memberRepository,
+                                MemberCouponRepository memberCouponRepository) {
         this.couponRepository = couponRepository;
+        this.memberRepository = memberRepository;
+        this.memberCouponRepository = memberCouponRepository;
     }
 
     public Coupon createCoupon(Coupon coupon) {
@@ -21,5 +30,15 @@ public class CouponCommandService {
 
     public Coupon getCoupon(Long id) {
         return couponRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+    }
+
+    public void issueCoupon(Long memberId, Long couponId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+        Coupon coupon = couponRepository.findById(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+
+        MemberCoupon memberCoupon = new MemberCoupon(member, coupon);
+        memberCouponRepository.save(memberCoupon);
     }
 }

--- a/src/main/java/coupon/service/CouponQueryService.java
+++ b/src/main/java/coupon/service/CouponQueryService.java
@@ -26,7 +26,6 @@ public class CouponQueryService {
 
     @Cacheable(value = "coupon", key = "#id", cacheManager = CACHE_MANAGER)
     public Coupon getCoupon(Long id) {
-        System.out.println("쿠폰겟=" + couponRepository.findById(1L).get());
         return couponRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
     }
 

--- a/src/main/java/coupon/service/CouponQueryService.java
+++ b/src/main/java/coupon/service/CouponQueryService.java
@@ -1,7 +1,12 @@
 package coupon.service;
 
-import coupon.repository.CouponRepository;
 import coupon.domain.Coupon;
+import coupon.domain.MemberCoupon;
+import coupon.dto.FindMemberCouponsDto;
+import coupon.repository.CouponRepository;
+import coupon.repository.MemberCouponRepository;
+import java.util.List;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,15 +14,33 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CouponQueryService {
 
+    public static final String CACHE_MANAGER = "redisCacheManager";
+
     private final CouponRepository couponRepository;
     private final CouponCommandService couponCommandService;
+    private final MemberCouponRepository memberCouponRepository;
 
-    public CouponQueryService(CouponRepository couponRepository, CouponCommandService couponCommandService) {
+    public CouponQueryService(CouponRepository couponRepository, CouponCommandService couponCommandService,
+                              MemberCouponRepository memberCouponRepository) {
         this.couponRepository = couponRepository;
         this.couponCommandService = couponCommandService;
+        this.memberCouponRepository = memberCouponRepository;
     }
 
+    @Cacheable(value = "coupon", key = "#id", cacheManager = CACHE_MANAGER)
     public Coupon getCoupon(Long id) {
-        return couponRepository.findById(id).orElseGet(()-> couponCommandService.getCoupon(id));
+        return couponRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+    }
+
+    @Cacheable(value = "private_coupons", key = "#memberId", cacheManager = CACHE_MANAGER)
+    public List<FindMemberCouponsDto> getCoupons(Long memberId) {
+        List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberId(memberId);
+
+        return memberCoupons.stream()
+                .map(memberCoupon -> {
+                    Coupon coupon = getCoupon(memberCoupon.getId());
+                    return new FindMemberCouponsDto(memberCoupon, coupon);
+                })
+                .toList();
     }
 }

--- a/src/main/java/coupon/service/CouponQueryService.java
+++ b/src/main/java/coupon/service/CouponQueryService.java
@@ -17,18 +17,16 @@ public class CouponQueryService {
     public static final String CACHE_MANAGER = "redisCacheManager";
 
     private final CouponRepository couponRepository;
-    private final CouponCommandService couponCommandService;
     private final MemberCouponRepository memberCouponRepository;
 
-    public CouponQueryService(CouponRepository couponRepository, CouponCommandService couponCommandService,
-                              MemberCouponRepository memberCouponRepository) {
+    public CouponQueryService(CouponRepository couponRepository, MemberCouponRepository memberCouponRepository) {
         this.couponRepository = couponRepository;
-        this.couponCommandService = couponCommandService;
         this.memberCouponRepository = memberCouponRepository;
     }
 
     @Cacheable(value = "coupon", key = "#id", cacheManager = CACHE_MANAGER)
     public Coupon getCoupon(Long id) {
+        System.out.println("쿠폰겟=" + couponRepository.findById(1L).get());
         return couponRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,10 +12,16 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: create
+        hbm2ddl.auto: create-drop
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false
+  data:
+    redis:
+      host: localhost
+      port: 36379
+  cache:
+    type: redis
 
 coupon.datasource:
   writer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
         format_sql: true
         show_sql: true
         use_sql_comments: true
-        hbm2ddl.auto: create-drop
+        hbm2ddl.auto: create
         check_nullability: true
         query.in_clause_parameter_padding: true
     open-in-view: false

--- a/src/test/java/coupon/CouponApplicationTests.java
+++ b/src/test/java/coupon/CouponApplicationTests.java
@@ -8,9 +8,11 @@ import coupon.domain.Coupon;
 import coupon.service.CouponQueryService;
 import coupon.service.CouponCommandService;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 
 @SpringBootTest
 class CouponApplicationTests {
@@ -22,8 +24,12 @@ class CouponApplicationTests {
     @Autowired
     private CouponQueryService couponQueryService;
 
-    @Test
-    void contextLoads() {
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager.getCache("coupon").clear();
     }
 
     @Test

--- a/src/test/java/coupon/service/CouponCommandServiceTest.java
+++ b/src/test/java/coupon/service/CouponCommandServiceTest.java
@@ -2,6 +2,7 @@ package coupon.service;
 
 import static coupon.domain.Category.FOOD;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import coupon.domain.Coupon;
 import coupon.domain.Member;
@@ -44,5 +45,24 @@ class CouponCommandServiceTest {
         couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId());
 
         assertThat(memberCouponRepository.count()).isOne();
+    }
+
+    @DisplayName("동일한 쿠폰은 5개까지만 발급 가능하다")
+    @Test
+    void issueByFive() {
+        Member savedMember = memberRepository.save(new Member());
+        Coupon savedCoupon = couponRepository.save(
+                new Coupon("쿠폰1", FOOD, 1_000, 10_000, LocalDateTime.now(), LocalDateTime.now().plusDays(1))
+        );
+
+        couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId());
+        couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId());
+        couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId());
+        couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId());
+        couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId());
+
+        assertThatThrownBy(() -> couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("동일한 쿠폰은 사용한 쿠폰 포함해서 5개까지만 발급 가능합니다.");
     }
 }

--- a/src/test/java/coupon/service/CouponCommandServiceTest.java
+++ b/src/test/java/coupon/service/CouponCommandServiceTest.java
@@ -1,0 +1,48 @@
+package coupon.service;
+
+import static coupon.domain.Category.FOOD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import coupon.domain.Coupon;
+import coupon.domain.Member;
+import coupon.repository.CouponRepository;
+import coupon.repository.MemberCouponRepository;
+import coupon.repository.MemberRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class CouponCommandServiceTest {
+
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private CouponCommandService couponCommandService;
+
+    @Autowired
+    private MemberCouponRepository memberCouponRepository;
+
+
+    @DisplayName("쿠폰을 발급 할 수 있다.")
+    @Transactional
+    @Test
+    void issueCoupon() {
+        Member savedMember = memberRepository.save(new Member());
+        Coupon savedCoupon = couponRepository.save(
+                new Coupon("쿠폰1", FOOD, 1_000, 10_000, LocalDateTime.now(), LocalDateTime.now().plusDays(1))
+        );
+
+        couponCommandService.issueCoupon(savedMember.getId(), savedCoupon.getId());
+
+        assertThat(memberCouponRepository.count()).isOne();
+    }
+}

--- a/src/test/java/coupon/service/CouponCommandServiceTest.java
+++ b/src/test/java/coupon/service/CouponCommandServiceTest.java
@@ -10,10 +10,12 @@ import coupon.repository.CouponRepository;
 import coupon.repository.MemberCouponRepository;
 import coupon.repository.MemberRepository;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -32,6 +34,14 @@ class CouponCommandServiceTest {
     @Autowired
     private MemberCouponRepository memberCouponRepository;
 
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        couponRepository.deleteAll();
+        memberCouponRepository.deleteAll();
+    }
 
     @DisplayName("쿠폰을 발급 할 수 있다.")
     @Transactional

--- a/src/test/java/coupon/service/CouponQueryServiceTest.java
+++ b/src/test/java/coupon/service/CouponQueryServiceTest.java
@@ -1,0 +1,61 @@
+package coupon.service;
+
+
+import static coupon.domain.Category.FOOD;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import coupon.domain.Coupon;
+import coupon.repository.CouponRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+class CouponQueryServiceTest {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @SpyBean
+    CouponRepository couponRepository;
+
+    @Autowired
+    CouponQueryService couponQueryService;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager.getCache("coupon").clear();
+    }
+
+    @DisplayName("쿠폰을 1번 조회 후 두번째 조회부터는 캐시에서 데이터를 조회한다.")
+    @Test
+    void get_coupon_in_cache() throws InterruptedException {
+        // given
+        Coupon coupon = new Coupon("쿠폰1", FOOD, 1_000, 10_000, LocalDateTime.now(), LocalDateTime.now().plusDays(1));
+        given(couponRepository.findById(1L))
+                .willReturn(Optional.of(coupon));
+
+        // when
+        verify(couponRepository, times(0)).findById(1L);
+        couponQueryService.getCoupon(1L); // 첫번 째 호출
+        verify(couponRepository, times(2)).findById(1L); // 원인은 아직 못찾았지만, getCoupon한번 호출 할때 findById가 두번 호출 되는 버그가 있습니다.
+        couponQueryService.getCoupon(1L); // 두번 째 호출
+
+        verify(couponRepository, times(2)).findById(1L); // 두번 째 호출 했음에도 verify그대로 2번이 true임을 검증
+    }
+}

--- a/src/test/java/coupon/service/CouponQueryServiceTest.java
+++ b/src/test/java/coupon/service/CouponQueryServiceTest.java
@@ -51,12 +51,10 @@ class CouponQueryServiceTest {
                 .willReturn(Optional.of(coupon));
 
         // when
-        verify(couponRepository, times(0)).findById(1L);
         couponQueryService.getCoupon(1L); // 첫번 째 호출
-        verify(couponRepository, times(2)).findById(1L); // 원인은 아직 못찾았지만, getCoupon한번 호출 할때 findById가 두번 호출 되는 버그가 있습니다.
         couponQueryService.getCoupon(1L); // 두번 째 호출
 
         // then
-        verify(couponRepository, times(2)).findById(1L); // 두번 째 호출 했음에도 verify그대로 2번이 true임을 검증
+        verify(couponRepository, times(1)).findById(1L);
     }
 }

--- a/src/test/java/coupon/service/CouponQueryServiceTest.java
+++ b/src/test/java/coupon/service/CouponQueryServiceTest.java
@@ -56,6 +56,7 @@ class CouponQueryServiceTest {
         verify(couponRepository, times(2)).findById(1L); // 원인은 아직 못찾았지만, getCoupon한번 호출 할때 findById가 두번 호출 되는 버그가 있습니다.
         couponQueryService.getCoupon(1L); // 두번 째 호출
 
+        // then
         verify(couponRepository, times(2)).findById(1L); // 두번 째 호출 했음에도 verify그대로 2번이 true임을 검증
     }
 }


### PR DESCRIPTION
안녕하세요 낙낙!
두번째 미션도 잘 부탁드립니다.

## 캐싱 전략
캐싱 적용한 메서드는 총 두개입니다
`getCoupon(쿠폰 단일조회)` `getCoupons(특정 멤버의 쿠폰리스트 조회)`

getCoupon은 모든 유저가 동일하게 사용하는 부분으로 제일 캐시적중이 많이 될 것으로 보여, 캐시를 적용했습니다.

getCoupons는 특정 멤버가 가지고 있는 쿠폰리스트 조회인데, 쿠팡같은 쇼핑몰을 생각했을 때, 상품목록들만 봐도 내가 가진 쿠폰들을 기반으로 가격을 보여주니, 쇼핑몰 체류시간동안에 내 쿠폰리스트도 많이 조회하겠다 싶었습니다.
그리고 내가 가진 쿠폰리스트는 다른 쿠폰을 발급 받으면 리스트에 추가가 되야하기 때문에, 쿠폰발급 시, 쿠폰리스트 캐시를 지우게 했습니다.

TTL은 6분->**10분**으로 했습니다. 그 이유는
[무신사가 8분 15초로 체류시간이 가장 길었고, 더한섬닷컴·쿠팡·하프클럽이 평균 7분 30초대로 근소한 차이를 보였다.](http://m.apparelnews.co.kr/news/news_view/?idx=187387)
라는 자료를 보고 평균 체류시간 보다는 많게, 1.5배로 산정했습니다.

도메인에 대한 리뷰도 좋지만, 학습목표가 목표인 만큼 복제와 캐시 관련된 질문이면 더 좋을 것 같아요!! 잘부탁드립니다!