### PR TITLE
[2단계 - DB 복제와 캐시] 이상(이건상) 미션 제출합니다.

### DIFF
--- a/src/main/java/coupon/Category.java
+++ b/src/main/java/coupon/Category.java
@@ -1,14 +1,6 @@
 package coupon;
 
 public enum Category {
-    /**
-     * 카테고리
-         * 서비스의 카테고리는 다음과 같이 네 종류가 있고, 이 중 하나의 카테고리만 선택할 수 있다.
-         * 패션
-         * 가전
-         * 가구
-         * 식품
-     */
     FASHION,
     APPLIANCES,
     FURNITURE,

--- a/src/main/java/coupon/Coupon.java
+++ b/src/main/java/coupon/Coupon.java
@@ -9,12 +9,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coupon")
 @Entity
 public class Coupon {
 

--- a/src/main/java/coupon/CouponService.java
+++ b/src/main/java/coupon/CouponService.java
@@ -1,9 +1,5 @@
 package coupon;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/coupon/Member.java
+++ b/src/main/java/coupon/Member.java
@@ -1,31 +1,25 @@
 package coupon;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
 public class Member {
 
     private static final int MIN_NAME_LENGTH = 1;
     private static final int MAX_NAME_LENGTH = 10;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
 
-    public Member(String name) {
+    public Member(Long id, String name) {
         if (name.isBlank() || 10 < name.length()) {
             throw new IllegalArgumentException(String.format("회원의 이름은 최소 %d자 이상 %d자 이하만 가능합니다.", MIN_NAME_LENGTH, MAX_NAME_LENGTH));
         }
+        this.id = id;
         this.name = name;
     }
 }

--- a/src/main/java/coupon/MemberCoupon.java
+++ b/src/main/java/coupon/MemberCoupon.java
@@ -6,12 +6,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_coupon")
 @Entity
 public class MemberCoupon {
 

--- a/src/main/java/coupon/MemberCoupon.java
+++ b/src/main/java/coupon/MemberCoupon.java
@@ -40,6 +40,10 @@ public class MemberCoupon {
     @Column(name = "expiration_date_time")
     private LocalDateTime expirationDateTime;
 
+    public MemberCoupon(Long couponId, Long memberId) {
+        this(couponId, memberId, false, LocalDateTime.now());
+    }
+
     public MemberCoupon(Long couponId, Long memberId, boolean isUsed, LocalDateTime issuedDateTime) {
         this.couponId = couponId;
         this.memberId = memberId;

--- a/src/main/java/coupon/MemberCouponRepository.java
+++ b/src/main/java/coupon/MemberCouponRepository.java
@@ -1,8 +1,13 @@
 package coupon;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+     Long countMemberCouponsByCouponIdAndMemberId(Long couponId, Long memberId);
+
+    List<MemberCoupon> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/coupon/MemberCouponRepository.java
+++ b/src/main/java/coupon/MemberCouponRepository.java
@@ -2,12 +2,13 @@ package coupon;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
-     Long countMemberCouponsByCouponIdAndMemberId(Long couponId, Long memberId);
+    Long countMemberCouponsByCouponIdAndMemberId(Long couponId, Long memberId);
 
-    List<MemberCoupon> findAllByMemberId(Long memberId);
+    @Query("select mc from MemberCoupon mc where mc.couponId = :couponId and mc.memberId = :memberId")
+    List<MemberCoupon> findAllByCouponAndMember(Long couponId, Long memberId);
 }

--- a/src/main/java/coupon/MemberCouponResponse.java
+++ b/src/main/java/coupon/MemberCouponResponse.java
@@ -1,0 +1,4 @@
+package coupon;
+
+public record MemberCouponResponse(Coupon coupon, MemberCoupon memberCoupon) {
+}

--- a/src/main/java/coupon/MemberCouponService.java
+++ b/src/main/java/coupon/MemberCouponService.java
@@ -1,0 +1,40 @@
+package coupon;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberCouponService {
+
+    private final MemberCouponRepository memberCouponRepository;
+    private final CouponService couponService;
+    private final RedisCacheService redisCacheService;
+    private final LockService lockService;
+
+    @Transactional
+    public void issue(Long couponId, Member member) {
+        // 회원과 쿠폰 번호로 사용한거 안 한거 합쳐서 5개 미만이면, 4개 이하면 발급.
+        Long issuedMemberCouponCount = lockService.executeWithLock(member.getId(), () -> memberCouponRepository.countMemberCouponsByCouponIdAndMemberId(couponId, member.getId()));
+        if (issuedMemberCouponCount < 5) {
+            MemberCoupon memberCoupon = new MemberCoupon(couponId, member.getId());
+            lockService.executeWithLock(memberCoupon.getId(), () -> memberCouponRepository.save(memberCoupon));
+            return;
+        }
+        throw new IllegalStateException("Issued member coupon counts already exceeded.");
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberCoupon> getMemberCoupons(Member member) {
+//        List<MemberCoupon> memberCoupons = memberCouponRepository.findAllByMemberId(member.getId());
+//        memberCoupons.stream()
+//                .map(mc -> {
+//                    Coupon coupon = couponService.getCoupon(mc.getCouponId());
+//                    // 쿠폰과 맴버 쿠폰을 합쳐서 DTO 생성 후 반환.
+//                    // 메서드 매개변수 DTO로 변환해야됨.
+//                });
+        return null;
+    }
+}

--- a/src/main/java/coupon/RedisCacheService.java
+++ b/src/main/java/coupon/RedisCacheService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class RedisCacheService {
 
     private static final String COUPON_CACHE_KEY_PREFIX = "coupon:";
+    private static final String MEMBER_COUPON_CACHE_KEY_PREFIX = "memberCoupon:";
     private static final int INITIAL_TIME_TO_LIVE_SECONDS = 10;
     private static final int EXTEND_TIME_TO_LIVE_SECONDS = 60;
 
@@ -28,6 +29,13 @@ public class RedisCacheService {
         String redisKey = COUPON_CACHE_KEY_PREFIX + id;
         Coupon coupon = (Coupon) redisTemplate.opsForValue().get(redisKey);
         return Optional.ofNullable(coupon);
+    }
+
+    public Optional<MemberCoupon> getMemberCouponFromCache(Long id) {
+        log.info("Coupon with ID {} found in cache.", id);
+        String redisKey = MEMBER_COUPON_CACHE_KEY_PREFIX + id;
+        MemberCoupon memberCoupon = (MemberCoupon) redisTemplate.opsForValue().get(redisKey);
+        return Optional.ofNullable(memberCoupon);
     }
 
     public void cache(Coupon coupon) {
@@ -43,6 +51,21 @@ public class RedisCacheService {
         }
         log.info("Coupon with ID {} cache in transaction.", id);
         TransactionSynchronizationManager.registerSynchronization(runAfterCommit(() -> cacheCoupon(coupon)));
+    }
+
+    public void cache(MemberCoupon memberCoupon) {
+        Long id = memberCoupon.getId();
+        if (isNotInTransaction()) {
+            log.info("MemberCoupon with ID {} doesn't cache without transaction.", id);
+            return;
+        }
+        if (isInReadOnlyTransaction()) {
+            log.info("MemberCoupon with ID {} cache in read-only transaction.", id);
+            cacheCoupon(memberCoupon);
+            return;
+        }
+        log.info("MemberCoupon with ID {} cache in transaction.", id);
+        TransactionSynchronizationManager.registerSynchronization(runAfterCommit(() -> cacheCoupon(memberCoupon)));
     }
 
     private boolean isNotInTransaction() {
@@ -68,8 +91,18 @@ public class RedisCacheService {
         log.info("Coupon with ID {} cached in Redis.", coupon.getId());
     }
 
+    private void cacheCoupon(MemberCoupon memberCoupon) {
+        String redisKey = MEMBER_COUPON_CACHE_KEY_PREFIX + memberCoupon.getId();
+        cacheWithTTL(redisKey, memberCoupon, INITIAL_TIME_TO_LIVE_SECONDS);
+        log.info("MemberCoupon with ID {} cached in Redis.", memberCoupon.getId());
+    }
+
     private void cacheWithTTL(String redisKey, Coupon coupon, int timeToLiveSeconds) {
         redisTemplate.opsForValue().set(redisKey, coupon, timeToLiveSeconds, TimeUnit.SECONDS);
+    }
+
+    private void cacheWithTTL(String redisKey, MemberCoupon MemberCoupon, int timeToLiveSeconds) {
+        redisTemplate.opsForValue().set(redisKey, MemberCoupon, timeToLiveSeconds, TimeUnit.SECONDS);
     }
 
     @Async
@@ -84,5 +117,19 @@ public class RedisCacheService {
         cacheWithTTL(redisKey, coupon, EXTEND_TIME_TO_LIVE_SECONDS);
         log.info("Coupon with ID {} extends TTL", id);
         return CompletableFuture.completedFuture(coupon);
+    }
+
+    @Async
+    public CompletableFuture<MemberCoupon> extendCacheTTL(MemberCoupon memberCoupon) {
+        Long id = memberCoupon.getId();
+        String redisKey = MEMBER_COUPON_CACHE_KEY_PREFIX + id;
+        Long ttl = Objects.requireNonNull(redisTemplate.getExpire(redisKey, TimeUnit.SECONDS));
+        if (INITIAL_TIME_TO_LIVE_SECONDS < ttl) {
+            log.info("Coupon with ID {} TTL remains {} seconds", id, ttl);
+            return CompletableFuture.completedFuture(memberCoupon);
+        }
+        cacheWithTTL(redisKey, memberCoupon, EXTEND_TIME_TO_LIVE_SECONDS);
+        log.info("Coupon with ID {} extends TTL", id);
+        return CompletableFuture.completedFuture(memberCoupon);
     }
 }

--- a/src/main/java/coupon/RedissonConfig.java
+++ b/src/main/java/coupon/RedissonConfig.java
@@ -8,15 +8,6 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RedissonConfig {
-    //  redis:
-    //    image: redis:7.0.12
-    //    container_name: redis
-    //    restart: always
-    //    ports:
-    //      - "36379:6379"
-    //    networks:
-    //      coupon_dock_net:
-    //        ipv4_address: 172.20.0.20
 
     @Bean(destroyMethod = "shutdown")
     public RedissonClient redissonClient() {

--- a/src/test/java/coupon/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/MemberCouponServiceTest.java
@@ -1,0 +1,77 @@
+package coupon;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.List;
+import coupon.cleaner.DatabaseCleanerExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest
+class MemberCouponServiceTest {
+
+    @Autowired
+    private MemberCouponService memberCouponService;
+
+    @Autowired
+    private CouponService couponService;
+
+    @DisplayName("회원 쿠폰은 5장까지 발급 가능하다.")
+    @Test
+    void issueSuccess() {
+        Member member = new Member(1L, "회원");
+        Coupon coupon = new Coupon("test", 1000, Category.APPLIANCES, 10000);
+        couponService.create(coupon);
+
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+
+        List<MemberCouponResponse> memberCoupons = memberCouponService.getMemberCoupons(coupon.getId(), member.getId());
+        assertThat(memberCoupons.size()).isEqualTo(5);
+    }
+
+    @DisplayName("회원 쿠폰을 5장 초과하여 발급하면 에러가 발생한다.")
+    @Test
+    void issueFail() {
+        Member member = new Member(1L, "회원");
+        Coupon coupon = new Coupon("test", 1000, Category.APPLIANCES, 10000);
+        couponService.create(coupon);
+
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+
+        assertThatCode(() -> memberCouponService.issue(coupon.getId(), member))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @DisplayName("발급한 회원 쿠폰을 조회하면 쿠폰과 회원 쿠폰들이 담겨있다.")
+    @Test
+    void getMemberCoupons() {
+        Member member = new Member(1L, "회원");
+        Coupon coupon = new Coupon("test", 1000, Category.APPLIANCES, 10000);
+        couponService.create(coupon);
+
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+        memberCouponService.issue(coupon.getId(), member);
+
+        List<MemberCouponResponse> memberCouponsResponse = memberCouponService.getMemberCoupons(coupon.getId(), member.getId());
+
+        assertThat(memberCouponsResponse.stream()
+                .allMatch(response -> response.coupon().getId().equals(coupon.getId()) &&
+                                      response.memberCoupon().getMemberId().equals(member.getId()))).isTrue();
+    }
+}

--- a/src/test/java/coupon/MemberTest.java
+++ b/src/test/java/coupon/MemberTest.java
@@ -12,7 +12,7 @@ class MemberTest {
     @ValueSource(strings = {"a", "1234567890"})
     @ParameterizedTest
     void nameSuccess(String name) {
-        assertThatCode(() -> new Member(name))
+        assertThatCode(() -> new Member(1L, name))
                 .doesNotThrowAnyException();
     }
 
@@ -20,7 +20,7 @@ class MemberTest {
     @ValueSource(strings = {"", " ", "  ", "\t", "12345678901"})
     @ParameterizedTest
     void nameFail(String name) {
-        assertThatCode(() -> new Member(name))
+        assertThatCode(() -> new Member(1L, name))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/coupon/cleaner/DatabaseCleaner.java
+++ b/src/test/java/coupon/cleaner/DatabaseCleaner.java
@@ -21,12 +21,17 @@ public class DatabaseCleaner {
     public void execute() {
         entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
         clearCoupon();
+        clearMemberCoupon();
         entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
         clearCache();
     }
 
     private void clearCoupon() {
         entityManager.createNativeQuery("TRUNCATE TABLE coupon").executeUpdate();
+    }
+
+    private void clearMemberCoupon() {
+        entityManager.createNativeQuery("TRUNCATE TABLE member_coupon").executeUpdate();
     }
 
     private void clearCache() {


### PR DESCRIPTION
안녕하세요 아톰 🙇🏽‍♂️
1 단계에서 이미 캐싱을 적용해놔서 2단계에는 기존 기능을 사용하여 
MemberCoupon을 발급하고 조회하는 기능을 구현했습니다.

1인당 5장 제한이 있고, 락을 사용해서 동시 요청 상황에도 5장을 초과하여 발급하지 못하도록 막았습니다.
또 MemberCoupon을 발급할 때에도 1초의 복제 지연이 생기는데, 그 것 또한 Coupon과 동일한 방식으로 처리했습니다.

감사합니다 리뷰 잘 부탁드립니다~ 😇