### PR TITLE
[2단계 - DB 복제와 캐시] 커비(이현지) 미션 제출합니다. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/coupon/CouponApplication.java
+++ b/src/main/java/coupon/CouponApplication.java
@@ -2,12 +2,13 @@ package coupon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class CouponApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(CouponApplication.class, args);
     }
-
 }

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -30,4 +30,12 @@ public class MemberCoupon {
     private LocalDateTime issuedAt;
 
     private LocalDateTime expiresAt;
+
+    public MemberCoupon(long couponId, long memberId, boolean used, LocalDateTime issuedAt, LocalDateTime expiresAt) {
+        this.couponId = couponId;
+        this.memberId = memberId;
+        this.used = used;
+        this.issuedAt = issuedAt;
+        this.expiresAt = expiresAt;
+    }
 }

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -2,6 +2,8 @@ package coupon.coupon.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 public class MemberCoupon {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "coupon_id", nullable = false)

--- a/src/main/java/coupon/coupon/domain/MemberCoupon.java
+++ b/src/main/java/coupon/coupon/domain/MemberCoupon.java
@@ -1,0 +1,33 @@
+package coupon.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class MemberCoupon {
+
+    @Id
+    private Long id;
+
+    @Column(name = "coupon_id", nullable = false)
+    private long couponId;
+
+    @Column(name = "member_id", nullable = false)
+    private long memberId;
+
+    @Column(name = "is_used", nullable = false)
+    private boolean used;
+
+    private LocalDateTime issuedAt;
+
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/coupon/coupon/dto/MemberCouponRequest.java
+++ b/src/main/java/coupon/coupon/dto/MemberCouponRequest.java
@@ -1,0 +1,7 @@
+package coupon.coupon.dto;
+
+public record MemberCouponRequest(
+        long couponId,
+        long memberId
+) {
+}

--- a/src/main/java/coupon/coupon/dto/MemberCouponResponse.java
+++ b/src/main/java/coupon/coupon/dto/MemberCouponResponse.java
@@ -1,5 +1,7 @@
 package coupon.coupon.dto;
 
+import coupon.coupon.domain.CouponEntity;
+import coupon.coupon.domain.MemberCoupon;
 import java.time.LocalDateTime;
 
 public record MemberCouponResponse(
@@ -12,4 +14,15 @@ public record MemberCouponResponse(
         LocalDateTime couponEndDate,
         boolean used
 ) {
+    public static MemberCouponResponse fromDomain(CouponEntity coupon, MemberCoupon memberCoupon) {
+        return new MemberCouponResponse(
+                coupon.getCouponName(),
+                coupon.getCouponDiscountAmount(),
+                coupon.getCouponMinOrderAmount(),
+                coupon.getCouponCategory().name(),
+                coupon.getStartAt(),
+                coupon.getEndAt(),
+                memberCoupon.isUsed()
+        );
+    }
 }

--- a/src/main/java/coupon/coupon/dto/MemberCouponResponse.java
+++ b/src/main/java/coupon/coupon/dto/MemberCouponResponse.java
@@ -1,0 +1,15 @@
+package coupon.coupon.dto;
+
+import java.time.LocalDateTime;
+
+public record MemberCouponResponse(
+
+        String couponName,
+        int couponDiscountAmount,
+        int couponMinOrderAmount,
+        String couponCategory,
+        LocalDateTime couponStartDate,
+        LocalDateTime couponEndDate,
+        boolean used
+) {
+}

--- a/src/main/java/coupon/coupon/repository/CouponRepository.java
+++ b/src/main/java/coupon/coupon/repository/CouponRepository.java
@@ -1,9 +1,14 @@
 package coupon.coupon.repository;
 
 import coupon.coupon.domain.CouponEntity;
+import java.util.Optional;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CouponRepository extends JpaRepository<CouponEntity, Long> {
+
+    @Cacheable(value = "coupon")
+    Optional<CouponEntity> findById(long id);
 }

--- a/src/main/java/coupon/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/coupon/repository/MemberCouponRepository.java
@@ -1,6 +1,7 @@
 package coupon.coupon.repository;
 
 import coupon.coupon.domain.MemberCoupon;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
 
     int countAllByMemberIdAndCouponId(long memberId, long couponId);
+
+    List<MemberCoupon> findAllByMemberId(long memberId);
 }

--- a/src/main/java/coupon/coupon/repository/MemberCouponRepository.java
+++ b/src/main/java/coupon/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,11 @@
+package coupon.coupon.repository;
+
+import coupon.coupon.domain.MemberCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+    int countAllByMemberIdAndCouponId(long memberId, long couponId);
+}

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -3,7 +3,9 @@ package coupon.coupon.service;
 import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.CouponCategory;
 import coupon.coupon.domain.CouponEntity;
