### PR TITLE
학습 의도에 부합하는 Lost Update 재현을 위한 동시성 테스트 로직 추가

### DIFF
--- a/src/test/java/coupon/quiz/MultipleUseRequestsTest.java
+++ b/src/test/java/coupon/quiz/MultipleUseRequestsTest.java
@@ -5,6 +5,8 @@ import static coupon.quiz.QuizHelper.getCoupon;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -53,14 +55,14 @@ public class MultipleUseRequestsTest {
     }
 
     @Test
-    void 동시_사용_요청() throws InterruptedException {
+    void 동시_사용_요청_ID_순차_스캔() throws InterruptedException {
         AtomicInteger successCount = new AtomicInteger(0);
         AtomicInteger requestCount = new AtomicInteger(0);
         AtomicBoolean requestStart = new AtomicBoolean(false);
 
         ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENT_REQUEST_COUNT);
         for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
-            executorService.submit(() -> useCoupon(requestCount, successCount, requestStart));
+            executorService.submit(() -> useCoupon(requestCount, successCount, requestStart, false));
         }
 
         Thread.sleep(1000L);    // 스레드에 실행 요청 후 1초간 대기한 후 요청을 시작하도록 변경한다.
@@ -77,12 +79,42 @@ public class MultipleUseRequestsTest {
         assertThat(useCount).isEqualTo(5);
     }
 