+import coupon.coupon.domain.MemberCoupon;
 import coupon.coupon.repository.CouponRepository;
+import coupon.coupon.repository.MemberCouponRepository;
 import coupon.coupon.service.validator.CouponDiscountAmountValidator;
 import coupon.coupon.service.validator.CouponMinOrderAmountValidator;
 import java.time.LocalDateTime;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
+    private final MemberCouponRepository memberCouponRepository;
 
     private final CouponDiscountAmountValidator couponDiscountAmountValidator;
     private final CouponMinOrderAmountValidator couponMinOrderAmountValidator;
@@ -39,5 +42,16 @@ public class CouponService {
     public CouponEntity getCoupon(long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰이에요."));
+    }
+
+    @Transactional
+    public long issueCoupon(MemberCoupon memberCoupon) {
+        int sameMemberCouponCount = memberCouponRepository.countAllByMemberIdAndCouponId(
+                memberCoupon.getMemberId(), memberCoupon.getCouponId());
+        if (sameMemberCouponCount > 5) {
+            throw new IllegalArgumentException("동일한 쿠폰은 5장까지 발급할 수 있어요.");
+        }
+        MemberCoupon issuedMemberCoupon = memberCouponRepository.save(memberCoupon);
+        return issuedMemberCoupon.getId();
     }
 }

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -3,15 +3,10 @@ package coupon.coupon.service;
 import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.CouponCategory;
 import coupon.coupon.domain.CouponEntity;
-import coupon.coupon.domain.MemberCoupon;
-import coupon.coupon.dto.MemberCouponResponse;
 import coupon.coupon.repository.CouponRepository;
-import coupon.coupon.repository.MemberCouponRepository;
 import coupon.coupon.service.validator.CouponDiscountAmountValidator;
 import coupon.coupon.service.validator.CouponMinOrderAmountValidator;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponService {
 
     private final CouponRepository couponRepository;
-    private final MemberCouponRepository memberCouponRepository;
 
     private final CouponDiscountAmountValidator couponDiscountAmountValidator;
     private final CouponMinOrderAmountValidator couponMinOrderAmountValidator;
@@ -45,36 +39,5 @@ public class CouponService {
     public CouponEntity getCoupon(long couponId) {
         return couponRepository.findById(couponId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰이에요."));
-    }
-
-    @Transactional
-    public long issueCoupon(MemberCoupon memberCoupon) {
-        int sameMemberCouponCount = memberCouponRepository.countAllByMemberIdAndCouponId(
-                memberCoupon.getMemberId(), memberCoupon.getCouponId());
-        if (sameMemberCouponCount > 5) {
-            throw new IllegalArgumentException("동일한 쿠폰은 5장까지 발급할 수 있어요.");
-        }
-        MemberCoupon issuedMemberCoupon = memberCouponRepository.save(memberCoupon);
-        return issuedMemberCoupon.getId();
-    }
-
-    @Transactional(readOnly = true)
-    public List<MemberCouponResponse> getCouponByMember(long memberId) {
-        List<MemberCouponResponse> memberCouponResponses = new ArrayList<>();
-        for (MemberCoupon memberCoupon : memberCouponRepository.findAllByMemberId(memberId)) {
-            CouponEntity coupon = couponRepository.findById(memberCoupon.getCouponId())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
-            MemberCouponResponse memberCouponResponse = new MemberCouponResponse(
-                    coupon.getCouponName(),
-                    coupon.getCouponDiscountAmount(),
-                    coupon.getCouponMinOrderAmount(),
-                    coupon.getCouponCategory().name(),
-                    coupon.getStartAt(),
-                    coupon.getEndAt(),
-                    memberCoupon.isUsed()
-            );
-            memberCouponResponses.add(memberCouponResponse);
-        }
-        return memberCouponResponses;
     }
 }

--- a/src/main/java/coupon/coupon/service/CouponService.java
+++ b/src/main/java/coupon/coupon/service/CouponService.java
@@ -4,11 +4,14 @@ import coupon.coupon.domain.Coupon;
 import coupon.coupon.domain.CouponCategory;
 import coupon.coupon.domain.CouponEntity;
 import coupon.coupon.domain.MemberCoupon;
+import coupon.coupon.dto.MemberCouponResponse;
 import coupon.coupon.repository.CouponRepository;
 import coupon.coupon.repository.MemberCouponRepository;
 import coupon.coupon.service.validator.CouponDiscountAmountValidator;
 import coupon.coupon.service.validator.CouponMinOrderAmountValidator;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,5 +56,25 @@ public class CouponService {
         }
         MemberCoupon issuedMemberCoupon = memberCouponRepository.save(memberCoupon);
         return issuedMemberCoupon.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberCouponResponse> getCouponByMember(long memberId) {
+        List<MemberCouponResponse> memberCouponResponses = new ArrayList<>();
+        for (MemberCoupon memberCoupon : memberCouponRepository.findAllByMemberId(memberId)) {
+            CouponEntity coupon = couponRepository.findById(memberCoupon.getCouponId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+            MemberCouponResponse memberCouponResponse = new MemberCouponResponse(
+                    coupon.getCouponName(),
+                    coupon.getCouponDiscountAmount(),
+                    coupon.getCouponMinOrderAmount(),
+                    coupon.getCouponCategory().name(),
+                    coupon.getStartAt(),
+                    coupon.getEndAt(),
+                    memberCoupon.isUsed()
+            );
+            memberCouponResponses.add(memberCouponResponse);
+        }
+        return memberCouponResponses;
     }
 }

--- a/src/main/java/coupon/member/domain/Member.java
+++ b/src/main/java/coupon/member/domain/Member.java
@@ -1,17 +1,21 @@
 package coupon.member.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "member")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 }

--- a/src/main/java/coupon/member/domain/Member.java
+++ b/src/main/java/coupon/member/domain/Member.java
@@ -1,0 +1,17 @@
+package coupon.member.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@NoArgsConstructor
+@Getter
+public class Member {
+
+    @Id
+    private Long id;
+}

--- a/src/main/java/coupon/member/sevice/MemberCouponService.java
+++ b/src/main/java/coupon/member/sevice/MemberCouponService.java
@@ -1,0 +1,54 @@
+package coupon.member.sevice;
+
+import coupon.coupon.domain.CouponEntity;
+import coupon.coupon.domain.MemberCoupon;
+import coupon.coupon.dto.MemberCouponRequest;
+import coupon.coupon.dto.MemberCouponResponse;
+import coupon.coupon.repository.CouponRepository;
+import coupon.coupon.repository.MemberCouponRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCouponService {
+
+    private final CouponRepository couponRepository;
+    private final MemberCouponRepository memberCouponRepository;
+
+    @Transactional
+    public long issueCoupon(MemberCouponRequest memberCouponRequest) {
+        int sameMemberCouponCount = memberCouponRepository.countAllByMemberIdAndCouponId(
+                memberCouponRequest.memberId(), memberCouponRequest.couponId()
+        );
+
+        if (sameMemberCouponCount > 5) {
+            throw new IllegalArgumentException("동일한 쿠폰은 5장까지 발급할 수 있어요.");
+        }
+
+        MemberCoupon issuedMemberCoupon = memberCouponRepository.save(
+                new MemberCoupon(
+                        memberCouponRequest.couponId(),
+                        memberCouponRequest.memberId(),
+                        false,
+                        LocalDateTime.now(),
+                        LocalDateTime.now().plusDays(7).withHour(0).withMinute(0).withSecond(0).withNano(0)
+                ));
+        return issuedMemberCoupon.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberCouponResponse> getCouponByMember(long memberId) {
+        return memberCouponRepository.findAllByMemberId(memberId)
+                .stream()
+                .map(memberCoupon -> {
+                    CouponEntity coupon = couponRepository.findById(memberCoupon.getCouponId())
+                            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+                    return MemberCouponResponse.fromDomain(coupon, memberCoupon);
+                })
+                .toList();
+    }
+}

--- a/src/test/java/coupon/member/sevice/MemberCouponServiceTest.java
+++ b/src/test/java/coupon/member/sevice/MemberCouponServiceTest.java
@@ -1,0 +1,89 @@
+package coupon.member.sevice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import coupon.coupon.domain.CouponCategory;
+import coupon.coupon.domain.CouponEntity;
+import coupon.coupon.domain.MemberCoupon;
+import coupon.coupon.dto.MemberCouponRequest;
+import coupon.coupon.dto.MemberCouponResponse;
+import coupon.coupon.repository.CouponRepository;
+import coupon.coupon.repository.MemberCouponRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class MemberCouponServiceTest {
+
+    @Autowired
+    MemberCouponService memberCouponService;
+
+    @Autowired
+    MemberCouponRepository memberCouponRepository;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Test
+    void 회원_쿠폰을_생성한다() throws InterruptedException {
+        // given
+        int couponId = 1;
+        MemberCouponRequest request = new MemberCouponRequest(couponId, 1);
+
+        // when
+        long memberCouponId = memberCouponService.issueCoupon(request);
+        Thread.sleep(2000);
+
+        // then
+        assertThat(memberCouponRepository.findById(memberCouponId).get().getCouponId()).isEqualTo(couponId);
+    }
+
+    @Test
+    void 중복된_쿠폰을_회원당_기준_수량_이상_발행하면_예외를_발생한다() throws InterruptedException {
+        // given
+        LocalDateTime couponStartAt = LocalDateTime.of(1, 1, 1, 1, 1);
+        int couponId = 1;
+        int memberId = 1;
+        memberCouponRepository.saveAll(
+                List.of(
+                        new MemberCoupon(couponId, memberId, false, couponStartAt, couponStartAt.plusDays(1)),
+                        new MemberCoupon(couponId, memberId, false, couponStartAt, couponStartAt.plusDays(2)),
+                        new MemberCoupon(couponId, memberId, false, couponStartAt, couponStartAt.plusDays(3)),
+                        new MemberCoupon(couponId, memberId, false, couponStartAt, couponStartAt.plusDays(4)),
+                        new MemberCoupon(couponId, memberId, false, couponStartAt, couponStartAt.plusDays(5))
+                )
+        );
+        MemberCouponRequest request = new MemberCouponRequest(couponId, memberId);
+        Thread.sleep(2000);
+
+        // when &&  then
+        assertThatThrownBy(() -> memberCouponService.issueCoupon(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("동일한 쿠폰은 5장까지 발급할 수 있어요.");
+    }
+
+    @Test
+    void 회원에_해당하는_쿠폰을_조회한다() throws InterruptedException {
+        // given
+        LocalDateTime couponStartAt = LocalDateTime.of(1, 1, 1, 1, 1);
+        CouponEntity coupon = couponRepository.save(
+                new CouponEntity("couponName", 5000, 50000, CouponCategory.FOOD,
+                        couponStartAt, couponStartAt.plusDays(1)));
+        int memberId = 1;
+        memberCouponRepository.save(
+                new MemberCoupon(coupon.getId(), memberId, false, couponStartAt, couponStartAt.plusDays(1))
+        );
+        Thread.sleep(2000);
+
+        // when
+        List<MemberCouponResponse> couponByMember = memberCouponService.getCouponByMember(memberId);
+
+        // then
+        assertThat(couponByMember).hasSize(1);
+    }
+}


### PR DESCRIPTION
안녕하세요 릴리 커비에요!

캐싱할 수 있는 방법으로 다중서버의 상황에서 redis 외부 캐시 저장소 방식과 인메모리 스프링 캐시 저장 방식, 2가지를 고민해보았고
스프링 캐시 방식을 선택했어요!

이유는 다음과 같아요. 만약 쿠폰 수정 상황을 가정한다면 각 서버가 업데이트되는 쿠폰 정보를 공유해야하기때문에 인메모리 스프링 캐시 방식을 사용한다면 문제가 발생할 수 있을 거에요. 이때는 redis를 사용해서 서버들이 캐시를 공유하는 게 낫겠죠?
하지만, 현재 쿠폰 수정 상황을 가정하지 않았기에 각 서버의 어플리케이션이 각자 쿠폰 정보를 갖고있어도 문제가 생기지 않을 거라 생각해서 **스프링 캐시** 저장 방식을 선택했습니다!