-    private static void useCoupon(AtomicInteger requestCount, AtomicInteger successCount, AtomicBoolean requestStart) {
+    @Test
+    void 동시_사용_요청_ID_랜덤_스캔() throws InterruptedException {
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger requestCount = new AtomicInteger(0);
+        AtomicBoolean requestStart = new AtomicBoolean(false);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENT_REQUEST_COUNT);
+        for (int i = 0; i < CONCURRENT_REQUEST_COUNT; i++) {
+            executorService.submit(() -> useCoupon(requestCount, successCount, requestStart, true));
+        }
+
+        Thread.sleep(1000L);    // 스레드에 실행 요청 후 1초간 대기한 후 요청을 시작하도록 변경한다.
+        requestStart.set(true);
+
+        executorService.shutdown();
+        executorService.awaitTermination(30, TimeUnit.SECONDS);
+
+        assertThat(successCount.get()).isEqualTo(5);
+        assertThat(requestCount.get()).isEqualTo(100);
+
+        Response couponResponse = getCoupon(USE_LIMIT_COUPON_ID);
+        long useCount = couponResponse.body().jsonPath().getLong("useCount");
+        assertThat(useCount).isEqualTo(5);
+    }
+
+    private static void useCoupon(AtomicInteger requestCount, AtomicInteger successCount, AtomicBoolean requestStart, boolean randomized) {
         while (requestStart.get() == false) {
             // 요청을 시작하기 전까지 대기한다.
         }
 
-        for (Long memberCouponId : MEMBER_COUPON_IDS) {
+        List<Long> ids = new ArrayList<>(MEMBER_COUPON_IDS);
+        if (randomized) {
+            Collections.shuffle(ids);
+        }
+
+        for (Long memberCouponId : ids) {
             String requestBody = "{ \"memberCouponId\": " + memberCouponId + ", \"memberId\": " + MEMBER_ID + " }";
             Response response = RestAssured.given()
                     .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())


### PR DESCRIPTION
안녕하세요, 네오! 😄 슬랙으로 말씀드린 것처럼, 인덱스 미션 8, 9번의 MultipleUseRequestsTest는 현재 형태만으로는 학습 의도를 충분히 드러내기 어려운 부분이 있다고 판단했습니다. 이에 보다 명확한 동시성 제어 학습을 위해 추가 학습용 테스트를 작성하여 공유드립니다. 제가 이해한 의도와 다른 부분이 있거나, 개선이 필요한 부분이 있다면 편하게 말씀해 주시면 감사하겠습니다!

## 1️⃣ 문제 인식
예시 데이터의 구조는 다음과 같이, 여러 member_coupon이 동일한 coupon_id를 참조하는 형태입니다.
member_coupon_id | member_id | coupon_id
-- | -- | --
1 | 1 | 1
2 | 1 | 1
3 | 1 | 1
... | ... | ...

MultipleUseRequestsTest는 이러한 데이터 구조를 기반으로 쿠폰의 동시 사용 요청 상황을 검증하는 테스트입니다. 이 테스트에서는 단순히 MemberCoupon 테이블의 필드만 변경되는 것이 아니라, 연관된 Coupon 엔티티의 useCount 값도 ++ 되어 공유 자원(Coupon)에 대한 동시성 제어가 필요한 상황을 다룹니다.

즉, 여러 스레드가 동시에 서로 다른 member_coupon을 사용 처리하더라도, 내부적으로는 동일한 Coupon 엔티티의 필드(useCount)를 갱신하게 되어 **공유 자원에 대한 락 경합이 발생**할 수 있습니다.

## 2️⃣ 문제점
현재 테스트 구조상 모든 스레드가 동일한 시점에 시작하여 동일한 순서로 20개의 MEMBER_COUPON_IDS를 순회하고 있습니다. 이렇게 되면 각 스레드가 동일한 접근 패턴으로 동작하기 때문에, MemberCoupon 엔티티에만 락을 걸고, Coupon 엔티티에는 락이 걸려 있지 않음에도 실제로 Coupon에 대한 락 경합이 거의 발생하지 않는 구조가 됩니다. 그 결과 테스트는 정상적으로 통과하지만, 실제로는 Coupon 단위에서의 락 경합이나 동시성 제어가 제대로 검증되지 않은 상태일 가능성이 높습니다.  **즉, 테스트 데이터 접근 방식이 우연히 충돌을 회피했기 때문에 테스트가 통과하는 것처럼 보이게 됩니다.**

(초기에 저 역시 @Lock 어노테이션이 포함된 JPQL 쿼리에 JOIN을 사용했을 때, JOIN 절의 Coupon에는 실제로 락이 걸리지 않았음에도 테스트가 통과하는 현상을 경험했습니다. 이로 인해 겉보기에는 모든 엔티티에 락이 걸린 것처럼 보이지만, 실제로는 Coupon 단위의 원자적 업데이트나 행 단위 잠금을 통해 동시성을 제어하라는 학습 의도에 부합하지 않을 수 있다고 판단했습니다.)

## 3️⃣ 개선 제안

락이 올바르게 설정되지 않아도 테스트가 통과하는 문제를 방지하기 위해, MEMBER_COUPON_IDS를 순회하기 전에 ID 순서를 무작위로 섞는 로직을 추가했습니다.

```
List<Long> ids = new ArrayList<>(MEMBER_COUPON_IDS);
if (randomized) {
    Collections.shuffle(ids);
}
```

이 변경을 통해 각 스레드가 서로 다른 순서로 member_coupon 데이터에 접근하게 되며, 락이 제대로 설정되어 있지 않은 경우 실제로 Lost Update 현상이 발생하게 됩니다.

기존 테스트는 유지하고 새로운 테스트를 추가한 이유는 의도하는 검증 대상이 서로 다르기 때문입니다. 기존 테스트는 MemberCoupon 엔티티의 락 경합을 확인하기 위한 것이며, 새로 추가한 테스트는 Coupon 엔티티의 락 경합을 확인하기 위한 것입니다.

## 4️⃣ 기대 효과

이번 변경으로 MemberCoupon 단위의 락 경합뿐만 아니라, 동일한 Coupon 엔티티에서 useCount를 갱신할 때 발생할 수 있는 락 경합 문제를 보다 명확하게 관찰할 수 있습니다.

이를 통해 크루들이 **단순히 @Lock 어노테이션을 쿼리에 추가하는 것만으로 연관된 엔티티(JOIN된 테이블)에까지 락이 실제로 적용되는지를 스스로 고민해 보고, 락의 범위와 동작 방식을 더 깊이 있게 이해**할 수 있게 합니다.